### PR TITLE
Support delete old finished recurring tasks in every recur task run

### DIFF
--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/TaskQueue.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/TaskQueue.java
@@ -160,9 +160,13 @@ public interface TaskQueue {
   /**
    * Remove finished tasks.
    * @param secondsAgo tasks finished seconds ago
+   * @param namespace cluster namespace, can be null or empty
+   * @param clusterName clusterName, can be null or empty
+   * @param taskName taskName
    * @return the number of finished tasks which are removed by this call.
    */
-  default int removeFinishedTasks(final int secondsAgo) {
+  default int removeFinishedTasks(final int secondsAgo, final String namespace,
+                                  final String clusterName, final String taskName) {
     return 0;
   }
 

--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/mysql/MySQLTaskQueue.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/mysql/MySQLTaskQueue.java
@@ -16,6 +16,7 @@
 
 package com.pinterest.rocksplicator.controller.mysql;
 
+import com.google.common.base.Strings;
 import com.pinterest.rocksplicator.controller.Cluster;
 import com.pinterest.rocksplicator.controller.Task;
 import com.pinterest.rocksplicator.controller.TaskBase;
@@ -357,7 +358,7 @@ public class MySQLTaskQueue extends MySQLBase implements TaskQueue {
     Query query;
     if (!cluster.getName().isEmpty() && !cluster.getNamespace().isEmpty() && state != null) {
       query = getEntityManager()
-        .createNamedQuery("task.peekTasksFromClusterWithState")
+        .createNamedQuery("task.peekTasksWithStateFromCluster")
         .setParameter("state", state)
         .setParameter("namespace", cluster.getNamespace()).setParameter("name", cluster.getName());
     } else if (!cluster.getNamespace().isEmpty() && cluster.getName().isEmpty() && state != null) {
@@ -414,12 +415,59 @@ public class MySQLTaskQueue extends MySQLBase implements TaskQueue {
   }
  
   @Override
-  public int removeFinishedTasks(final int secondsAgo) {
+  public int removeFinishedTasks(final int secondsAgo, final String namespace,
+                                 final String clusterName, final String taskName) {
     beginTransaction();
-    List<TaskEntity> finishedTasks = getEntityManager()
-        .createNamedQuery("task.peekTasksWithState")
-        .setParameter("state", TaskState.DONE.intValue())
-        .setLockMode(LockModeType.PESSIMISTIC_WRITE).getResultList();
+    List<TaskEntity> finishedTasks;
+    if (Strings.isNullOrEmpty(namespace)) {
+      if (Strings.isNullOrEmpty(taskName)) {
+        finishedTasks = getEntityManager()
+            .createNamedQuery("task.peekTasksWithState")
+            .setParameter("state", TaskState.DONE.intValue())
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE).getResultList();
+      } else {
+        finishedTasks = getEntityManager()
+            .createNamedQuery("task.peekTasksWithStateAndName")
+            .setParameter("state", TaskState.DONE.intValue())
+            .setParameter("name", taskName)
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE).getResultList();
+      }
+    } else {
+      if (Strings.isNullOrEmpty(clusterName)) {
+        if (Strings.isNullOrEmpty(taskName)) {
+          finishedTasks = getEntityManager()
+              .createNamedQuery("task.peekTasksWithStateFromNamespace")
+              .setParameter("state", TaskState.DONE.intValue())
+              .setParameter("namespace", namespace)
+              .setLockMode(LockModeType.PESSIMISTIC_WRITE).getResultList();
+        } else {
+          finishedTasks = getEntityManager()
+              .createNamedQuery("task.peekTasksWithStateAndNameFromNamespace")
+              .setParameter("state", TaskState.DONE.intValue())
+              .setParameter("namespace", namespace)
+              .setParameter("name", taskName)
+              .setLockMode(LockModeType.PESSIMISTIC_WRITE).getResultList();
+        }
+      } else {
+        if (Strings.isNullOrEmpty(taskName)) {
+          finishedTasks = getEntityManager()
+              .createNamedQuery("task.peekTasksWithStateFromCluster")
+              .setParameter("state", TaskState.DONE.intValue())
+              .setParameter("namespace", namespace)
+              .setParameter("name", clusterName)
+              .setLockMode(LockModeType.PESSIMISTIC_WRITE).getResultList();
+        } else {
+          finishedTasks = getEntityManager()
+              .createNamedQuery("task.peekTasksWithStateAndNameFromCluster")
+              .setParameter("state", TaskState.DONE.intValue())
+              .setParameter("namespace", namespace)
+              .setParameter("name", taskName)
+              .setParameter("clusterName", clusterName)
+              .setLockMode(LockModeType.PESSIMISTIC_WRITE).getResultList();
+        }
+      }
+    }
+
     List<TaskEntity> removingTasks = finishedTasks.stream().filter(t -> DateUtils.addSeconds(t
         .getCreatedAt(), secondsAgo).before(new Date())).collect(Collectors.toList());
     removingTasks.stream().forEach(t -> getEntityManager().remove(t));

--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/mysql/MySQLTaskQueue.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/mysql/MySQLTaskQueue.java
@@ -16,7 +16,6 @@
 
 package com.pinterest.rocksplicator.controller.mysql;
 
-import com.google.common.base.Strings;
 import com.pinterest.rocksplicator.controller.Cluster;
 import com.pinterest.rocksplicator.controller.Task;
 import com.pinterest.rocksplicator.controller.TaskBase;
@@ -25,6 +24,8 @@ import com.pinterest.rocksplicator.controller.bean.TaskState;
 import com.pinterest.rocksplicator.controller.mysql.entity.TagEntity;
 import com.pinterest.rocksplicator.controller.mysql.entity.TagId;
 import com.pinterest.rocksplicator.controller.mysql.entity.TaskEntity;
+
+import com.google.common.base.Strings;
 import org.apache.commons.lang3.time.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/mysql/entity/TaskEntity.java
+++ b/controller/controller-common/src/main/java/com/pinterest/rocksplicator/controller/mysql/entity/TaskEntity.java
@@ -67,12 +67,21 @@ import java.util.Date;
                         "WHERE c.name = :name AND c.namespace = :namespace"),
     @NamedQuery(name = "task.peekTasksWithState",
                 query = "SELECT t FROM task t WHERE t.state = :state"),
+    @NamedQuery(name = "task.peekTasksWithStateAndName",
+                query = "SELECT t FROM task t INNER JOIN t.cluster c WHERE t.state = :state AND " +
+                        "t.name = :name"),
     @NamedQuery(name = "task.peekTasksWithStateFromNamespace",
                 query = "SELECT t FROM task t INNER JOIN t.cluster c WHERE t.state = :state AND " +
                         "c.namespace = :namespace"),
-    @NamedQuery(name = "task.peekTasksFromClusterWithState",
+    @NamedQuery(name = "task.peekTasksWithStateAndNameFromNamespace",
                 query = "SELECT t FROM task t INNER JOIN t.cluster c WHERE t.state = :state AND " +
-                    "c.namespace = :namespace AND c.name = :name"),
+                        "c.namespace = :namespace AND t.name = :name"),
+    @NamedQuery(name = "task.peekTasksWithStateFromCluster",
+                query = "SELECT t FROM task t INNER JOIN t.cluster c WHERE t.state = :state AND " +
+                        "c.namespace = :namespace AND c.name = :name"),
+    @NamedQuery(name = "task.peekTasksWithStateAndNameFromCluster",
+                query = "SELECT t FROM task t INNER JOIN t.cluster c WHERE t.state = :state AND " +
+                        "t.name = :name AND c.namespace = :namespace AND c.name = :clusterName")
 })
 public class TaskEntity {
 

--- a/controller/controller-common/src/test/java/com/pinterest/rocksplicator/controller/mysql/MySQLTaskQueueIntegrationTest.java
+++ b/controller/controller-common/src/test/java/com/pinterest/rocksplicator/controller/mysql/MySQLTaskQueueIntegrationTest.java
@@ -199,7 +199,7 @@ public class MySQLTaskQueueIntegrationTest {
   }
 
   @Test
-  public void testRemoveFinishedTasks() throws InterruptedException {
+  public void testRemoveFinishedTasksBasic() throws InterruptedException {
     Assert.assertTrue(
         queue.enqueueTask(createTaskBase("test-task-p0", 0, "test-task-body-p0"),
             cluster, 0));
@@ -212,7 +212,42 @@ public class MySQLTaskQueueIntegrationTest {
     Assert.assertTrue(queue.finishTask(task1.id, ""));
     Task task2 = queue.dequeueTask("worker");
     Assert.assertTrue(queue.finishTask(task2.id, ""));
-    Assert.assertEquals(queue.removeFinishedTasks(3), 1);
+    Assert.assertEquals(queue.removeFinishedTasks(3, null, null, null), 1);
+  }
+
+  @Test
+  public void testRemoveFinishedTasksWithTaskName() throws InterruptedException {
+    Assert.assertTrue(
+        queue.enqueueTask(createTaskBase("test-task-p0", 0, "test-task-body-p0"),
+            cluster, 0));
+    Thread.sleep(2000);
+    Assert.assertTrue(
+        queue.enqueueTask(createTaskBase("test-task-p2", 2, "test-task-body-p2"),
+            cluster, 0));
+    Thread.sleep(2000);
+    Task task1 = queue.dequeueTask("worker");
+    Assert.assertTrue(queue.finishTask(task1.id, ""));
+    Task task2 = queue.dequeueTask("worker");
+    Assert.assertTrue(queue.finishTask(task2.id, ""));
+    Assert.assertEquals(queue.removeFinishedTasks(1, null, null, "test-task-p0"), 1);
+  }
+
+  @Test
+  public void testRemoveFinishedTasksWithNameFromCluster() throws InterruptedException {
+    Assert.assertTrue(
+        queue.enqueueTask(createTaskBase("test-task-p0", 0, "test-task-body-p0"),
+            cluster, 0));
+    Thread.sleep(2000);
+    Assert.assertTrue(
+        queue.enqueueTask(createTaskBase("test-task-p2", 2, "test-task-body-p2"),
+            cluster, 0));
+    Thread.sleep(2000);
+    Task task1 = queue.dequeueTask("worker");
+    Assert.assertTrue(queue.finishTask(task1.id, ""));
+    Task task2 = queue.dequeueTask("worker");
+    Assert.assertTrue(queue.finishTask(task2.id, ""));
+    Assert.assertEquals(queue.removeFinishedTasks(
+        1, TEST_CLUSTER_NAMESPACE, TEST_CLUSTER_NAME, "test-task-p0"), 1);
   }
 
   @Test

--- a/controller/controller-worker/src/main/java/com/pinterest/rocksplicator/controller/tasks/LocalAckTaskQueue.java
+++ b/controller/controller-worker/src/main/java/com/pinterest/rocksplicator/controller/tasks/LocalAckTaskQueue.java
@@ -139,8 +139,9 @@ class LocalAckTaskQueue implements TaskQueue {
   }
 
   @Override
-  public int removeFinishedTasks(final int secondsAgo) {
-    return taskQueue.removeFinishedTasks(secondsAgo);
+  public int removeFinishedTasks(final int secondsAgo, final String namespace,
+                                 final String clusterName, final String taskName) {
+    return taskQueue.removeFinishedTasks(secondsAgo, namespace, clusterName, taskName);
   }
 
   @Override


### PR DESCRIPTION
Only keeping 1 hour recurring tasks, assuming healthcheck recurring task are executed every 30 seconds, the rolling window can keep at most 240 recent tasks (if there are failed tasks, will be more) per cluster.

This change will help keep the db size small.