### PR TITLE
exclude disabled hosts from shard map config

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 public class ConfigGenerator implements CustomCodeCallbackHandler {
   private static final Logger LOG = LoggerFactory.getLogger(ConfigGenerator.class);
@@ -184,9 +183,6 @@ public class ConfigGenerator implements CustomCodeCallbackHandler {
     } catch (Exception e) {
       LOG.error("Failed to post the new config", e);
     }
-
-    LOG.info("Sleep for 3 seconds before generating the next config");
-    TimeUnit.SECONDS.sleep(3);
   }
 
   private String getHostWithDomain(String host) {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
@@ -181,12 +181,12 @@ public class ConfigGenerator implements CustomCodeCallbackHandler {
       } else {
         LOG.error(response.getStatusLine().getReasonPhrase());
       }
+
+      LOG.info("Sleep for 3 seconds before generating the next config");
+      TimeUnit.SECONDS.sleep(3);
     } catch (Exception e) {
       LOG.error("Failed to post the new config", e);
     }
-
-    LOG.info("Sleep for 3 seconds before generating the next config");
-    TimeUnit.SECONDS.sleep(3);
   }
 
   private String getHostWithDomain(String host) {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
@@ -181,12 +181,12 @@ public class ConfigGenerator implements CustomCodeCallbackHandler {
       } else {
         LOG.error(response.getStatusLine().getReasonPhrase());
       }
-
-      LOG.info("Sleep for 3 seconds before generating the next config");
-      TimeUnit.SECONDS.sleep(3);
     } catch (Exception e) {
       LOG.error("Failed to post the new config", e);
     }
+
+    LOG.info("Sleep for 3 seconds before generating the next config");
+    TimeUnit.SECONDS.sleep(3);
   }
 
   private String getHostWithDomain(String host) {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 public class ConfigGenerator implements CustomCodeCallbackHandler {
   private static final Logger LOG = LoggerFactory.getLogger(ConfigGenerator.class);
@@ -183,6 +184,9 @@ public class ConfigGenerator implements CustomCodeCallbackHandler {
     } catch (Exception e) {
       LOG.error("Failed to post the new config", e);
     }
+
+    LOG.info("Sleep for 3 seconds before generating the next config");
+    TimeUnit.SECONDS.sleep(3);
   }
 
   private String getHostWithDomain(String host) {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
@@ -112,6 +112,11 @@ public class ConfigGenerator implements CustomCodeCallbackHandler {
         for (Map.Entry<String, String> entry : hostToState.entrySet()) {
           existingHosts.add(entry.getKey());
 
+          if (disabledHosts.contains(entry.getKey())) {
+            // exclude disabled hosts from the shard map config
+            continue;
+          }
+
           String state = entry.getValue();
           if (!state.equalsIgnoreCase("ONLINE") &&
               !state.equalsIgnoreCase("MASTER") &&
@@ -209,11 +214,6 @@ public class ConfigGenerator implements CustomCodeCallbackHandler {
       // no changes
       LOG.info("No changes to disabled instances");
       return false;
-    }
-
-    LOG.info("Latest disabled instances:");
-    for (String instance : latestDisabledInstances) {
-      LOG.info(instance);
     }
 
     disabledHosts = latestDisabledInstances;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -183,7 +183,7 @@ public class Participant {
     // Add callback to create rocksplicator shard config
     HelixCustomCodeRunner codeRunner = new HelixCustomCodeRunner(helixManager, zkConnectString)
         .invoke(new ConfigGenerator(clusterName, helixManager, postUrl))
-        .on(HelixConstants.ChangeType.EXTERNAL_VIEW)
+        .on(HelixConstants.ChangeType.EXTERNAL_VIEW, HelixConstants.ChangeType.CONFIG)
         .usingLeaderStandbyModel("ConfigWatcher" + clusterName);
 
     codeRunner.start();


### PR DESCRIPTION
So we can exclude hosts being restarted by disabling them first.

Manually tested it.
