### PR TITLE
[rocksplicator] fix a race

### DIFF
--- a/rocksdb_admin/application_db_manager.cpp
+++ b/rocksdb_admin/application_db_manager.cpp
@@ -98,7 +98,9 @@ ApplicationDBManager::~ApplicationDBManager() {
   auto itor = dbs_.begin();
   while (itor != dbs_.end()) {
     waitOnApplicationDBRef(itor->second);
-    std::unique_ptr<rocksdb::DB>(itor->second->db_.get());
+    // we want to first remove the ApplicationDB and then release the RocksDB
+    // it contains.
+    auto tmp = std::unique_ptr<rocksdb::DB>(itor->second->db_.get());
     itor = dbs_.erase(itor);
   }
 }

--- a/rocksdb_replicator/fast_read_map.h
+++ b/rocksdb_replicator/fast_read_map.h
@@ -96,8 +96,8 @@ class FastReadMap {
     std::lock_guard<std::mutex> g(write_lock_);
 
     auto new_map = std::make_shared<std::unordered_map<K, V>>(*map_);
-    auto itor = new_map.find(key);
-    if (itor == new_map.end()) {
+    auto itor = new_map->find(key);
+    if (itor == new_map->end()) {
       // the key is not in the map
       return false;
     }
@@ -106,7 +106,7 @@ class FastReadMap {
       *value = std::move(itor->second);
     }
 
-    new_map.erease(itor);
+    new_map->erase(itor);
 
     {
       folly::RWSpinLock::WriteHolder write_guard(map_rwlock_);

--- a/rocksdb_replicator/fast_read_map.h
+++ b/rocksdb_replicator/fast_read_map.h
@@ -92,14 +92,21 @@ class FastReadMap {
    * Remove key from the map.
    * Return false if key is not found in the map.
    */
-  bool remove(const K& key) {
+  bool remove(const K& key, V* value = nullptr) {
     std::lock_guard<std::mutex> g(write_lock_);
 
     auto new_map = std::make_shared<std::unordered_map<K, V>>(*map_);
-    if (new_map->erase(key) == 0) {
+    auto itor = new_map.find(key);
+    if (itor == new_map.end()) {
       // the key is not in the map
       return false;
     }
+
+    if (value) {
+      *value = std::move(itor->second);
+    }
+
+    new_map.erease(itor);
 
     {
       folly::RWSpinLock::WriteHolder write_guard(map_rwlock_);


### PR DESCRIPTION
The replicating thread could hold the shared_ptr to a replicated db even after we remove the db from replicator.
    This could result in using a destroyed rocksdb instance.
    This diff makes the RemoveDB() API to wait for the shared_ptr ref count drop to 0.