### PR TITLE
[common] add a simple aws rate limiter

### DIFF
--- a/common/aws_s3_rate_limiter.cpp
+++ b/common/aws_s3_rate_limiter.cpp
@@ -1,0 +1,71 @@
+/// Copyright 2018 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author bol (bol@pinterest.com)
+//
+
+#include "common/aws_s3_rate_limiter.h"
+
+#include <thread>
+
+using Aws::Utils::RateLimits::RateLimiterInterface;
+
+
+namespace common {
+
+RateLimiterInterface::DelayType AwsS3RateLimiter::ApplyCost(int64_t cost) {
+  auto pre_state = atomic_state_.load();
+  while (true) {
+    auto current_seconds = clock_();
+    State new_state(pre_state);
+    if (current_seconds > pre_state.last_update_seconds) {
+      auto new_budget =
+        (current_seconds - pre_state.last_update_seconds) * rate_.load();
+
+      new_state.budget = std::min(new_state.budget + new_budget, rate_.load());
+      new_state.last_update_seconds = current_seconds;
+    }
+
+    new_state.budget -= cost;
+
+    RateLimiterInterface::DelayType res(0);
+
+    if (new_state.budget < 0) {
+      res = RateLimiterInterface::DelayType(
+        static_cast<int>((-new_state.budget) * 1000 / rate_.load()));
+    }
+
+    if (atomic_state_.compare_exchange_weak(pre_state, new_state)) {
+      return res;
+    }
+  }
+}
+
+void AwsS3RateLimiter::ApplyAndPayForCost(int64_t cost) {
+  auto time_to_sleep = ApplyCost(cost);
+  if (time_to_sleep.count() > 0) {
+    std::this_thread::sleep_for(time_to_sleep);
+  }
+}
+
+void AwsS3RateLimiter::SetRate(int64_t rate, bool) {
+  rate_.store(rate);
+}
+
+uint32_t AwsS3RateLimiter::GetCurrentTimeSeconds() {
+  return static_cast<uint32_t>(time(nullptr));
+}
+
+}  // namespace common

--- a/common/aws_s3_rate_limiter.h
+++ b/common/aws_s3_rate_limiter.h
@@ -1,0 +1,74 @@
+/// Copyright 2018 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author bol (bol@pinterest.com)
+//
+
+#pragma once
+
+#include "aws/core/utils/ratelimiter/RateLimiterInterface.h"
+#include "folly/AtomicStruct.h"
+#include "glog/logging.h"
+
+namespace common {
+
+/**
+ * AwsS3RateLimiter is an implementation of AWS RateLimiterInterface.
+ */
+class AwsS3RateLimiter : public Aws::Utils::RateLimits::RateLimiterInterface {
+  struct State {
+    uint32_t last_update_seconds;
+    float budget;
+  };
+
+ public:
+  // Allow at most "rate" tokens per "n_seconds".
+  explicit AwsS3RateLimiter(
+      const float rate,
+      std::function<uint32_t(void)> clock = GetCurrentTimeSeconds)
+      : rate_(rate)
+      , clock_(std::move(clock))
+      , atomic_state_() {
+    CHECK_GT(rate_.load(), 0);
+    State s;
+    s.last_update_seconds = clock_();
+    s.budget = rate_.load();
+    atomic_state_.store(s);
+  }
+
+  /**
+   * Calculates time in milliseconds that should be delayed before letting anymore data through.
+   */
+  DelayType ApplyCost(int64_t cost) override;
+
+  /**
+   * Same as ApplyCost() but then goes ahead and sleeps the current thread.
+   */
+  void ApplyAndPayForCost(int64_t cost) override;
+
+  /**
+   * Update the bandwidth rate to allow.
+   */
+  void SetRate(int64_t rate, bool resetAccumulator = false) override;
+
+ private:
+  static uint32_t GetCurrentTimeSeconds();
+
+  std::atomic<float> rate_;
+  const std::function<uint32_t(void)> clock_;
+  folly::AtomicStruct<State> atomic_state_;
+};
+
+}  // namespace common

--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -22,7 +22,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <aws/core/utils/ratelimiter/DefaultRateLimiter.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/HeadObjectRequest.h>
@@ -39,6 +38,7 @@
 #include <fstream>
 #include "boost/algorithm/string.hpp"
 #include "boost/iostreams/stream.hpp"
+#include "common/aws_s3_rate_limiter.h"
 #include "glog/logging.h"
 
 using std::string;
@@ -47,7 +47,6 @@ using std::tuple;
 using Aws::S3::Model::GetObjectRequest;
 using Aws::S3::Model::ListObjectsRequest;
 using Aws::S3::Model::HeadObjectRequest;
-using Aws::Utils::RateLimits::DefaultRateLimiter;
 
 DEFINE_int32(direct_io_buffer_n_pages, 1,
              "Number of pages we need to set to direct io buffer");
@@ -318,7 +317,7 @@ shared_ptr<S3Util> S3Util::BuildS3Util(
   aws_config.requestTimeoutMs = request_timeout_ms;
   if (read_ratelimit_mb > 0) {
     aws_config.readRateLimiter =
-        std::make_shared<DefaultRateLimiter<>>(
+        std::make_shared<AwsS3RateLimiter>(
             read_ratelimit_mb * 1024 * 1024);
   }
   SDKOptions options;

--- a/common/tests/aws_s3_rate_limiter_test.cpp
+++ b/common/tests/aws_s3_rate_limiter_test.cpp
@@ -1,0 +1,82 @@
+/// Copyright 2018 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author bol (bol@pinterest.com)
+//
+
+#include <atomic>
+
+#include "common/aws_s3_rate_limiter.h"
+#include "gtest/gtest.h"
+
+using common::AwsS3RateLimiter;
+
+struct TestClock {
+  static uint32_t GetCurrentTimeSeconds() {
+    return current_time_.load();
+  }
+
+  static void SetCurrentTime(const uint32_t t) {
+    current_time_.store(t);
+  }
+
+  static std::atomic<uint32_t> current_time_;
+};
+
+std::atomic<uint32_t> TestClock::current_time_;
+
+TEST(AwsS3RateLimiterTest, Basics) {
+  TestClock::SetCurrentTime(0);
+  float rate = 10;
+  AwsS3RateLimiter rl(rate, TestClock::GetCurrentTimeSeconds);
+
+  auto delay = rl.ApplyCost(0);
+  EXPECT_EQ(delay.count(), 0);
+
+  delay = rl.ApplyCost(1);
+  EXPECT_EQ(delay.count(), 0);
+
+  delay = rl.ApplyCost(0);
+  EXPECT_EQ(delay.count(), 0);
+
+  // budget left = 9
+  delay = rl.ApplyCost(8);
+  EXPECT_EQ(delay.count(), 0);
+
+  // budget left = 1
+  delay = rl.ApplyCost(2);
+  EXPECT_EQ(delay.count(), 100);
+
+  delay = rl.ApplyCost(2);
+  EXPECT_EQ(delay.count(), 300);
+
+  delay = rl.ApplyCost(10);
+  EXPECT_EQ(delay.count(), 1300);
+
+  delay = rl.ApplyCost(0);
+  EXPECT_EQ(delay.count(), 1300);
+
+  // refill budget
+  TestClock::SetCurrentTime(3);
+
+  delay = rl.ApplyCost(10000);
+  EXPECT_EQ(delay.count(), (10000 - 10) * 1000 / 10);
+}
+
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
We have been seeing S3 List object call stuck in the default rate limiter forever. This PR implements a simple rate limiter, it will solve the issue if the problem is in the aws default rate limiter.