### PR TITLE
[client_pool] enable 10 second tcp_user_timeout

### DIFF
--- a/common/thrift_client_pool.cpp
+++ b/common/thrift_client_pool.cpp
@@ -33,6 +33,6 @@ DEFINE_int32(default_thrift_client_pool_threads, sysconf(_SC_NPROCESSORS_ONLN),
 DEFINE_int32(min_channel_create_interval_seconds, 10,
              "The minimum time between two identical channel creation");
 
-DEFINE_int32(tcp_user_timeout_ms, 0,
+DEFINE_int32(tcp_user_timeout_ms, 10000,
              "The max time allowed for unacked tcp data before closing the "
              "corresponding TCP connection");


### PR DESCRIPTION
Make it default so every system can benefit from it. We have enabled it for scorpion p2p and pinnability for a few weeks now.