### PR TITLE
[common] use identical name for threads in global cpu pool

### DIFF
--- a/common/global_cpu_executor.cpp
+++ b/common/global_cpu_executor.cpp
@@ -30,7 +30,7 @@ DEFINE_int32(global_worker_threads, sysconf(_SC_NPROCESSORS_ONLN),
 DEFINE_bool(block_on_global_cpu_pool_full, true,
             "Block on enqueuing when the global cpu pool is full.");
 
-DEFINE_string(global_cpu_thread_pool_name, "g_cpu_pool",
+DEFINE_string(global_cpu_thread_pool_name, "g-cpu-pool",
               "The name for threads in the global cpu pool");
 
 namespace {

--- a/common/identical_name_thread_factory.h
+++ b/common/identical_name_thread_factory.h
@@ -1,0 +1,45 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author bol (bol@pinterest.com)
+//
+
+#pragma once
+
+#include <string>
+#include <thread>
+
+#include "folly/ThreadName.h"
+#include "wangle/concurrent/ThreadFactory.h"
+
+namespace common {
+
+class IdenticalNameThreadFactory : public wangle::ThreadFactory {
+ public:
+  explicit IdenticalNameThreadFactory(const std::string& name)
+    : name_(name) {}
+
+  std::thread newThread(folly::Func&& func) override {
+    auto thread = std::thread(std::move(func));
+    folly::setThreadName(thread.native_handle(), name_);
+
+    return thread;
+  }
+
+ private:
+  const std::string name_;
+};
+
+}  // namespace common


### PR DESCRIPTION
It can help us generate better looking cpu profiling flame graph.