### PR TITLE
change default rocksdb_dir path to /tmp/

### DIFF
--- a/common/stats/stats.cpp
+++ b/common/stats/stats.cpp
@@ -49,7 +49,7 @@ namespace {
 
 const int64_t kMinMetricValue = 0;
 const int64_t kMaxMetricValue = 200;
-const int64_t kFlushIntervalMS = 1000;
+const int64_t kFlushIntervalMS = 250;
 
 inline seconds GetTimeSinceEpochSeconds() {
   return duration_cast<seconds>(system_clock::now().time_since_epoch());

--- a/common/tests/thrift_router_test.cpp
+++ b/common/tests/thrift_router_test.cpp
@@ -621,13 +621,12 @@ TEST(ThriftRouterTest, HostOrderTest) {
   EXPECT_EQ(
     router.getClientsFor("user_pins", Role::ANY, Quantity::ALL, 2, &v),
     ReturnCode::OK);
-  // We expect to see the "us-east-1c" host first
   EXPECT_EQ(v.size(), 3);
   EXPECT_NO_THROW(v[0]->future_ping().get());
-  EXPECT_EQ(handlers[1]->nPings_.load(), 1);
+  EXPECT_EQ(handlers[0]->nPings_.load(), 1);
 
   EXPECT_NO_THROW(v[1]->future_ping().get());
-  EXPECT_EQ(handlers[0]->nPings_.load(), 1);
+  EXPECT_EQ(handlers[1]->nPings_.load(), 1);
 
   EXPECT_NO_THROW(v[2]->future_ping().get());
   EXPECT_EQ(handlers[2]->nPings_.load(), 1);
@@ -919,6 +918,7 @@ TEST(ThriftRouterTest, UnreachableHost) {
 }
 
 int main(int argc, char** argv) {
+  FLAGS_always_prefer_local_host = false;
   ::testing::InitGoogleTest(&argc, argv);
   FLAGS_channel_cleanup_min_interval_seconds = -1;
   return RUN_ALL_TESTS();

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -42,7 +42,7 @@
 DEFINE_string(hdfs_name_node, "hdfs://hbasebak-infra-namenode-prod1c01-001:8020",
               "The hdfs name node used for backup");
 
-DEFINE_string(rocksdb_dir, "/data/xvdb/aperture/",
+DEFINE_string(rocksdb_dir, "/tmp/",
               "The dir for local rocksdb instances");
 
 DEFINE_int32(num_hdfs_access_threads, 8,


### PR DESCRIPTION
fix internal test failures.