### PR TITLE
Make controller http possible to integrate with Pinterest internal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
       cache:
         directories:
           - $HOME/.m2
+      notifications:
+          email: false
       before_install:
         - sudo apt-get update -qq
         - sudo apt-get install -q -y --force-yes libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev

--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/util/ZookeeperConfigParser.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/util/ZookeeperConfigParser.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2017 Pinterest, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.pinterest.rocksplicator.controller.util;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+import com.google.common.io.Files;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Parse the zookeeper host config file that consists of a list of ZK endpoints..
+ * @author Shu Zhang (shu@pinterest.com)
+ */
+public class ZookeeperConfigParser {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ZookeeperConfigParser.class);
+
+  // Parse endpoints separated by commas
+  public static String parseEndpoints(String zkHostsFile, String zkCluster) {
+    Yaml yaml = new Yaml();
+    try {
+      String cluster;
+      if (Strings.isNullOrEmpty(zkCluster)) {
+        cluster = "default";
+      } else {
+        cluster = zkCluster;
+      }
+      String content = Files.toString(new File(zkHostsFile), Charsets.US_ASCII);
+      Map<String, Map<String, List<String>>> config = (Map) yaml.load(content);
+      List<String> endpoints = config.get("clusters").get(cluster);
+      return String.join(",", endpoints);
+    } catch (Exception e) {
+      LOG.error("Cannot parse Zookeeper endpoints!", e);
+      return null;
+    }
+  }
+}

