### PR TITLE
give a connection timeout for opening a tsock

### DIFF
--- a/controller/controller-worker/src/main/java/com/pinterest/rocksplicator/controller/util/AdminClientFactory.java
+++ b/controller/controller-worker/src/main/java/com/pinterest/rocksplicator/controller/util/AdminClientFactory.java
@@ -92,6 +92,7 @@ public class AdminClientFactory {
     @Override
     public TTransport load(InetSocketAddress key) throws Exception {
       TSocket sock = new TSocket(key.getHostName(), key.getPort());
+      sock.setConnectTimeout(5000);
       sock.open();
       return sock;
     }


### PR DESCRIPTION
default value is 0, which will hang if the endpoint is not available.
set it to 5 sec for now, may tune later when we get more sense.