### PR TITLE
Support Serverset routing in thrift router

### DIFF
--- a/common/tests/thrift_router_test.cpp
+++ b/common/tests/thrift_router_test.cpp
@@ -712,19 +712,6 @@ TEST(ThriftRouterTest, ServerSetTest) {
     EXPECT_EQ(client, nullptr);
   }
 
-  // Start servers again
-  tie(handlers[0], servers[0], thrs[0]) = makeServer(8090);
-  tie(handlers[1], servers[1], thrs[1]) = makeServer(8091);
-  tie(handlers[2], servers[2], thrs[2]) = makeServer(8092);
-
-  // stop all servers
-  for (auto& s : servers) {
-    s->stop();
-  }
-
-  for (auto& t : thrs) {
-    t->join();
-  }
 }
 
 int main(int argc, char** argv) {

--- a/common/tests/thrift_router_test.cpp
+++ b/common/tests/thrift_router_test.cpp
@@ -703,8 +703,19 @@ TEST(ThriftRouterTest, ServerSetTest) {
   // Only pick good clients
   EXPECT_EQ(5, handlers[1]->nPings_.load() + handlers[2]->nPings_.load());
 
-  // Start server again
+  servers[1]->stop();
+  thrs[1]->join();
+  servers[2]->stop();
+  thrs[2]->join();
+  for (size_t i = 0; i < router.getHostsCount(); i ++) {
+    auto client = router.getClientFromServerset();
+    EXPECT_EQ(client, nullptr);
+  }
+
+  // Start servers again
   tie(handlers[0], servers[0], thrs[0]) = makeServer(8090);
+  tie(handlers[1], servers[1], thrs[1]) = makeServer(8091);
+  tie(handlers[2], servers[2], thrs[2]) = makeServer(8092);
 
   // stop all servers
   for (auto& s : servers) {

--- a/common/tests/thrift_router_test.cpp
+++ b/common/tests/thrift_router_test.cpp
@@ -107,6 +107,10 @@ static const char* g_config_v3 =
   "   }"
   "}";
 
+static const char* g_serverset =
+  "127.0.0.1:8090\n"
+  "127.0.0.1:8091\n"
+  "127.0.0.1:8092";
 
 using ClusterLayout = ThriftRouter<DummyServiceAsyncClient>::ClusterLayout;
 using Role = ThriftRouter<DummyServiceAsyncClient>::Role;
@@ -658,6 +662,49 @@ TEST(ThriftRouterTest, HostOrderTest) {
   EXPECT_EQ(handlers[2]->nPings_.load(), 4);
 
   FLAGS_always_prefer_local_host = false;
+
+  // stop all servers
+  for (auto& s : servers) {
+    s->stop();
+  }
+
+  for (auto& t : thrs) {
+    t->join();
+  }
+}
+
+TEST(ThriftRouterTest, ServerSetTest) {
+  updateConfigFile(g_serverset);
+  shared_ptr<DummyServiceTestHandler> handlers[3];
+  shared_ptr<ThriftServer> servers[3];
+  unique_ptr<thread> thrs[3];
+
+  tie(handlers[0], servers[0], thrs[0]) = makeServer(8090);
+  tie(handlers[1], servers[1], thrs[1]) = makeServer(8091);
+  tie(handlers[2], servers[2], thrs[2]) = makeServer(8092);
+  sleep(1);
+  ThriftRouter<DummyServiceAsyncClient> router(
+    "", g_config_path, common::parseServerset);
+  for (size_t i = 0; i < router.getHostsCount(); i ++) {
+    auto client = router.getClientFromServerset();
+    EXPECT_NO_THROW(client->future_ping().get());
+  }
+  for (const auto& h: handlers) {
+    EXPECT_EQ(h->nPings_.load(), 1);
+  }
+
+  // stop servers[0]
+  servers[0]->stop();
+  thrs[0]->join();
+  for (size_t i = 0; i < router.getHostsCount(); i ++) {
+    auto client = router.getClientFromServerset();
+    EXPECT_NO_THROW(client->future_ping().get());
+  }
+  // Only pick good clients
+  EXPECT_EQ(5, handlers[1]->nPings_.load() + handlers[2]->nPings_.load());
+
+  // Start server again
+  tie(handlers[0], servers[0], thrs[0]) = makeServer(8090);
 
   // stop all servers
   for (auto& s : servers) {


### PR DESCRIPTION
Extend thrift_router to be able to parse and select client from serverset.

The motivation is that by reusing the logic we did for shard config, we can ensure we always get good client from the serverset, so we dont need to handle retries in serverset_thrift_client_pool, which is less efficient because we need to send out actual request to know the channel is broken, and try other clients.