### PR TITLE
Add a counter in S3Util to track number of instances. 

### DIFF
--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -54,6 +54,7 @@ DEFINE_int32(direct_io_buffer_n_pages, 1,
 
 namespace common {
 
+std::atomic<std::uint32_t> S3Util::counter_(0);
 const uint32_t kPageSize = getpagesize();
 
 DirectIOWritableFile::DirectIOWritableFile(const string& file_path)

--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -324,8 +324,8 @@ shared_ptr<S3Util> S3Util::BuildS3Util(
   }
   SDKOptions options;
   TryAwsInitAPI(options);
-  return std::make_shared<S3Util>(
-          ThisIsPrivate{0}, bucket, aws_config, options, read_ratelimit_mb);
+  return std::shared_ptr<S3Util>(
+      new S3Util(bucket, aws_config, options, read_ratelimit_mb));
 }
 
 }  // namespace common

--- a/common/tests/s3_util_test.cpp
+++ b/common/tests/s3_util_test.cpp
@@ -140,22 +140,6 @@ TEST(S3UtilTest, DirectIOTest) {
   fs::remove(file_path);
 }
 
-TEST(S3UtilTest, CallDestructorOnlyOnce) {
-  EXPECT_EQ(0, common::S3Util::getInstanceCounter());
-  auto instance1 = common::S3Util::BuildS3Util(0, "", 0, 0);
-  EXPECT_EQ(1, common::S3Util::getInstanceCounter());
-  auto instance2 = common::S3Util::BuildS3Util(0, "", 0, 0);
-  EXPECT_EQ(2, common::S3Util::getInstanceCounter());
-  auto instance3 = common::S3Util::BuildS3Util(0, "", 0, 0);
-  EXPECT_EQ(3, common::S3Util::getInstanceCounter());
-  instance1 = nullptr;
-  EXPECT_EQ(2, common::S3Util::getInstanceCounter());
-  instance2 = nullptr;
-  EXPECT_EQ(1, common::S3Util::getInstanceCounter());
-  instance3 = nullptr;
-  EXPECT_EQ(0, common::S3Util::getInstanceCounter());
-}
-
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/common/tests/s3_util_test.cpp
+++ b/common/tests/s3_util_test.cpp
@@ -141,9 +141,6 @@ TEST(S3UtilTest, DirectIOTest) {
 }
 
 TEST(S3UtilTest, CallDestructorOnlyOnce) {
-  SDKOptions options;
-  Aws::InitAPI(options);
-
   EXPECT_EQ(0, common::S3Util::getInstanceCounter());
   auto instance1 = common::S3Util::BuildS3Util(0, "", 0, 0);
   EXPECT_EQ(1, common::S3Util::getInstanceCounter());

--- a/common/tests/s3_util_test.cpp
+++ b/common/tests/s3_util_test.cpp
@@ -29,12 +29,6 @@ namespace fs = boost::filesystem;
 
 using std::string;
 
-class MOckS3Util : public common::S3Util {
- public:
-  MOckS3Util() : S3Util("", ClientConfiguration(), SDKOptions(), 0) {}
-  ~MOckS3Util() {}
-};
-
 TEST(S3UtilTest, ParseS3StringTest) {
   string test_path = "invalid/string";
   tuple<string, string> result = common::S3Util::parseFullS3Path(test_path);
@@ -151,17 +145,17 @@ TEST(S3UtilTest, CallDestructorOnlyOnce) {
   Aws::InitAPI(options);
 
   EXPECT_EQ(0, common::S3Util::getInstanceCounter());
-  MOckS3Util* instance1 = new MOckS3Util();
+  auto instance1 = common::S3Util::BuildS3Util(0, "", 0, 0);
   EXPECT_EQ(1, common::S3Util::getInstanceCounter());
-  MOckS3Util* instance2 = new MOckS3Util();
+  auto instance2 = common::S3Util::BuildS3Util(0, "", 0, 0);
   EXPECT_EQ(2, common::S3Util::getInstanceCounter());
-  MOckS3Util* instance3 = new MOckS3Util();
+  auto instance3 = common::S3Util::BuildS3Util(0, "", 0, 0);
   EXPECT_EQ(3, common::S3Util::getInstanceCounter());
-  delete instance1;
+  instance1 = nullptr;
   EXPECT_EQ(2, common::S3Util::getInstanceCounter());
-  delete instance2;
+  instance2 = nullptr;
   EXPECT_EQ(1, common::S3Util::getInstanceCounter());
-  delete instance3;
+  instance3 = nullptr;
   EXPECT_EQ(0, common::S3Util::getInstanceCounter());
 }
 


### PR DESCRIPTION
Add a counter in S3Util to track number of instances. Aws::ShutdownAPI() will be called only when there is no other instences left.