### PR TITLE
Make db protected

### DIFF
--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -93,10 +93,12 @@ class ApplicationDB {
 
   ~ApplicationDB();
 
- private:
-  const std::string db_name_;
+ protected:
+  // It will be used for inheritance of ApplicationDB
   std::shared_ptr<rocksdb::DB> db_;
 
+ private:
+  const std::string db_name_;
   const replicator::DBRole role_;
   std::unique_ptr<folly::SocketAddress> upstream_addr_;
   replicator::RocksDBReplicator::ReplicatedDB* replicated_db_;


### PR DESCRIPTION
realpindb will need to inheirt applicationdb and use this member in a lot of places. making it protected can make realpin side change easier.