### PR TITLE
Include schema's Admin.h for RealPin only

### DIFF
--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -24,7 +24,11 @@
 
 #include "common/object_lock.h"
 #include "rocksdb_admin/application_db_manager.h"
+#ifdef PINTEREST_INTERNAL
+#include "schemas/gen-cpp2/Admin.h"
+#else
 #include "rocksdb_admin/gen-cpp2/Admin.h"
+#endif
 
 namespace admin {
 

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -25,6 +25,7 @@
 #include "common/object_lock.h"
 #include "rocksdb_admin/application_db_manager.h"
 #ifdef PINTEREST_INTERNAL
+// NEVER SET THIS UNLESS PINTEREST INTERNAL USAGE.
 #include "schemas/gen-cpp2/Admin.h"
 #else
 #include "rocksdb_admin/gen-cpp2/Admin.h"


### PR DESCRIPTION
Only Realpin will set this Macro to include the generated thrift header from Schemas. The reason is that realpin.thrift is in schemas and rely on Admin.h in schemas. If we don't set it and realpin depends on rocksdb_admin, it will have redefiniation of all methods because realpin and rocksplicator include thrift headers.

using it, we can avoid keeping 2 copies of realpin schemas in cosmos and schemas, schemas is still the ground truth.

The diff is tested locally. we can build realpin with rocksplicator together.