### PR TITLE
Fix a race condition in cached_iter evb

### DIFF
--- a/rocksdb_replicator/cached_iter_cleaner.cpp
+++ b/rocksdb_replicator/cached_iter_cleaner.cpp
@@ -29,6 +29,7 @@ namespace replicator {
 
 RocksDBReplicator::CachedIterCleaner::CachedIterCleaner()
     : dbs_(), dbs_mutex_(), thread_(), evb_() {
+  scheduleCleanup();
   thread_ = std::thread([this] {
       if (!folly::setThreadName("IterCleaner")) {
         LOG(ERROR) << "Failed to setThreadName() for CachedIterCleaner thread";
@@ -38,8 +39,6 @@ RocksDBReplicator::CachedIterCleaner::CachedIterCleaner()
       this->evb_.loopForever();
       LOG(INFO) << "Stopping idle iter cleanup thread ...";
     });
-  evb_.waitUntilRunning();
-  scheduleCleanup();
 }
 
 void RocksDBReplicator::CachedIterCleaner::scheduleCleanup() {

--- a/rocksdb_replicator/cached_iter_cleaner.cpp
+++ b/rocksdb_replicator/cached_iter_cleaner.cpp
@@ -38,7 +38,7 @@ RocksDBReplicator::CachedIterCleaner::CachedIterCleaner()
       this->evb_.loopForever();
       LOG(INFO) << "Stopping idle iter cleanup thread ...";
     });
-
+  evb_.waitUntilRunning();
   scheduleCleanup();
 }
 


### PR DESCRIPTION
the evb's loopForever() call may not be running when runAfterDelay() is called, hence we see Assertion `isInEventBaseThread()' failed error which made tests flaky.