### PR TITLE
[rocksdb_admin] add a semaphore to limit concurrent sst loadings

### DIFF
--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <semaphore.h>
+
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -132,6 +134,8 @@ class AdminHandler : virtual public AdminSvIf {
   std::unique_ptr<rocksdb::DB> meta_db_;
   // segments which allow for overlapping keys when adding SST files
   std::unordered_set<std::string> allow_overlapping_keys_segments_;
+  // semaphore to limit concurrent S3 SST file loadings
+  sem_t s3_sst_loading_sem_;
 };
 
 }  // namespace admin


### PR DESCRIPTION
This PR will help us use large Helix transition concurrency without causing trouble during neither service restart or batch data uploading.