### PR TITLE
add a gflag tcp_user_timeout_ms

### DIFF
--- a/common/thrift_client_pool.cpp
+++ b/common/thrift_client_pool.cpp
@@ -32,3 +32,7 @@ DEFINE_int32(default_thrift_client_pool_threads, sysconf(_SC_NPROCESSORS_ONLN),
 
 DEFINE_int32(min_channel_create_interval_seconds, 10,
              "The minimum time between two identical channel creation");
+
+DEFINE_int32(tcp_user_timeout_ms, 0,
+             "The max time allowed for unacked tcp data before closing the "
+             "corresponding TCP connection");


### PR DESCRIPTION
Setting this flag will help when a peer host crash without gracefully closing established TCP connections.