### PR TITLE
[rocksplicator] use a dedicated thread pool for rocksplicator

### DIFF
--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -199,7 +199,7 @@ class RocksDBReplicator {
   RocksDBReplicator();
   ~RocksDBReplicator();
 
-  wangle::CPUThreadPoolExecutor* const executor_;
+  std::unique_ptr<wangle::CPUThreadPoolExecutor> executor_;
 
   common::ThriftClientPool<ReplicatorAsyncClient> client_pool_;
 


### PR DESCRIPTION
to get around the rocksdb GetUpdatesSince() regression.