### PR TITLE
Add getDBs() method to ApplicationDBManager

### DIFF
--- a/rocksdb_admin/application_db_manager.cpp
+++ b/rocksdb_admin/application_db_manager.cpp
@@ -94,6 +94,13 @@ std::unique_ptr<rocksdb::DB> ApplicationDBManager::removeDB(
   return std::unique_ptr<rocksdb::DB>(ret->db_.get());
 }
 
+const std::unordered_map<std::string, std::shared_ptr<ApplicationDB>>
+ApplicationDBManager::getDBs() {
+  // return copy as a snapshot
+  folly::RWSpinLock::ReadHolder read_guard(dbs_lock_);
+  return dbs_;
+};
+
 ApplicationDBManager::~ApplicationDBManager() {
   auto itor = dbs_.begin();
   while (itor != dbs_.end()) {

--- a/rocksdb_admin/application_db_manager.h
+++ b/rocksdb_admin/application_db_manager.h
@@ -73,6 +73,13 @@ class ApplicationDBManager {
   // Return non-null pointer on success
   std::unique_ptr<rocksdb::DB> removeDB(const std::string& db_name,
                                         std::string* error_message);
+
+  // Get all dbs it currently manages.
+  // Note: The method only return a snapshot so there is no guarantee the
+  // snapshot is always up to date.
+  const std::unordered_map<
+          std::string, std::shared_ptr<ApplicationDB>> getDBs();
+
   ~ApplicationDBManager();
 
  private:


### PR DESCRIPTION
RealPin will need to iterate all Dbs to set up a index map for all shards in startup time. currently no such interface is avaiable. the method is simply returning a snapshot.