### PR TITLE
Get S3 Object MD5 and length by parsing HTTP response

### DIFF
--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -131,7 +131,6 @@ GetObjectMetadataResponse S3Util::getObjectMetadata(const string &key) {
   headObjectRequest.SetBucket(bucket_);
   headObjectRequest.SetKey(key);
   map<string, string> metadata;
-  // Copied from Aws S3 Client
   Aws::StringStream ss;
   ss << this->uri_ << "/" << headObjectRequest.GetBucket() << "/"
      << headObjectRequest.GetKey();

--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -132,7 +132,7 @@ GetObjectMetadataResponse S3Util::getObjectMetadata(const string &key) {
   headObjectRequest.SetKey(key);
   map<string, string> metadata;
   Aws::StringStream ss;
-  ss << this->uri_ << "/" << headObjectRequest.GetBucket() << "/"
+  ss << uri_ << "/" << headObjectRequest.GetBucket() << "/"
      << headObjectRequest.GetKey();
   XmlOutcome headObjectOutcome = s3Client.MakeHttpRequest(
           ss.str(), headObjectRequest,HttpMethod::HTTP_HEAD);

--- a/common/s3util.h
+++ b/common/s3util.h
@@ -68,23 +68,24 @@ using ListObjectsResponse = S3UtilResponse<vector<string>>;
 using GetObjectsResponse = S3UtilResponse<vector<GetObjectResponse>>;
 using GetObjectMetadataResponse = S3UtilResponse<map<string, string>>;
 
-/**
- * A wrapper of S3Client so we can control the HTTP request and
- * response directly
- */
-class CutomizedS3Client: public S3Client {
- public:
-  CutomizedS3Client(
-          const ClientConfiguration& config): S3Client(config) {}
-  XmlOutcome MakeHttpRequest(const Aws::String& uri,
-          const Aws::AmazonWebServiceRequest& request,
-          HttpMethod method = HttpMethod::HTTP_POST) const {
-    return MakeRequest(uri, request, method);
-  }
-};
 
 class S3Util {
  public:
+  /**
+   * A wrapper of S3Client so we can control the HTTP request and
+   * response directly
+   */
+  class CutomizedS3Client: public S3Client {
+   public:
+    CutomizedS3Client(
+            const ClientConfiguration& config): S3Client(config) {}
+    XmlOutcome MakeHttpRequest(const Aws::String& uri,
+            const Aws::AmazonWebServiceRequest& request,
+            HttpMethod method = HttpMethod::HTTP_POST) const {
+      return MakeRequest(uri, request, method);
+    }
+  };
+
   // Don't recommend using this directly. Using BuildS3Util instead.
   S3Util(const string& bucket,
          const ClientConfiguration& client_config) :


### PR DESCRIPTION
The aws sdk doesn't provide md5 information. we have to parse it by ourself.

tested with a real object.