### PR TITLE
Retrun pointer to the static StatsServer

### DIFF
--- a/common/stats/status_server.cpp
+++ b/common/stats/status_server.cpp
@@ -70,8 +70,9 @@ int ServeCallback(void* param, struct MHD_Connection* connection,
 }
 }  // namespace
 
-void StatusServer::StartStatusServer(EndPointToOPMap op_map) {
+StatusServer* StatusServer::StartStatusServer(EndPointToOPMap op_map) {
   static StatusServer server(FLAGS_http_status_port, std::move(op_map));
+  return &server;
 }
 
 void StatusServer::StartStatusServerOrDie(EndPointToOPMap op_map) {

--- a/common/stats/status_server.h
+++ b/common/stats/status_server.h
@@ -60,7 +60,7 @@ class StatusServer {
    * (arrays can be passed in as delimited values) and returns a
    * std::string.
    */
-  static void StartStatusServer(EndPointToOPMap op_map = EndPointToOPMap());
+  static StatusServer* StartStatusServer(EndPointToOPMap op_map = EndPointToOPMap());
   // Instantiate a StatusServer or Die.
   static void StartStatusServerOrDie(
       EndPointToOPMap op_map = EndPointToOPMap());


### PR DESCRIPTION
We saw some crashes in libmicrohttpd thread during service shutdown. So we want to get a handle of the StatusServer and stop it in shutdown hook.