### PR TITLE
[rocksdb_admin] give admin interface high priority

### DIFF
--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -247,4 +247,4 @@ SetDBOptionsResponse setDBOptions(1:SetDBOptionsRequest request)
  */
 CompactDBResponse compactDB(1:CompactDBRequest request)
   throws (1:AdminException e)
-}
+} (priority = 'HIGH')


### PR DESCRIPTION
so that admin requests won't be discarded when a server is overloaded by application requests.