### PR TITLE
[rocksdb_admin] adding two spaces to the beginning of db dumped stats

### DIFF
--- a/rocksdb_admin/application_db_manager.cpp
+++ b/rocksdb_admin/application_db_manager.cpp
@@ -116,7 +116,7 @@ std::string ApplicationDBManager::DumpDBStatsAsText() const {
       sz = 0;
     }
 
-    stats += folly::stringPrintf("total_sst_file_size db=%s: %" PRIu64 "\n",
+    stats += folly::stringPrintf("  total_sst_file_size db=%s: %" PRIu64 "\n",
                                  db->db_name().c_str(), sz);
   }
 


### PR DESCRIPTION
so that it can be correctly parsed by ostrich