### PR TITLE
update Healthcheck tasks to use cluster manager information

### DIFF
--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/ClusterManager.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/ClusterManager.java
@@ -87,12 +87,4 @@ public interface ClusterManager {
     return Collections.emptySet();
   }
 
-  /**
-   * Take in the ClusterBean, return the hosts registered but not in real cluster Config.
-   */
-  default Set<HostBean> getHostsNotInConfig(final Cluster cluster,
-                                            final ClusterBean clusterBean) {
-    return Collections.emptySet();
-  }
-
 }

--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/ClusterManager.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/ClusterManager.java
@@ -16,6 +16,7 @@
 
 package com.pinterest.rocksplicator.controller;
 
+import com.pinterest.rocksplicator.controller.bean.ClusterBean;
 import com.pinterest.rocksplicator.controller.bean.HostBean;
 
 import java.util.Collections;
@@ -83,6 +84,14 @@ public interface ClusterManager {
    * @return
    */
   default Set<HostBean> getBlacklistedHosts(final Cluster cluster) {
+    return Collections.emptySet();
+  }
+
+  /**
+   * Take in the ClusterBean, return the hosts registered but not in real cluster Config.
+   */
+  default Set<HostBean> getHostsNotInConfig(final Cluster cluster,
+                                            final ClusterBean clusterBean) {
     return Collections.emptySet();
   }
 

--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/bean/ClusterBean.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/bean/ClusterBean.java
@@ -22,7 +22,9 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Ang Xu (angxu@pinterest.com)
@@ -56,6 +58,16 @@ public class ClusterBean {
   @Override
   public String toString() {
     return cluster.toString();
+  }
+
+  public Set<HostBean> getHosts() {
+    Set<HostBean> hosts = new HashSet<>();
+    for (SegmentBean segmentBean : getSegments()) {
+      for (HostBean hostBean: segmentBean.getHosts()) {
+        hosts.add(hostBean);
+      }
+    }
+    return hosts;
   }
 
 }

--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/bean/ConsistentHashRingsBean.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/bean/ConsistentHashRingsBean.java
@@ -19,9 +19,12 @@ package com.pinterest.rocksplicator.controller.bean;
 import com.pinterest.rocksplicator.controller.Cluster;
 import org.hibernate.validator.constraints.NotEmpty;
 
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Mapping to another type of config: a collection of consistent hash rings.
@@ -57,6 +60,16 @@ public class ConsistentHashRingsBean {
   @Override
   public String toString() {
     return cluster.toString();
+  }
+
+  public Set<HostBean> getHosts() {
+    Set<HostBean> hosts = new HashSet<>();
+    for (ConsistentHashRingBean ring : getConsistentHashRings()) {
+      for (HostBean hostBean : ring.getHosts()) {
+        hosts.add(hostBean);
+      }
+    }
+    return hosts;
   }
 
 }

--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/mysql/MySQLClusterManager.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/mysql/MySQLClusterManager.java
@@ -19,6 +19,7 @@ package com.pinterest.rocksplicator.controller.mysql;
 import com.google.common.base.Strings;
 import com.pinterest.rocksplicator.controller.Cluster;
 import com.pinterest.rocksplicator.controller.ClusterManager;
+import com.pinterest.rocksplicator.controller.bean.ClusterBean;
 import com.pinterest.rocksplicator.controller.bean.HostBean;
 import com.pinterest.rocksplicator.controller.mysql.entity.TagEntity;
 import com.pinterest.rocksplicator.controller.mysql.entity.TagHostsEntity;
@@ -174,5 +175,13 @@ public class MySQLClusterManager extends MySQLBase implements ClusterManager{
       return new HashSet<>();
     }
     return fromHostsString(tagHostsEntity.getBlacklistedHosts());
+  }
+
+  @Override
+  public Set<HostBean> getHostsNotInConfig(final Cluster cluster, final ClusterBean clusterBean) {
+    Set<HostBean> hostsInConfig = clusterBean.getHosts();
+    Set<HostBean> hosts = getHosts(cluster, false);
+    hosts.removeAll(hostsInConfig);
+    return hosts;
   }
 }

--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/mysql/MySQLClusterManager.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/mysql/MySQLClusterManager.java
@@ -19,7 +19,6 @@ package com.pinterest.rocksplicator.controller.mysql;
 import com.google.common.base.Strings;
 import com.pinterest.rocksplicator.controller.Cluster;
 import com.pinterest.rocksplicator.controller.ClusterManager;
