### PR TITLE
Support multiple groups in one AZ for routing (good version)

### DIFF
--- a/common/network_util.cpp
+++ b/common/network_util.cpp
@@ -17,9 +17,9 @@
 #include <ifaddrs.h>
 #include "folly/SocketAddress.h"
 
-namespace common {
+namespace {
 
-std::string getLocalIPAddress() {
+std::string getLocalIPAddressImpl() {
   ifaddrs* ips;
   CHECK_EQ(::getifaddrs(&ips), 0);
   ifaddrs* ips_tmp = ips;
@@ -37,6 +37,16 @@ std::string getLocalIPAddress() {
     ips_tmp = ips_tmp->ifa_next;
   }
   freeifaddrs(ips);
+  return local_ip;
+}
+
+}  // namespace
+
+
+namespace common {
+
+const std::string& getLocalIPAddress() {
+  static const std::string local_ip = getLocalIPAddressImpl();
   return local_ip;
 }
 

--- a/common/network_util.h
+++ b/common/network_util.h
@@ -21,6 +21,6 @@ namespace common {
 /*
  * Get the local IP address from eth0.
  */
-std::string getLocalIPAddress();
+const std::string& getLocalIPAddress();
 
 }  // namespace common

--- a/common/tests/thrift_router_test.cpp
+++ b/common/tests/thrift_router_test.cpp
@@ -799,11 +799,11 @@ TEST(ThriftRouterTest, ForeignHostGroupTestPreferLocal) {
     EXPECT_EQ(v.size(), 1);
     v[0]->future_ping().get();
   }
-  // Load should be balanced
-  ASSERT_TRUE(handlers[0]->nPings_.load() == 51);
-  ASSERT_TRUE(handlers[1]->nPings_.load() == 51);
+  ASSERT_TRUE(handlers[0]->nPings_.load() > 1);
+  ASSERT_TRUE(handlers[1]->nPings_.load() > 1);
   ASSERT_TRUE(handlers[2]->nPings_.load() == 1);
   ASSERT_TRUE(handlers[3]->nPings_.load() == 1);
+  ASSERT_TRUE(handlers[0]->nPings_.load() + handlers[1]->nPings_.load() == 102);
 
   // stop all servers
   for (auto& s : servers) {

--- a/common/thrift_router.cpp
+++ b/common/thrift_router.cpp
@@ -121,16 +121,15 @@ std::unique_ptr<const detail::ClusterLayout> parseConfig(
         LOG(ERROR) << "Invalid host port group " << host_port_group;
         return nullptr;
       }
-
-      if (cl->all_hosts.find(host.addr) == cl->all_hosts.end()) {
-        cl->all_hosts.emplace(host.addr, host);
-      } else {
-        cl->all_hosts[host.addr].groups_prefix_lengths.insert(
-                host.groups_prefix_lengths.begin(),
-                host.groups_prefix_lengths.end());
+      auto host_iter = cl->all_hosts.find(host);
+      if (host_iter != cl->all_hosts.end()) {
+        host.groups_prefix_lengths.insert(
+                host_iter->groups_prefix_lengths.begin(),
+                host_iter->groups_prefix_lengths.end());
+        cl->all_hosts.erase(host_iter);
       }
-
-      detail::Host* pHost = &(cl->all_hosts.at(host.addr));
+        cl->all_hosts.insert(std::move(host));
+      const detail::Host* pHost = &*(cl->all_hosts.find(host));
       const auto& shard_list = segment_value[host_port_group];
       // for each shard
       for (Json::ArrayIndex i = 0; i < shard_list.size(); ++i) {

--- a/common/thrift_router.cpp
+++ b/common/thrift_router.cpp
@@ -128,7 +128,7 @@ std::unique_ptr<const detail::ClusterLayout> parseConfig(
                 host_iter->groups_prefix_lengths.end());
         cl->all_hosts.erase(host_iter);
       }
-        cl->all_hosts.insert(std::move(host));
+      cl->all_hosts.insert(std::move(host));
       const detail::Host* pHost = &*(cl->all_hosts.find(host));
       const auto& shard_list = segment_value[host_port_group];
       // for each shard

--- a/common/thrift_router.cpp
+++ b/common/thrift_router.cpp
@@ -33,18 +33,6 @@ DEFINE_int64(client_connect_timeout_millis, 100,
 
 namespace {
 
-inline uint16_t longest_common_prefix(const std::string& s1,
-                                      const std::string& s2) {
-  auto length = std::min(s1.length(), s2.length());
-  uint16_t count = 0;
-  for (int i = 0; i < length; i ++, count ++) {
-    if (s1[i] != s2[i]) {
-      return count;
-    }
-  }
-  return count;
-}
-
 bool parseHost(const std::string& str, common::detail::Host* host,
                const std::string& segment, const std::string& local_group) {
   std::vector<std::string> tokens;
@@ -58,10 +46,10 @@ bool parseHost(const std::string& str, common::detail::Host* host,
   } catch (...) {
     return false;
   }
-  auto group = (tokens.size() == 3 ? tokens[2] : "unknown");
+  auto group = (tokens.size() == 3 ? tokens[2] : "");
   host->groups_prefix_lengths[segment] =
-    longest_common_prefix(group, local_group);
-  tokens.clear();
+    std::distance(group.begin(), std::mismatch(group.begin(), group.end(),
+                  local_group.begin(), local_group.end()).first);
   return true;
 }
 
@@ -91,7 +79,7 @@ bool parseShard(const std::string& str, common::detail::Role* role,
 namespace common {
 
 std::unique_ptr<const detail::ClusterLayout> parseConfig(
-  std::string content, const std::string& local_group) {
+    std::string content, const std::string& local_group) {
   auto cl = std::make_unique<detail::ClusterLayout>();
   Json::Reader reader;
   Json::Value root;

--- a/common/thrift_router.cpp
+++ b/common/thrift_router.cpp
@@ -28,7 +28,6 @@ DEFINE_bool(always_prefer_local_host, false,
             "Always prefer local host when ordering hosts");
 DEFINE_int32(min_client_reconnect_interval_seconds, 5,
              "min reconnect interval in seconds");
-DEFINE_int32(port, 9090, "Port of the server");
 DEFINE_int64(client_connect_timeout_millis, 100,
              "Timeout for establishing client connection.");
 

--- a/common/thrift_router.h
+++ b/common/thrift_router.h
@@ -58,7 +58,7 @@ struct Host {
   folly::SocketAddress addr;
   std::string az;  // availability zone
   // The hosts's groups in different segments
-  std::unordered_map<std::string, std::string> groups;
+  std::unordered_map<std::string, uint16_t> groups_prefix_lengths;
 };
 
 struct SegmentInfo {
@@ -98,14 +98,14 @@ class ThriftRouter {
    *                     an in memory READONLY ClusterLayout structure.
    */
   ThriftRouter(
-      const std::string& local_az,
+      const std::string& local_group,
       const std::string& config_path,
       std::function<std::unique_ptr<const ClusterLayout>(std::string)> parser)
       : config_path_(config_path)
       , parser_(std::move(parser))
       , layout_rwlock_()
       , cluster_layout_()
-      , local_client_map_(local_az) {
+      , local_client_map_(local_group) {
     CHECK(common::FileWatcher::Instance()->AddFile(
       config_path_,
       [this] (std::string content) {
@@ -579,6 +579,7 @@ class ThriftRouter {
   "   }"
   "}";
  */
-std::unique_ptr<const detail::ClusterLayout> parseConfig(std::string content);
+std::unique_ptr<const detail::ClusterLayout> parseConfig(
+  std::string content, const std::string& local_group);
 
 }  // namespace common

--- a/common/thrift_router.h
+++ b/common/thrift_router.h
@@ -55,7 +55,7 @@ struct Host {
   }
 
   folly::SocketAddress addr;
-  // The hosts's groups in different segments
+  // The hosts' longest common prefix length with local group
   std::unordered_map<std::string, uint16_t> groups_prefix_lengths;
 };
 
@@ -393,7 +393,7 @@ class ThriftRouter {
         const unsigned rotation_counter,
         const std::string& segment) {
       if (v->size() == 0) return;
-      auto comparator = [this, segment]
+      auto comparator = [this, &segment]
         (const Host* h1, const Host* h2) -> bool {
         // Descending order
         return h1->groups_prefix_lengths.at(segment) >

--- a/common/thrift_router.h
+++ b/common/thrift_router.h
@@ -393,15 +393,15 @@ class ThriftRouter {
         std::vector<const Host*>* v,
         const unsigned rotation_counter,
         const std::string& segment) {
-      auto comparator = [this, &segment, &rotation_counter]
+      auto comparator = [this, &segment, rotation_counter]
         (const Host* h1, const Host* h2) -> bool {
         // Descending order
-        auto s1 = h1->groups_prefix_lengths.at(segment);
-        auto s2 = h2->groups_prefix_lengths.at(segment);
+        const auto s1 = h1->groups_prefix_lengths.at(segment);
+        const auto s2 = h2->groups_prefix_lengths.at(segment);
         if (s1 == s2) {
-          auto hash1 = folly::hash::twang_mix64(
+          const auto hash1 = folly::hash::twang_mix64(
             reinterpret_cast<uint64_t>(h1) ^ rotation_counter);
-          auto hash2 = folly::hash::twang_mix64(
+          const auto hash2 = folly::hash::twang_mix64(
             reinterpret_cast<uint64_t>(h2) ^ rotation_counter);
           return hash1 < hash2;
         } else {

--- a/common/thrift_router.h
+++ b/common/thrift_router.h
@@ -31,6 +31,7 @@
 #include "common/file_watcher.h"
 #include "common/network_util.h"
 #include "common/thrift_client_pool.h"
+#include "folly/Hash.h"
 #include "folly/RWSpinLock.h"
 #include "folly/SocketAddress.h"
 #include "folly/ThreadLocal.h"
@@ -398,10 +399,10 @@ class ThriftRouter {
         auto s1 = h1->groups_prefix_lengths.at(segment);
         auto s2 = h2->groups_prefix_lengths.at(segment);
         if (s1 == s2) {
-          auto hash1 = std::hash<std::string>{}(
-            std::to_string(reinterpret_cast<uint64_t>(h1) ^ rotation_counter));
-          auto hash2 = std::hash<std::string>{}(
-            std::to_string(reinterpret_cast<uint64_t>(h2) ^ rotation_counter));
+          auto hash1 = folly::hash::twang_mix64(
+            reinterpret_cast<uint64_t>(h1) ^ rotation_counter);
+          auto hash2 = folly::hash::twang_mix64(
+            reinterpret_cast<uint64_t>(h2) ^ rotation_counter);
           return hash1 < hash2;
         } else {
           return s1 > s2;

--- a/common/thrift_router.h
+++ b/common/thrift_router.h
@@ -400,15 +400,6 @@ class ThriftRouter {
                 h2->groups_prefix_lengths.at(segment);
       };
       std::sort(v->begin(), v->end(), comparator);
-      /*
-      LOG(ERROR) << "start";
-      for (int i = 0; i < v->size(); i ++) {
-        LOG(ERROR) << v->at(i)->addr.getAddressStr() << ": " << v->at(i)
-                ->addr.getPort() << ": " << v->at(i)->groups_prefix_lengths
-                .at(segment);
-      }
-      LOG(ERROR) << "end";
-       */
       // for the front k hosts, rotate them.
       auto longest_prefix_length = v->at(0)->groups_prefix_lengths.at(segment);
       auto smaller_prefix_length =

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -48,7 +48,7 @@ DEFINE_string(rocksdb_dir, "/data/xvdb/aperture/",
 DEFINE_int32(num_hdfs_access_threads, 8,
              "The number of threads for backup or restore to/from HDFS");
 
-DECLARE_int32(port);
+DEFINE_int32(port, 9090, "Port of the server")
 
 DEFINE_string(shard_config_path, "",
              "Local path of file storing shard mapping for Aperture");

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -48,7 +48,7 @@ DEFINE_string(rocksdb_dir, "/data/xvdb/aperture/",
 DEFINE_int32(num_hdfs_access_threads, 8,
              "The number of threads for backup or restore to/from HDFS");
 
-DEFINE_int32(port, 9090, "Port of the server");
+DECLARE_int32(port);
 
 DEFINE_string(shard_config_path, "",
              "Local path of file storing shard mapping for Aperture");

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -48,7 +48,7 @@ DEFINE_string(rocksdb_dir, "/data/xvdb/aperture/",
 DEFINE_int32(num_hdfs_access_threads, 8,
              "The number of threads for backup or restore to/from HDFS");
 
-DEFINE_int32(port, 9090, "Port of the server")
+DEFINE_int32(port, 9090, "Port of the server");
 
 DEFINE_string(shard_config_path, "",
              "Local path of file storing shard mapping for Aperture");

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -106,7 +106,7 @@ std::unique_ptr<::admin::ApplicationDBManager> CreateDBBasedOnConfig(
   std::string content;
   CHECK(folly::readFile(FLAGS_shard_config_path.c_str(), content));
 
-  auto cluster_layout = common::parseConfig(std::move(content));
+  auto cluster_layout = common::parseConfig(std::move(content), "");
   CHECK(cluster_layout);
 
   folly::SocketAddress local_addr(common::getLocalIPAddress(), FLAGS_port);


### PR DESCRIPTION
The change should cover 3 parts:
1. Foreign host (not in the config) to route using AZ information
2. host in config to talk to other hosts in config, but the config doesn't have group concept. The routing is based on AZ information, only route traffic to local az.
3. host in config to talk to other hosts in config, and the config contains group concept. The routing is based on group information, only route traffic to local group.

1-3 is the behavior when FLAGS_always_prefer_local_host is true.