### PR TITLE
Replace AZ concept in thrift router to Replica

### DIFF
--- a/common/network_util.cpp
+++ b/common/network_util.cpp
@@ -19,7 +19,7 @@
 
 namespace common {
 
-std::string getLocalIPAddress() {
+const std::string getLocalIPAddress() {
   ifaddrs* ips;
   CHECK_EQ(::getifaddrs(&ips), 0);
   ifaddrs* ips_tmp = ips;

--- a/common/network_util.cpp
+++ b/common/network_util.cpp
@@ -17,9 +17,9 @@
 #include <ifaddrs.h>
 #include "folly/SocketAddress.h"
 
-namespace common {
+namespace {
 
-const std::string getLocalIPAddress() {
+std::string getLocalIPAddressImpl() {
   ifaddrs* ips;
   CHECK_EQ(::getifaddrs(&ips), 0);
   ifaddrs* ips_tmp = ips;
@@ -37,6 +37,16 @@ const std::string getLocalIPAddress() {
     ips_tmp = ips_tmp->ifa_next;
   }
   freeifaddrs(ips);
+  return local_ip;
+}
+
+}  // namespace
+
+
+namespace common {
+
+const std::string& getLocalIPAddress() {
+  static const std::string local_ip = getLocalIPAddressImpl();
   return local_ip;
 }
 

--- a/common/network_util.h
+++ b/common/network_util.h
@@ -21,6 +21,6 @@ namespace common {
 /*
  * Get the local IP address from eth0.
  */
-std::string getLocalIPAddress();
+const std::string getLocalIPAddress();
 
 }  // namespace common

--- a/common/network_util.h
+++ b/common/network_util.h
@@ -21,6 +21,6 @@ namespace common {
 /*
  * Get the local IP address from eth0.
  */
-const std::string getLocalIPAddress();
+const std::string& getLocalIPAddress();
 
 }  // namespace common

--- a/common/tests/thrift_router_test.cpp
+++ b/common/tests/thrift_router_test.cpp
@@ -72,7 +72,7 @@ static const char* g_config_v1 =
   "   }"
   "}";
 
-static const char* g_config_v1Replica =
+static const char* g_config_v1Group =
   "{"
   "  \"user_pins\": {"
   "  \"num_leaf_segments\": 3,"
@@ -423,9 +423,9 @@ TEST(ThriftRouterTest, Stress) {
   stress(99, 1000);
 }
 
-TEST(ThriftRouterTest, LocalReplicaTest) {
+TEST(ThriftRouterTest, LocalGroupTest) {
   FLAGS_port = 8090;
-  updateConfigFile(g_config_v1Replica);
+  updateConfigFile(g_config_v1Group);
   ThriftRouter<DummyServiceAsyncClient> router(
     "127.0.0.1", g_config_path, common::parseConfig);
 
@@ -455,8 +455,8 @@ TEST(ThriftRouterTest, LocalReplicaTest) {
     EXPECT_EQ(h->nPings_.load(), 1);
   }
 
-  // Get the client from local Replica
-  // All requests should hit the local Replica handler
+  // Get the client from local Group
+  // All requests should hit the local Group handler
   for (int i = 0; i < 100; i ++) {
     std::vector<shared_ptr<DummyServiceAsyncClient>> v;
     EXPECT_EQ(
@@ -478,9 +478,9 @@ TEST(ThriftRouterTest, LocalReplicaTest) {
 }
 
 
-TEST(ThriftRouterTest, ForeignReplicaTest) {
+TEST(ThriftRouterTest, ForeignGroupTest) {
   FLAGS_port = 8096;
-  updateConfigFile(g_config_v1Replica);
+  updateConfigFile(g_config_v1Group);
   ThriftRouter<DummyServiceAsyncClient> router(
     "127.0.0.1", g_config_path, common::parseConfig);
 
@@ -532,9 +532,9 @@ TEST(ThriftRouterTest, ForeignReplicaTest) {
   }
 }
 
-TEST(ThriftRouterTest, ForeignReplicaMultiClientsTest) {
+TEST(ThriftRouterTest, ForeignGroupMultiClientsTest) {
   FLAGS_port = 8099;
-  updateConfigFile(g_config_v1Replica);
+  updateConfigFile(g_config_v1Group);
   ThriftRouter<DummyServiceAsyncClient> router(
     "127.0.0.1", g_config_path, common::parseConfig);
 

--- a/common/thrift_router.cpp
+++ b/common/thrift_router.cpp
@@ -46,7 +46,7 @@ bool parseHost(const std::string& str, common::detail::Host* host) {
     return false;
   }
 
-  host->replica_name = (tokens.size() == 3 ? tokens[2] : "unknown");
+  host->group_name = (tokens.size() == 3 ? tokens[2] : "unknown");
   return true;
 }
 

--- a/common/thrift_router.cpp
+++ b/common/thrift_router.cpp
@@ -29,7 +29,7 @@ DEFINE_int32(min_client_reconnect_interval_seconds, 5,
              "min reconnect interval in seconds");
 DEFINE_int64(client_connect_timeout_millis, 100,
              "Timeout for establishing client connection.");
-
+DEFINE_int32(port, 9090, "Port of the server");
 
 namespace {
 
@@ -46,7 +46,7 @@ bool parseHost(const std::string& str, common::detail::Host* host) {
     return false;
   }
 
-  host->az = (tokens.size() == 3 ? tokens[2] : "unknown");
+  host->replica_name = (tokens.size() == 3 ? tokens[2] : "unknown");
   return true;
 }
 
@@ -118,7 +118,8 @@ std::unique_ptr<const detail::ClusterLayout> parseConfig(std::string content) {
         return nullptr;
       }
 
-      const detail::Host* pHost = &*(cl->all_hosts.insert(host).first);
+      const detail::Host* pHost =
+        &(cl->all_hosts.emplace(host.addr, host).first->second);
       const auto& shard_list = segment_value[host_port_az];
       // for each shard
       for (Json::ArrayIndex i = 0; i < shard_list.size(); ++i) {

--- a/common/thrift_router.h
+++ b/common/thrift_router.h
@@ -476,7 +476,7 @@ class ThriftRouter {
       uint64_t create_time;
     };
 
-    folly::SocketAddress local_addr_;
+    const folly::SocketAddress local_addr_;
     std::string local_group_;
     ThriftClientPool<ClientType, USE_BINARY_PROTOCOL> client_pool_;
     folly::ThreadLocal<std::shared_ptr<const ClusterLayout>>

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -48,8 +48,6 @@ DEFINE_string(rocksdb_dir, "/data/xvdb/aperture/",
 DEFINE_int32(num_hdfs_access_threads, 8,
              "The number of threads for backup or restore to/from HDFS");
 
-DEFINE_int32(port, 9090, "Port of the server");
-
 DEFINE_string(shard_config_path, "",
              "Local path of file storing shard mapping for Aperture");
 
@@ -62,6 +60,7 @@ DEFINE_bool(compact_db_after_load_sst, false,
 DECLARE_int32(rocksdb_replicator_port);
 
 DEFINE_bool(s3_direct_io, false, "Whether to enable direct I/O for s3 client");
+DECLARE_int32(port);
 
 namespace {
 


### PR DESCRIPTION
To enable multiple replica in one az, remove the AZ dependency in thrift router and generalize it to be replica name.