-import com.pinterest.rocksplicator.controller.bean.ClusterBean;
 import com.pinterest.rocksplicator.controller.bean.HostBean;
 import com.pinterest.rocksplicator.controller.mysql.entity.TagEntity;
 import com.pinterest.rocksplicator.controller.mysql.entity.TagHostsEntity;
@@ -175,13 +174,5 @@ public class MySQLClusterManager extends MySQLBase implements ClusterManager{
       return new HashSet<>();
     }
     return fromHostsString(tagHostsEntity.getBlacklistedHosts());
-  }
-
-  @Override
-  public Set<HostBean> getHostsNotInConfig(final Cluster cluster, final ClusterBean clusterBean) {
-    Set<HostBean> hostsInConfig = clusterBean.getHosts();
-    Set<HostBean> hosts = getHosts(cluster, false);
-    hosts.removeAll(hostsInConfig);
-    return hosts;
   }
 }

--- a/controller/controller-worker/src/main/java/com/pinterest/rocksplicator/controller/tasks/BadHostsStatesKeeper.java
+++ b/controller/controller-worker/src/main/java/com/pinterest/rocksplicator/controller/tasks/BadHostsStatesKeeper.java
@@ -17,6 +17,7 @@
 package com.pinterest.rocksplicator.controller.tasks;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pinterest.rocksplicator.controller.bean.HostBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +62,7 @@ public class BadHostsStatesKeeper {
   private long emailMuteIntervalMillis;
 
   @JsonProperty
-  private Map<String, BadHostState> badHostStates = new HashMap<>();
+  private Map<HostBean, BadHostState> badHostStates = new HashMap<>();
 
   public BadHostsStatesKeeper() {
     this(3, 30 * 60);
@@ -91,11 +92,11 @@ public class BadHostsStatesKeeper {
     return this;
   }
 
-  public Map<String, BadHostState> getBadHostStates() {
+  public Map<HostBean, BadHostState> getBadHostStates() {
     return badHostStates;
   }
 
-  public BadHostsStatesKeeper setBadHostStates(Map<String, BadHostState> badHostStates) {
+  public BadHostsStatesKeeper setBadHostStates(Map<HostBean, BadHostState> badHostStates) {
     this.badHostStates = badHostStates;
     return this;
   }
@@ -106,11 +107,11 @@ public class BadHostsStatesKeeper {
    * @param thisTimeBadHosts
    * @return
    */
-  public List<String> updateStatesAndGetHostsToEmail(Set<String> thisTimeBadHosts) {
-    Map<String, BadHostState> updatedBadHostStates = new HashMap<>();
-    List<String> hostsShouldSendEmail = new ArrayList<>();
+  public List<HostBean> updateStatesAndGetHostsToEmail(Set<HostBean> thisTimeBadHosts) {
+    Map<HostBean, BadHostState> updatedBadHostStates = new HashMap<>();
+    List<HostBean> hostsShouldSendEmail = new ArrayList<>();
     Date currentTime = new Date();
-    for (String thisTimeBadHost : thisTimeBadHosts) {
+    for (HostBean thisTimeBadHost : thisTimeBadHosts) {
       if (badHostStates.containsKey(thisTimeBadHost)) {
         BadHostState previousState = badHostStates.get(thisTimeBadHost);
         previousState.consecutiveFailures ++;

--- a/controller/controller-worker/src/main/java/com/pinterest/rocksplicator/controller/tasks/HealthCheckTask.java
+++ b/controller/controller-worker/src/main/java/com/pinterest/rocksplicator/controller/tasks/HealthCheckTask.java
@@ -19,7 +19,6 @@ package com.pinterest.rocksplicator.controller.tasks;
 import com.pinterest.rocksplicator.controller.ClusterManager;
 import com.pinterest.rocksplicator.controller.bean.ClusterBean;
 import com.pinterest.rocksplicator.controller.bean.HostBean;
-import com.pinterest.rocksplicator.controller.bean.SegmentBean;
 import com.pinterest.rocksplicator.controller.util.AdminClientFactory;
 import com.pinterest.rocksplicator.controller.util.EmailSender;
 import com.pinterest.rocksplicator.controller.util.ZKUtil;

--- a/controller/controller-worker/src/test/java/com/pinterest/rocksplicator/controller/tasks/BadHostsStatsKeeperTest.java
+++ b/controller/controller-worker/src/test/java/com/pinterest/rocksplicator/controller/tasks/BadHostsStatsKeeperTest.java
@@ -16,6 +16,7 @@
 
 package com.pinterest.rocksplicator.controller.tasks;
 
+import com.pinterest.rocksplicator.controller.bean.HostBean;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -28,28 +29,30 @@ public class BadHostsStatsKeeperTest {
   @Test
   public void testCounting() {
     BadHostsStatesKeeper badHostsStatesKeeper = new BadHostsStatesKeeper();
-    Set<String> inputSet = new HashSet<>();
-    inputSet.add("1.2.3.4");
-    List<String> emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
+    Set<HostBean> inputSet = new HashSet<>();
+    HostBean bean = new HostBean().setIp("1.2.3.4").setPort(9090);
+    inputSet.add(bean);
+    List<HostBean> emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(emailedHosts.isEmpty());
     emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(emailedHosts.isEmpty());
     emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(!emailedHosts.isEmpty());
-    Assert.assertEquals(emailedHosts.get(0), "1.2.3.4");
+    Assert.assertEquals(emailedHosts.get(0), bean);
     // It goes into silence mode
     emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(emailedHosts.isEmpty());
-    Assert.assertEquals(badHostsStatesKeeper.getBadHostStates().get("1.2.3.4").consecutiveFailures, 4);
+    Assert.assertEquals(badHostsStatesKeeper.getBadHostStates().get(bean).consecutiveFailures, 4);
   }
 
   @Test
   public void testReset() {
     BadHostsStatesKeeper badHostsStatesKeeper = new BadHostsStatesKeeper();
-    Set<String> inputSet = new HashSet<>();
-    inputSet.add("1.2.3.4");
-    Set<String> emptySet = new HashSet<>();
-    List<String> emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
+    Set<HostBean> inputSet = new HashSet<>();
+    HostBean bean = new HostBean().setIp("1.2.3.4").setPort(9090);
+    inputSet.add(bean);
+    Set<HostBean> emptySet = new HashSet<>();
+    List<HostBean> emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(emailedHosts.isEmpty());
     emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(emailedHosts.isEmpty());
@@ -61,29 +64,30 @@ public class BadHostsStatsKeeperTest {
     Assert.assertTrue(emailedHosts.isEmpty());
     emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(!emailedHosts.isEmpty());
-    Assert.assertEquals(emailedHosts.get(0), "1.2.3.4");
+    Assert.assertEquals(emailedHosts.get(0), bean);
   }
 
   @Test
   public void testExpiration() throws InterruptedException {
     BadHostsStatesKeeper badHostsStatesKeeper = new BadHostsStatesKeeper(3, 5);
-    Set<String> inputSet = new HashSet<>();
-    inputSet.add("1.2.3.4");
-    List<String> emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
+    Set<HostBean> inputSet = new HashSet<>();
+    HostBean bean = new HostBean().setIp("1.2.3.4").setPort(9090);
+    inputSet.add(bean);
+    List<HostBean> emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(emailedHosts.isEmpty());
     emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(emailedHosts.isEmpty());
     emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(!emailedHosts.isEmpty());
-    Assert.assertEquals(emailedHosts.get(0), "1.2.3.4");
+    Assert.assertEquals(emailedHosts.get(0), bean);
     // It goes into silence mode
     emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(emailedHosts.isEmpty());
-    Assert.assertEquals(badHostsStatesKeeper.getBadHostStates().get("1.2.3.4").consecutiveFailures, 4);
+    Assert.assertEquals(badHostsStatesKeeper.getBadHostStates().get(bean).consecutiveFailures, 4);
     Thread.sleep(6000);
     emailedHosts = badHostsStatesKeeper.updateStatesAndGetHostsToEmail(inputSet);
     Assert.assertTrue(!emailedHosts.isEmpty());
-    Assert.assertEquals(emailedHosts.get(0), "1.2.3.4");
+    Assert.assertEquals(emailedHosts.get(0), bean);
   }
 
 }


### PR DESCRIPTION
Implement the behavior:

Ping all hosts in live_hosts json. If a host is not reachable after X consecutive pings (default is 3):

If the host is not in zk cluster config but in blacklisted_hosts, remove the host from live_hosts and blacklisted_hosts. It is very likely the host has been terminated by people.

If the host is not in zk cluster config and not in blacklisted_hosts, meaning the host is in a candidate pool but not good anymore, send email alert

If the host is in zk cluster config, then send email alert as this is a bad host in the working set.
