### PR TITLE
added create_db option to AddS3SstFilesToDB

### DIFF
--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -114,6 +114,7 @@ struct AddS3SstFilesToDBRequest {
   2: required string s3_bucket,
   3: required string s3_path,
   4: optional i32 s3_download_limit_mb = 64,
+  5: optional bool create_db = false,
 }
 
 struct AddS3SstFilesToDBResponse {


### PR DESCRIPTION
The reason for this pull request, is so that we can download a shard from S3 even if it doesn't exist in the config. The user who does this can afterwards update their cluster config to reflect that this host is now serving this shard.