### PR TITLE
[cluster_management] more reliable way to get partition number

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/OnlineOfflineConfigGenerator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/OnlineOfflineConfigGenerator.java
@@ -82,7 +82,8 @@ public class OnlineOfflineConfigGenerator implements CustomCodeCallbackHandler {
 
       // compose resource config
       JSONObject resourceConfig = new JSONObject();
-      resourceConfig.put("num_shards", partitions.size());
+      String partitionsStr = externalView.getRecord().getSimpleField("NUM_PARTITIONS");
+      resourceConfig.put("num_shards", Integer.parseInt(partitionsStr));
 
       // build host to partition list map
       Map<String, List<String>> hostToPartitionList = new HashMap<String, List<String>>();


### PR DESCRIPTION
During the startup stage, we may have less partitions than expected.
use the source of truth which is specified in NUM_PARTITIONS