### PR TITLE
[common] enable tls support for outgoing connections

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -5,7 +5,7 @@ AUX_SOURCE_DIRECTORY(./ COMMON_FILES)
 
 add_library(common ${COMMON_FILES})
 
-target_link_libraries(common jemalloc glog gflags wangle folly aws-cpp-sdk-core aws-cpp-sdk-s3 boost_system boost_filesystem thrift thriftcpp2 jsoncpp_lib_static zstd)
+target_link_libraries(common jemalloc glog gflags ssl wangle folly aws-cpp-sdk-core aws-cpp-sdk-s3 boost_system boost_filesystem thrift thriftcpp2 jsoncpp_lib_static zstd)
 
 add_subdirectory(rocksdb_glogger)
 add_subdirectory(stats)

--- a/common/tests/CMakeLists.txt
+++ b/common/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ FILE(GLOB TEST_SOURCES ./*.cpp)
 foreach(testsourcefile ${TEST_SOURCES})
   get_filename_component(testname ${testsourcefile} NAME_WE)
   add_executable(${testname} ${testsourcefile})
-  target_link_libraries(${testname} common dummy_service_thrift gtest stats thriftprotocol)
+  target_link_libraries(${testname} common dummy_service_thrift gtest ssl stats thriftprotocol)
   add_test(NAME ${testname} COMMAND ${testname})
 endforeach(testsourcefile ${TEST_SOURCES})
 

--- a/common/thrift_client_pool.cpp
+++ b/common/thrift_client_pool.cpp
@@ -38,3 +38,7 @@ DEFINE_int32(tcp_user_timeout_ms, 10000,
              "corresponding TCP connection");
 
 DEFINE_bool(channel_enable_snappy, false, "Enable snappy compression or not");
+
+DEFINE_string(tls_certfile, "", "Certificate file path location for TLS");
+
+DEFINE_string(tls_keyfile, "", "Key file path location for TLS");

--- a/common/thrift_client_pool.cpp
+++ b/common/thrift_client_pool.cpp
@@ -41,4 +41,7 @@ DEFINE_bool(channel_enable_snappy, false, "Enable snappy compression or not");
 
 DEFINE_string(tls_certfile, "", "Certificate file path location for TLS");
 
+DEFINE_string(tls_trusted_certfile, "",
+              "Trusted certificate file path location for TLS");
+
 DEFINE_string(tls_keyfile, "", "Key file path location for TLS");

--- a/common/thrift_client_pool.h
+++ b/common/thrift_client_pool.h
@@ -226,8 +226,7 @@ class ThriftClientPool {
         if (skip_tls) {
           socket = apache::thrift::async::TAsyncSocket::newSocket(evb_);
         } else {
-          std::shared_ptr<folly::SSLContext> ctx =
-              std::make_shared<folly::SSLContext>();
+          auto ctx = std::make_shared<folly::SSLContext>();
           ctx->loadCertificate(FLAGS_tls_certfile.c_str());
           if (!ctx->getErrors().empty()) {
             LOG(ERROR) << "Got errors loading certificate : "

--- a/common/thrift_client_pool.h
+++ b/common/thrift_client_pool.h
@@ -28,8 +28,10 @@
 
 #include "folly/futures/Promise.h"
 #include "folly/io/async/EventBase.h"
+#include "folly/io/async/SSLContext.h"
 #include "folly/SocketAddress.h"
 #include "thrift/lib/cpp/async/TAsyncSocket.h"
+#include "thrift/lib/cpp/async/TAsyncSSLSocket.h"
 #include "thrift/lib/cpp/transport/THeader.h"
 #include "thrift/lib/cpp2/async/HeaderClientChannel.h"
 #include "thrift/lib/cpp2/protocol/BinaryProtocol.h"
@@ -47,6 +49,10 @@ DECLARE_int32(min_channel_create_interval_seconds);
 DECLARE_int32(tcp_user_timeout_ms);
 
 DECLARE_bool(channel_enable_snappy);
+
+DECLARE_string(tls_certfile);
+
+DECLARE_string(tls_keyfile);
 
 namespace common {
 
@@ -211,7 +217,21 @@ class ThriftClientPool {
       }
 
       if (should_new_channel) {
-        auto socket = apache::thrift::async::TAsyncSocket::newSocket(evb_);
+        std::shared_ptr<apache::thrift::async::TAsyncSocket> socket;
+        if (FLAGS_tls_certfile.empty() || FLAGS_tls_keyfile.empty()) {
+          socket = apache::thrift::async::TAsyncSocket::newSocket(evb_);
+        } else {
+          std::shared_ptr<folly::SSLContext> ctx;
+          ctx->loadCertificate(FLAGS_tls_certfile.c_str());
+          if (!ctx->getErrors().empty()) {
+            LOG(ERROR) << "Got errors loading certificate : " << ctx->getErrors();
+          }
+          ctx->loadPrivateKey(FLAGS_tls_keyfile.c_str());
+          if (!ctx->getErrors().empty()) {
+            LOG(ERROR) << "Got errors loading private key : " << ctx->getErrors();
+          }
+          socket = apache::thrift::async::TAsyncSSLSocket::newSocket(ctx, evb_);
+        }
         auto cb = std::make_unique<ClientStatusCallback>(addr);
         socket->connect(cb.get(), addr, connect_timeout_ms);
 

--- a/common/thrift_client_pool.h
+++ b/common/thrift_client_pool.h
@@ -226,7 +226,8 @@ class ThriftClientPool {
         if (skip_tls) {
           socket = apache::thrift::async::TAsyncSocket::newSocket(evb_);
         } else {
-          std::shared_ptr<folly::SSLContext> ctx;
+          std::shared_ptr<folly::SSLContext> ctx =
+              std::make_shared<folly::SSLContext>();
           ctx->loadCertificate(FLAGS_tls_certfile.c_str());
           if (!ctx->getErrors().empty()) {
             LOG(ERROR) << "Got errors loading certificate : "

--- a/rocksdb_replicator/CMakeLists.txt
+++ b/rocksdb_replicator/CMakeLists.txt
@@ -6,7 +6,7 @@ list(REMOVE_ITEM SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/performance.cpp)
 
 add_library(rocksdb_replicator ${SRC_FILES})
 
-target_link_libraries(rocksdb_replicator replicator_thrift jemalloc glog gflags folly thriftcpp2 thrift rocksdb pthread stats boost_system common thriftprotocol)
+target_link_libraries(rocksdb_replicator replicator_thrift jemalloc glog gflags folly thriftcpp2 thrift rocksdb pthread ssl stats boost_system common thriftprotocol)
 
 # Build performance
 add_executable(performance ./performance.cpp)


### PR DESCRIPTION
For full context on the SSL socket we use in this dockerfile, see

https://github.com/facebook/folly/blob/b59ee6802a2454e854a52535d31598aa967e33c0/folly/io/async/SSLContext.h