--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/util/ZookeeperConfigParser.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/util/ZookeeperConfigParser.java
@@ -39,10 +39,8 @@ public class ZookeeperConfigParser {
   public static String parseEndpoints(String zkHostsFile, String zkCluster) {
     Yaml yaml = new Yaml();
     try {
-      String cluster;
-      if (Strings.isNullOrEmpty(zkCluster)) {
-        cluster = "default";
-      } else {
+      String cluster = "default";
+      if (!Strings.isNullOrEmpty(zkCluster)) {
         cluster = zkCluster;
       }
       String content = Files.toString(new File(zkHostsFile), Charsets.US_ASCII);

--- a/controller/controller-common/src/main/resources/META-INF/persistence.xml
+++ b/controller/controller-common/src/main/resources/META-INF/persistence.xml
@@ -4,15 +4,9 @@
                            xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
              http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
                            version="2.1">
-<persistence-unit name="controller-test" transaction-type="RESOURCE_LOCAL">
+<persistence-unit name="controller" transaction-type="RESOURCE_LOCAL">
     <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
     <class>com.pinterest.rocksplicator.controller.mysql.entity.TagEntity</class>
     <class>com.pinterest.rocksplicator.controller.mysql.entity.TaskEntity</class>
-    <properties>
-        <property name="javax.persistence.jdbc.driver" value="com.mysql.jdbc.Driver"/>
-        <property name="javax.persistence.jdbc.url" value="jdbc:mysql://localhost:3306/controller"/>
-        <property name="javax.persistence.jdbc.user" value="root"/>
-        <property name="javax.persistence.jdbc.password" value=""/>
-    </properties>
 </persistence-unit>
 </persistence>

--- a/controller/controller-common/src/test/java/com/pinterest/rocksplicator/controller/mysql/MySQLTaskQueueIntegrationTest.java
+++ b/controller/controller-common/src/test/java/com/pinterest/rocksplicator/controller/mysql/MySQLTaskQueueIntegrationTest.java
@@ -24,25 +24,18 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
 import java.util.Date;
 import java.util.Set;
 
 public class MySQLTaskQueueIntegrationTest {
 
   private static final String TEST_CLUSTER_NAME = "integ_test";
-  private EntityManager entityManager;
   private MySQLTaskQueue queue;
 
   @BeforeMethod
   protected void checkMySQLRunning() {
     try {
-      EntityManagerFactory entityManagerFactory =
-          Persistence.createEntityManagerFactory("controller-test");
-      this.entityManager = entityManagerFactory.createEntityManager();
-      this.queue = new MySQLTaskQueue(entityManager);
+      this.queue = new MySQLTaskQueue("jdbc:mysql://localhost:3306/controller", "root", "");
     } catch (Exception e) {
       throw new SkipException("MySQL is not running correctly");
     }

--- a/controller/controller-common/src/test/java/com/pinterest/rocksplicator/controller/util/ZookeeperConfigParserTest.java
+++ b/controller/controller-common/src/test/java/com/pinterest/rocksplicator/controller/util/ZookeeperConfigParserTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pinterest.rocksplicator.controller.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ZookeeperConfigParserTest {
+
+  @Test
+  public void testParseZookeeperConfig() {
+    String path = Thread.currentThread().getContextClassLoader().getResource("zookeeper_hosts.conf").getPath();
+    String result = ZookeeperConfigParser.parseEndpoints(path, "default");
+    Assert.assertEquals("observerzookeeper010:2181,observerzookeeper011:2181," +
+        "observerzookeeper012:2181,observerzookeeper013:2181,observerzookeeper014:2181", result);
+  }
+}

--- a/controller/controller-common/src/test/resources/zookeeper_hosts.conf
+++ b/controller/controller-common/src/test/resources/zookeeper_hosts.conf
@@ -1,0 +1,8 @@
+# This file is an example zookeeper endpoints yaml file.
+clusters:
+  default:
+    - observerzookeeper010:2181
+    - observerzookeeper011:2181
+    - observerzookeeper012:2181
+    - observerzookeeper013:2181
+    - observerzookeeper014:2181

--- a/controller/controller-http/bin/demo_server.yaml
+++ b/controller/controller-http/bin/demo_server.yaml
@@ -3,4 +3,8 @@ server:
     - type: http
       port: 8080
 
-zkEndpoints: observerzookeeper010:2181
+zkHostsFile: bin/zookeeper_hosts.conf
+zkCluster: default
+
+jdbcUrl: jdbc:mysql://localhost:3306/controller
+mysqlUser: root

--- a/controller/controller-http/bin/zookeeper_hosts.conf
+++ b/controller/controller-http/bin/zookeeper_hosts.conf
@@ -1,0 +1,8 @@
+# This file is an example zookeeper endpoints yaml file.
+clusters:
+  default:
+    - observerzookeeper010:2181
+    - observerzookeeper011:2181
+    - observerzookeeper012:2181
+    - observerzookeeper013:2181
+    - observerzookeeper014:2181

--- a/controller/controller-http/src/main/java/com/pinterest/rocksplicator/controller/ControllerConfiguration.java
+++ b/controller/controller-http/src/main/java/com/pinterest/rocksplicator/controller/ControllerConfiguration.java
@@ -26,19 +26,30 @@ import org.hibernate.validator.constraints.NotEmpty;
 public class ControllerConfiguration extends Configuration {
 
   @NotEmpty
-  private String zkEndpoints;
+  private String zkHostsFile;
+
+  @NotEmpty
+  private String zkCluster;
 
   @NotEmpty
   private String zkPath = "/config/services/rocksdb/";
 
+  @NotEmpty
+  private String jdbcUrl;
+
+  @NotEmpty
+  private String mysqlUser;
+
+  private String mysqlPassword = "";
+
   @JsonProperty
-  public String getZkEndpoints() {
-    return zkEndpoints;
+  public String getZkHostsFile() {
+    return zkHostsFile;
   }
 
   @JsonProperty
-  public void setZkEndpoints(String zkEndpoints) {
-    this.zkEndpoints = zkEndpoints;
+  public void setZkHostsFile(String zkHostsFile) {
+    this.zkHostsFile = zkHostsFile;
   }
 
   @JsonProperty
@@ -50,4 +61,44 @@ public class ControllerConfiguration extends Configuration {
   public void setZkPath(String zkPath) {
     this.zkPath = zkPath;
   }
+
+  @JsonProperty
+  public String getZkCluster() {
+    return zkCluster;
+  }
+
+  @JsonProperty
+  public void setZkCluster(String zkCluster) {
+    this.zkCluster = zkCluster;
+  }
+
+  @JsonProperty
+  public String getJdbcUrl() {
+    return jdbcUrl;
+  }
+
+  @JsonProperty
+  public void setJdbcUrl(String jdbcUrl) {
+    this.jdbcUrl = jdbcUrl;
+  }
+
+  @JsonProperty
+  public String getMysqlUser() {
+    return mysqlUser;
+  }
+
+  @JsonProperty
+  public void setMysqlUser(String mysqlUser) {
+    this.mysqlUser = mysqlUser;
+  }
+
+  @JsonProperty
+  public String getMysqlPassword() {
+    return mysqlPassword;
+  }
+
+  public void setMysqlPassword(String mysqlPassword) {
+    this.mysqlPassword = mysqlPassword;
+  }
+
 }

--- a/controller/controller-http/src/main/java/com/pinterest/rocksplicator/controller/ControllerService.java
+++ b/controller/controller-http/src/main/java/com/pinterest/rocksplicator/controller/ControllerService.java
@@ -16,9 +16,11 @@
 
 package com.pinterest.rocksplicator.controller;
 
+import com.pinterest.rocksplicator.controller.mysql.MySQLTaskQueue;
 import com.pinterest.rocksplicator.controller.resource.Clusters;
 import com.pinterest.rocksplicator.controller.resource.Tasks;
 
+import com.pinterest.rocksplicator.controller.util.ZookeeperConfigParser;
 import io.dropwizard.Application;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
@@ -41,10 +43,12 @@ public class ControllerService extends Application<ControllerConfiguration> {
   @Override
   public void run(ControllerConfiguration configuration,
                   Environment environment) throws Exception {
-    //TODO(angxu) initialize taskQueue in the right way after implementation is ready
-    TaskQueue taskQueue = new TaskQueue(){};
+    TaskQueue taskQueue = new MySQLTaskQueue(configuration.getJdbcUrl(), configuration
+        .getMysqlUser(), configuration.getMysqlPassword());
     CuratorFramework zkClient = CuratorFrameworkFactory.newClient(
-        configuration.getZkEndpoints(), new RetryOneTime(3000));
+        ZookeeperConfigParser.parseEndpoints(
+            configuration.getZkHostsFile(), configuration.getZkCluster()),
+        new RetryOneTime(3000));
 
     environment.lifecycle().manage(new Managed() {
       @Override


### PR DESCRIPTION
1. Make http service accept a zookeeper config file path instead of a string of zk endpoints. which we use in pinterest.
2. Make mysql parameters configurable and can be passed in from server config file.