### PR TITLE
[rocksplicator] create and use a global cpu executor

### DIFF
--- a/common/global_cpu_executor.cpp
+++ b/common/global_cpu_executor.cpp
@@ -1,0 +1,42 @@
+/// Copyright 2016 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author bol (bol@pinterest.com)
+//
+
+#include "common/global_cpu_executor.h"
+
+#include "gflags/gflags.h"
+#include "wangle/concurrent/CPUThreadPoolExecutor.h"
+
+DEFINE_int32(cpu_executor_thread_num, sysconf(_SC_NPROCESSORS_ONLN),
+             "The number of threads in the global cpu executor");
+
+DEFINE_int64(cpu_executor_queue_size, 1 << 14,
+             "The queue size in the global cpu executor");
+
+namespace common {
+
+wangle::CPUThreadPoolExecutor* getGlobalCPUExecutor() {
+  static wangle::CPUThreadPoolExecutor g_executor(
+    FLAGS_cpu_executor_thread_num,
+    std::make_unique<
+      wangle::LifoSemMPMCQueue<wangle::CPUThreadPoolExecutor::CPUTask,
+      wangle::QueueBehaviorIfFull::BLOCK>>(FLAGS_cpu_executor_queue_size));
+
+  return &g_executor;
+}
+
+}  // namespace common

--- a/common/global_cpu_executor.h
+++ b/common/global_cpu_executor.h
@@ -1,0 +1,34 @@
+/// Copyright 2016 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author bol (bol@pinterest.com)
+//
+
+#pragma once
+
+namespace wangle {
+
+class CPUThreadPoolExecutor;
+
+}
+
+namespace common {
+
+/*
+ * Return the global CPUThreadPoolExecutor.
+ */
+wangle::CPUThreadPoolExecutor* getGlobalCPUExecutor();
+
+}  // namespace common

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -33,11 +33,17 @@
 #include "rocksdb_replicator/max_number_box.h"
 #include "rocksdb_replicator/non_blocking_condition_variable.h"
 #include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
-#include "folly/Executor.h"
 #include "folly/SocketAddress.h"
 #include "rocksdb/db.h"
 #include "thrift/lib/cpp2/server/ThriftServer.h"
-#include "wangle/concurrent/CPUThreadPoolExecutor.h"
+
+namespace folly {
+  class Executor;
+}
+
+namespace wangle {
+  class CPUThreadPoolExecutor;
+}
 
 namespace replicator {
 
@@ -193,7 +199,7 @@ class RocksDBReplicator {
   RocksDBReplicator();
   ~RocksDBReplicator();
 
-  wangle::CPUThreadPoolExecutor executor_;
+  wangle::CPUThreadPoolExecutor* const executor_;
 
   common::ThriftClientPool<ReplicatorAsyncClient> client_pool_;
 


### PR DESCRIPTION
Some services need to use cpu thread pool in multiple places. Have a global one to avoid potential cpu over-subscription.