### PR TITLE
Add kafka consumer to rocksplicator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       cache:
         - ccache
       before_install:
-        - docker pull pinterestbo/rocksplicator-build:latest
+        - docker pull rajathprasad/rocksplicator-build:latest
       script:
         - cd $HOME/.ccache
         - |
@@ -42,7 +42,7 @@ matrix:
           else
             echo "Full build ..."
           fi
-        - docker run -v $HOME/.ccache:/rocksplicator/build -v $TRAVIS_BUILD_DIR:/rocksplicator pinterestbo/rocksplicator-build:latest /bin/sh -c "cd /rocksplicator/build && cmake .. && make && env CTEST_OUTPUT_ON_FAILURE=1 make test"
+        - docker run -v $HOME/.ccache:/rocksplicator/build -v $TRAVIS_BUILD_DIR:/rocksplicator rajathprasad/rocksplicator-build:latest /bin/sh -c "cd /rocksplicator/build && cmake .. && make && env CTEST_OUTPUT_ON_FAILURE=1 make test"
       before_cache:
         - cd $HOME/.ccache && find . -type f -printf "%T+\t%p\n" | sort | cut -f 2 > touch_order.txt
         - cd "${TRAVIS_BUILD_DIR}" && git rev-parse HEAD > $HOME/.ccache/previous_git_commit.txt

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd docker && docker build -t rocksplicator-build .
 
 Or pull the one we uploaded.
 ```sh
-docker pull pinterestbo/rocksplicator-build:latest
+docker pull rajathprasad/rocksplicator-build:latest
 ```
 
 ### Initialize submodules
@@ -50,7 +50,7 @@ cd rocksplicator && git submodule update --init
 Get into the docker build environment. We are assuming the rocksplicator repo is under $HOME/code/, and $HOME/docker-root is an existing directory.
 
 ```sh
-docker run -v <SOURCE-DIR>:/rocksplicator -v $HOME/docker-root:/root -ti pinterestbo/rocksplicator-build:latest bash
+docker run -v <SOURCE-DIR>:/rocksplicator -v $HOME/docker-root:/root -ti rajathprasad/rocksplicator-build:latest bash
 ```
 
 Run the following command in the docker bash to build Rocksplicator:

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -11,3 +11,5 @@ add_subdirectory(rocksdb_glogger)
 add_subdirectory(stats)
 add_subdirectory(tests)
 add_subdirectory(jsoncpp)
+add_subdirectory(kafka)
+

--- a/common/kafka/CMakeLists.txt
+++ b/common/kafka/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.1)
+
+add_subdirectory(tests)
+

--- a/common/kafka/kafka_broker_file_watcher.cpp
+++ b/common/kafka/kafka_broker_file_watcher.cpp
@@ -1,0 +1,84 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "common/kafka/kafka_broker_file_watcher.h"
+
+#include <string>
+#include <vector>
+
+#include "folly/RWSpinLock.h"
+#include "folly/String.h"
+#include "glog/logging.h"
+#include "common/file_watcher.h"
+
+namespace {
+
+// Return CSV list of broker("host:port") from the broker serverset local file
+// content. An empty string is returned if it failed to parse the content.
+std::string ParseKafkaBrokerList(const std::string& content) {
+  // A CSV list of broker("host:port").
+  std::string broker_list;
+  // some simple validation on the serverset format
+  std::vector<std::string> endpoints;
+  folly::split("\n", content, endpoints);
+  std::vector<std::string> valid_endpoints;
+  for (const auto& endpoint : endpoints) {
+    if (endpoint.empty()) {
+      continue;
+    }
+    std::vector<std::string> tokens;
+    folly::split(":", endpoint, tokens);
+    if (tokens.size() == 2) {
+      valid_endpoints.push_back(endpoint);
+    } else {
+      LOG(ERROR) << "Endpoint is not in the ip:port format: " << endpoint;
+    }
+  }
+  folly::join(",", valid_endpoints, broker_list);
+  return broker_list;
+}
+
+KafkaBrokerFileWatcher::KafkaBrokerFileWatcher(std::string local_serverset_path)
+    : local_serverset_path_(std::move(local_serverset_path)) {
+  // Add file watcher for Kafka serverset.
+  CHECK(common::FileWatcher::Instance()->AddFile(
+      local_serverset_path_, [this](std::string content) {
+        const auto new_kafka_broker_list = ParseKafkaBrokerList(content);
+        if (new_kafka_broker_list.empty()) {
+          LOG(ERROR) << "Failed to find Kafka broker serverset at "
+                     << local_serverset_path_;
+          return;
+        }
+        LOG(INFO) << "Found new kafka brokers: " << new_kafka_broker_list
+                  << " from serverset: " << local_serverset_path_
+                  << ", old serverset: " << kafka_broker_list_;
+        {
+          folly::RWSpinLock::WriteHolder write_guard(
+              kafka_broker_list_rw_lock_);
+          kafka_broker_list_ = new_kafka_broker_list;
+        }
+      })) << "Failed to add file watcher to " << local_serverset_path_;
+}
+
+KafkaBrokerFileWatcher::~KafkaBrokerFileWatcher() {
+  common::FileWatcher::Instance()->RemoveFile(local_serverset_path_);
+}
+
+const std::string& KafkaBrokerFileWatcher::GetKafkaBrokerList() const {
+  folly::RWSpinLock::ReadHolder read_guard(kafka_broker_list_rw_lock_);
+  return kafka_broker_list_;
+}
+
+}  // namespace
+

--- a/common/kafka/kafka_broker_file_watcher.h
+++ b/common/kafka/kafka_broker_file_watcher.h
@@ -1,0 +1,43 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "folly/RWSpinLock.h"
+
+
+namespace {
+
+class KafkaBrokerFileWatcher {
+ public:
+  explicit KafkaBrokerFileWatcher(std::string local_serverset_path);
+
+  ~KafkaBrokerFileWatcher();
+
+  const std::string& GetKafkaBrokerList() const;
+
+ private:
+  const std::string local_serverset_path_;
+  // TODO: We are currently not using the updateable kafka_broker_list_.
+  // The kafka consumer pool is set up only once at the beginning now. Consider
+  // re-creating kafka consumer pool if the broker changes. But we should be
+  // aware that there is a bug with librdkafka client's close() which might
+  // hang forever.
+  std::string kafka_broker_list_;
+  mutable folly::RWSpinLock kafka_broker_list_rw_lock_;
+};
+
+}  // namespace

--- a/common/kafka/kafka_consumer.cpp
+++ b/common/kafka/kafka_consumer.cpp
@@ -1,0 +1,338 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "common/kafka/kafka_consumer.h"
+
+#include <atomic>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "common/stats/stats.h"
+#include "folly/String.h"
+#include "librdkafka/rdkafka.h"
+#include "librdkafka/rdkafkacpp.h"
+#include "common/kafka/stats_enum.h"
+
+DEFINE_int32(kafka_consumer_timeout_ms, 1000,
+    "Kafka consumer timeout in ms");
+DEFINE_int32(kafka_consumer_num_retries, 0,
+    "Number of retries to try the kafka consumer");
+DEFINE_int32(kafka_consumer_time_between_retries_ms, 100,
+    "Time in ms to sleep between each retry");
+
+namespace {
+
+RdKafka::ErrorCode ExecuteKafkaOperationWithRetry(
+    std::function<RdKafka::ErrorCode()> func) {
+  auto error_code = func();
+  size_t num_retries = 0;
+  while (num_retries < FLAGS_kafka_consumer_num_retries
+  && error_code != RdKafka::ERR_NO_ERROR) {
+    error_code = func();
+    num_retries++;
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(
+            FLAGS_kafka_consumer_time_between_retries_ms));
+  }
+  return error_code;
+}
+
+bool KafkaSeekWithRetry(RdKafka::KafkaConsumer* consumer,
+                        const RdKafka::TopicPartition& topic_partition) {
+  auto error_code = ExecuteKafkaOperationWithRetry([consumer,
+                                                    &topic_partition]() {
+    return consumer->seek(topic_partition, FLAGS_kafka_consumer_timeout_ms);
+  });
+  if (error_code != RdKafka::ERR_NO_ERROR) {
+    LOG(ERROR) << "Failed to seek to offset for partition: " <<
+    topic_partition.partition()
+               << ", offset: " << topic_partition.offset()
+               << ", error_code: " << RdKafka::err2str(error_code)
+               << ", num retries: " << FLAGS_kafka_consumer_num_retries;
+    return false;
+  }
+  return true;
+}
+
+std::shared_ptr<RdKafka::KafkaConsumer> CreateRdKafkaConsumer(
+    const std::unordered_set<uint32_t>& partition_ids,
+    const std::string& broker_list,
+    const std::string& group_id,
+    const std::string kafka_consumer_type) {
+  std::string err;
+  auto conf = std::shared_ptr<RdKafka::Conf>(RdKafka::Conf::create(
+      RdKafka::Conf::CONF_GLOBAL));
+  // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+  if (conf->set("metadata.broker.list", broker_list, err) !=
+  RdKafka::Conf::CONF_OK) {
+    LOG(ERROR) << "Failed to create kafka config for partitions: "
+               << folly::join(",", partition_ids) << ", error: " << err;
+    common::Stats::get()->Incr(getFullCounterName(
+        kKafkaConsumerErrorInit, {"kafka_consumer_type=" + kafka_consumer_type}));
+    return nullptr;
+  }
+  // set api.version.request to true so that Kafka timestamp can be used.
+  conf->set("api.version.request", "true", err);
+  conf->set("enable.auto.offset.store", "false", err);
+  conf->set("group.id", group_id, err);
+  return std::shared_ptr<RdKafka::KafkaConsumer>(
+      RdKafka::KafkaConsumer::create(conf.get(), err));
+}
+
+}  // namespace
+
+namespace kafka {
+
+KafkaConsumer::KafkaConsumer(const std::unordered_set<uint32_t>& partition_ids,
+                             const std::string& broker_list,
+                             const std::unordered_set<std::string>& topic_names,
+                             const std::string& group_id,
+                             const std::string& kafka_consumer_type)
+    : KafkaConsumer(
+          CreateRdKafkaConsumer(partition_ids, broker_list,
+              group_id, kafka_consumer_type),
+          partition_ids,
+          topic_names,
+          kafka_consumer_type) {}
+
+KafkaConsumer::KafkaConsumer(std::shared_ptr<RdKafka::KafkaConsumer> consumer,
+                             const std::unordered_set<uint32_t>& partition_ids,
+                             const std::unordered_set<std::string>& topic_names,
+                             const std::string& kafka_consumer_type)
+    : consumer_(std::move(consumer)),
+      partition_ids_str_(folly::join(",", partition_ids)),
+      topic_names_(topic_names),
+      partition_ids_(partition_ids),
+      kafka_consumer_type_metric_tag_("kafka_consumer_type=" +
+      kafka_consumer_type),
+      is_healthy_(false) {
+  if (consumer_ == nullptr) {
+    return;
+  }
+
+  // TODO: Change to unique_ptr
+  std::vector<std::shared_ptr<RdKafka::TopicPartition>> topic_partitions;
+  // A temporary RdKafka::TopicPartition* vector specifically used
+  // for KafkaConsumer->assign(). The pointers inside this vector is
+  // owned by `topic_partitions`.
+  std::vector<RdKafka::TopicPartition*> tmp_topic_partitions;
+  topic_partitions.reserve(partition_ids_.size() * topic_names_.size());
+  tmp_topic_partitions.reserve(partition_ids_.size() * topic_names_.size());
+  for (const auto partition_id : partition_ids_) {
+    for (const auto& topic_name : topic_names_) {
+      topic_partitions.push_back(
+          std::shared_ptr<RdKafka::TopicPartition>(
+              RdKafka::TopicPartition::create(
+              topic_name,
+              partition_id,
+              // Use the end of the offset to init here, but it does not matter.
+              // When kafkaconsumer is used, the caller is supposed to call
+              // seek() to the expected offset before consuming messages.
+              RdKafka::Topic::OFFSET_END)));
+      tmp_topic_partitions.push_back(topic_partitions.back().get());
+      topic_names_string_.append(topic_name);
+      topic_names_string_.append(", ");
+    }
+  }
+  const auto error_code = ExecuteKafkaOperationWithRetry(
+      [this, &tmp_topic_partitions]() {
+        return consumer_->assign(tmp_topic_partitions); });
+  if (error_code != RdKafka::ERR_NO_ERROR) {
+    LOG(ERROR) << "Failed to assign partitions: " << partition_ids_str_
+               << ", error_code: " << RdKafka::err2str(error_code)
+               << ", num retries: " << FLAGS_kafka_consumer_num_retries;
+    common::Stats::get()->Incr(getFullCounterName(
+        kKafkaConsumerErrorAssign,
+        {kafka_consumer_type_metric_tag_,
+         "error_code=" + std::to_string(error_code)}));
+    return;
+  }
+  LOG(INFO) << "Successfully created kafka consumer for partitions: "
+            << partition_ids_str_ << ", topics: "
+            << folly::join(",", topic_names_);
+  is_healthy_.store(true);
+}
+
+bool KafkaConsumer::IsHealthy() const { return is_healthy_.load(); }
+
+bool KafkaConsumer::Seek(const int64_t timestamp_ms) {
+  if (SeekInternal(topic_names_, timestamp_ms)) {
+    return true;
+  } else {
+    common::Stats::get()->Incr(
+        getFullCounterName(kKafkaConsumerErrorSeek,
+            {kafka_consumer_type_metric_tag_}));
+    return false;
+  }
+}
+
+bool KafkaConsumer::Seek(const std::string& topic_name,
+    const int64_t timestamp_ms) {
+  bool is_success = false;
+  if (topic_names_.find(topic_name) != topic_names_.end()) {
+    const std::unordered_set<std::string> tmp_topic_names{topic_name};
+    is_success = SeekInternal(tmp_topic_names, timestamp_ms);
+  } else {
+    LOG(ERROR) << "Kakfa consumer is unaware of topic_name: " << topic_name;
+  }
+
+  if (!is_success) {
+    common::Stats::get()->Incr(getFullCounterName(
+        kKafkaConsumerErrorSeek, {kafka_consumer_type_metric_tag_,
+                                  "topic=" + topic_name}));
+  }
+  return is_success;
+}
+
+bool KafkaConsumer::Seek(const std::map<std::string, std::map<int32_t,
+    int64_t>>& last_offsets) {
+  if (SeekInternal(last_offsets)) {
+    return true;
+  }
+
+  common::Stats::get()->Incr(
+      getFullCounterName(kKafkaConsumerErrorSeek,
+          {kafka_consumer_type_metric_tag_}));
+  return false;
+}
+
+bool KafkaConsumer::SeekInternal(
+    const std::map<std::string, std::map<int32_t, int64_t>>& last_offsets) {
+  if (consumer_ == nullptr) {
+    return false;
+  }
+  for (const auto& topic_partitions_pair : last_offsets) {
+    for (const auto& partition_offset_pair : topic_partitions_pair.second) {
+      // Seek to offset + 1 for each topic and partition.
+      std::unique_ptr<RdKafka::TopicPartition> topic_partition(
+          RdKafka::TopicPartition::create(
+          topic_partitions_pair.first,
+          partition_offset_pair.first,
+          // TODO: it is possible that offset+1 reach a invalid offset position
+          partition_offset_pair.second + 1));
+
+      LOG(INFO) << "Seeking topic: " << topic_partition->topic()
+                << ", partition: " << topic_partition->partition()
+                << ", offset: " << topic_partition->offset();
+      if (!KafkaSeekWithRetry(consumer_.get(), *topic_partition)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool KafkaConsumer::SeekInternal(
+    const std::unordered_set<std::string>& topic_names,
+    const int64_t timestamp_ms) {
+  if (consumer_ == nullptr) {
+    return false;
+  }
+  std::vector<std::shared_ptr<RdKafka::TopicPartition>> topic_partitions;
+  // A temporary RdKafka::TopicPartition* vector specifically used for
+  // KafkaConsumer->offsetsForTimes().
+  // The pointers inside this vector is owned by `topic_partitions`.
+  std::vector<RdKafka::TopicPartition*> tmp_topic_partitions;
+  topic_partitions.reserve(topic_names.size());
+  tmp_topic_partitions.reserve(topic_names.size());
+  for (const auto partition_id : partition_ids_) {
+    for (const auto& topic_name : topic_names) {
+      topic_partitions.push_back(
+          std::shared_ptr<RdKafka::TopicPartition>(
+              RdKafka::TopicPartition::create(
+              topic_name,
+              partition_id,
+              timestamp_ms)));
+      tmp_topic_partitions.push_back(topic_partitions.back().get());
+    }
+  }
+  // Find the offset starting from the given timestamp.
+
+  auto error_code = ExecuteKafkaOperationWithRetry(
+      [this, &tmp_topic_partitions]() {
+    return consumer_->offsetsForTimes(tmp_topic_partitions,
+        FLAGS_kafka_consumer_timeout_ms);
+  });
+  if (error_code != RdKafka::ERR_NO_ERROR) {
+    LOG(ERROR) << "Failed to get offset from partitions: " << partition_ids_str_
+               << ", timestamp_ms: " << timestamp_ms
+               << ", error_code: " << RdKafka::err2str(error_code)
+               << ", num retries: " << FLAGS_kafka_consumer_num_retries;
+    return false;
+  }
+
+  // For each topic, seek to the above offset.
+  for (const auto* topic_partition : tmp_topic_partitions) {
+    LOG(INFO) << "Seeking partition: " << topic_partition->partition()
+              << ", offset: " << topic_partition->offset();
+
+    common::Stats::get()->Incr(
+        getFullCounterName(kKafkaConsumerSeek,
+                           {kafka_consumer_type_metric_tag_,
+                            "topic=" + topic_partition->topic(),
+                            "partition=" +
+                            std::to_string(topic_partition->partition())}));
+    if (!KafkaSeekWithRetry(consumer_.get(), *topic_partition)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+RdKafka::Message* KafkaConsumer::Consume(int32_t timeout_ms) const {
+  if (consumer_ == nullptr) {
+    return nullptr;
+  }
+
+  auto* message = consumer_->consume(timeout_ms);
+
+  if (message == nullptr) {
+    common::Stats::get()->Incr(
+        getFullCounterName(kKafkaConsumerMessageNull,
+            {kafka_consumer_type_metric_tag_}));
+    return nullptr;
+  }
+
+  const auto error_code = message->err();
+  if (error_code != RdKafka::ERR_NO_ERROR && error_code !=
+      RdKafka::ERR__PARTITION_EOF && error_code != RdKafka::ERR__TIMED_OUT) {
+    LOG(ERROR) << "Failed to consume from kafka, error_code: "
+               << RdKafka::err2str(error_code)
+               << ", partition ids: " << partition_ids_str_;
+    common::Stats::get()->Incr(getFullCounterName(
+        kKafkaConsumerErrorConsume,
+        {kafka_consumer_type_metric_tag_,
+         "error_code=" + std::to_string(error_code)}));
+  }
+
+  return message;
+}
+
+const std::unordered_set<std::string>& KafkaConsumer::GetTopicNames() const {
+  return topic_names_;
+}
+
+const std::unordered_set<uint32_t>& KafkaConsumer::GetPartitionIds() const {
+  return partition_ids_;
+}
+
+const std::string& KafkaConsumer::GetTopicsString() const {
+  return topic_names_string_;
+}
+
+}  // namespace kafka

--- a/common/kafka/kafka_consumer.h
+++ b/common/kafka/kafka_consumer.h
@@ -1,0 +1,107 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_set>
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+#include "librdkafka/rdkafkacpp.h"
+
+namespace kafka {
+
+class KafkaConsumer {
+public:
+  KafkaConsumer(const std::unordered_set<uint32_t>& partition_ids,
+                const std::string& broker_list,
+                const std::unordered_set<std::string>& topic_names,
+                const std::string& group_id,
+                const std::string& kafka_consumer_type);
+
+  KafkaConsumer(std::shared_ptr<RdKafka::KafkaConsumer> consumer,
+                const std::unordered_set<uint32_t>& partition_ids,
+                const std::unordered_set<std::string>& topic_names,
+                const std::string& kafka_consumer_type);
+
+  // no copy nor move
+  KafkaConsumer(const KafkaConsumer&) = delete;
+
+  KafkaConsumer(KafkaConsumer&&) = delete;
+
+  // Returns false if this kafka consumer is not initialized correctly.
+  // In this case, this Kafka consumer is not useable. Seek() always returns
+  // false and Consume() always return nullptr.
+  virtual bool IsHealthy() const;
+
+  // Seek to the Kafka message whose offset is the earliest one greater than or
+  // equal to the given timestamp. After calling this, messages returned by
+  // Consume() will be starting from this new offset.
+  bool Seek(const int64_t timestamp_ms);
+
+  bool Seek(const std::string& topic_name, const int64_t timestamp_ms);
+
+  // Seek to offsets specified in the KafkaTopicPartitionOffsets map.
+  bool Seek(const std::map<std::string, std::map<int32_t,
+      int64_t>>& last_offsets);
+
+  // It returns nullptr if IsHealthy() returns false.
+  virtual RdKafka::Message* Consume(int32_t timeout_ms) const;
+
+  // Gets Kafka topic names this consumer is assigned to.
+  const std::unordered_set<std::string>& GetTopicNames() const;
+
+  // Get Kafka partition ids this consumer is assigned to.
+  const std::unordered_set<uint32_t>& GetPartitionIds() const;
+
+  // Return set of topics as a string for logging
+  const std::string& GetTopicsString() const;
+
+  virtual ~KafkaConsumer() {
+    if (consumer_) {
+      consumer_->close();
+    }
+  }
+
+  const std::string partition_ids_str_;
+
+private:
+  // For mock ONLY
+  explicit KafkaConsumer(const std::unordered_set<std::string>& topic_names)
+      : partition_ids_str_("0"),
+        topic_names_(topic_names),
+        partition_ids_({0}),
+        kafka_consumer_type_metric_tag_("") {}
+
+  virtual bool SeekInternal(const std::unordered_set<std::string>& topic_names,
+                            const int64_t timestamp_ms);
+
+  virtual bool SeekInternal(const std::map<std::string, std::map<int32_t,
+      int64_t>>& last_offsets);
+
+  std::unordered_set<std::string> topic_names_;
+  std::string topic_names_string_;
+  const std::unordered_set<uint32_t> partition_ids_;
+  std::shared_ptr<RdKafka::KafkaConsumer> consumer_;
+  // Tag used when logging metrics, so we can differentiate between kafka
+  // consumers for different use cases.
+  const std::string kafka_consumer_type_metric_tag_;
+  std::atomic<bool> is_healthy_;
+};
+
+}  // namespace kafka

--- a/common/kafka/kafka_consumer_pool.cpp
+++ b/common/kafka/kafka_consumer_pool.cpp
@@ -1,0 +1,89 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "common/kafka/kafka_consumer_pool.h"
+
+#include <string>
+#include <unordered_set>
+
+#include "common/stats/stats.h"
+#include "folly/MPMCQueue.h"
+#include "librdkafka/rdkafkacpp.h"
+#include "librdkafka/rdkafka.h"
+#include "common/kafka/stats_enum.h"
+#include "common/kafka/kafka_consumer.h"
+
+namespace {
+
+static const std::string kKafkaConsumerPoolGetQueueSize =
+    "kafka_consumer_pool_get_queue_size";
+static const std::string kKafkaConsumerPoolPutQueueSize =
+    "kafka_consumer_pool_put_queue_size";
+
+}  // namespace
+
+namespace kafka {
+
+KafkaConsumerPool::KafkaConsumerPool(
+    uint32_t queue_size,
+    const std::unordered_set<uint32_t>& partition_ids,
+    const std::string& broker_list,
+    const std::unordered_set<std::string>& topic_names,
+    const std::string& group_id,
+    const std::string& kafka_consumer_type)
+    : queue_(std::make_unique<KafkaConsumerQueue>(queue_size)),
+      kafka_consumer_type_metric_tag_("kafka_consumer_type="
+        + kafka_consumer_type),
+      partition_ids_(partition_ids),
+      broker_list_(broker_list),
+      topic_names_(topic_names),
+      group_id_(group_id),
+      kafka_consumer_type_(kafka_consumer_type) {
+  for (uint32_t i = 0; i < queue_size; ++i) {
+    queue_->write(std::make_shared<KafkaConsumer>(
+        partition_ids,
+        broker_list,
+        topic_names,
+        group_id,
+        kafka_consumer_type));
+  }
+}
+
+std::shared_ptr<KafkaConsumer> KafkaConsumerPool::Get() {
+  common::Stats::get()->AddMetric(getFullMetricName(
+      kKafkaConsumerPoolGetQueueSize, {kafka_consumer_type_metric_tag_}),
+          queue_->size());
+
+  // Try to get consumer from queue, otherwise return new one.
+  std::shared_ptr<KafkaConsumer> consumer;
+  if (queue_->read(consumer)) {
+    return consumer;
+  }
+  return std::make_shared<KafkaConsumer>(
+      partition_ids_,
+      broker_list_,
+      topic_names_,
+      group_id_,
+      kafka_consumer_type_);
+}
+
+void KafkaConsumerPool::Put(std::shared_ptr<KafkaConsumer> consumer) {
+  common::Stats::get()->AddMetric(getFullMetricName(
+      kKafkaConsumerPoolPutQueueSize, {kafka_consumer_type_metric_tag_}),
+          queue_->size());
+
+  queue_->write(std::move(consumer));
+}
+
+}  // namespace kafka

--- a/common/kafka/kafka_consumer_pool.h
+++ b/common/kafka/kafka_consumer_pool.h
@@ -1,0 +1,80 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_set>
+
+#include "folly/MPMCQueue.h"
+
+namespace kafka {
+
+class KafkaConsumer;
+
+typedef folly::MPMCQueue<std::shared_ptr<KafkaConsumer>> KafkaConsumerQueue;
+
+/**
+ * A thread safe kafka consumer pool for one particular kafka partition. The
+ * pool will be initialized with the fixed queue_size at the construction time.
+ * Then caller can call Get() and Put() to use and return the consumer.
+ * All Get() and Put() are blocking.
+ */
+class KafkaConsumerPool {
+ public:
+  explicit KafkaConsumerPool(
+      uint32_t queue_size,
+      const std::unordered_set<uint32_t>& partition_ids,
+      const std::string& broker_list,
+      const std::unordered_set<std::string>& topic_names,
+      const std::string& group_id,
+      const std::string& kafka_consumer_type);
+
+  // Creates an empty consumer pool, caller needs to add the consumers in order
+  // to use the pool. Note that the pool does not differentiate between
+  // different consumers
+  explicit KafkaConsumerPool(uint32_t queue_size)
+      : queue_(std::make_unique<KafkaConsumerQueue>(queue_size)) {}
+
+
+  KafkaConsumerPool(const KafkaConsumerPool&) = delete;
+
+  KafkaConsumerPool(KafkaConsumerPool&&) = delete;
+
+  ~KafkaConsumerPool() = default;
+
+  virtual std::shared_ptr<KafkaConsumer> Get();
+
+  virtual void Put(std::shared_ptr<KafkaConsumer> consumer);
+
+ protected:
+  // For tests only
+  KafkaConsumerPool() {}
+
+ private:
+  std::unique_ptr<KafkaConsumerQueue> queue_;
+  // Tag used when logging metrics, so we can differentiate between kafka
+  // consumers for different use cases
+  const std::string kafka_consumer_type_metric_tag_;
+
+  // TODO: put those into a struct.
+  const std::unordered_set<uint32_t> partition_ids_;
+  const std::string broker_list_;
+  const std::unordered_set<std::string> topic_names_;
+  const std::string group_id_;
+  const std::string kafka_consumer_type_;
+};
+
+}  // namespace kafka

--- a/common/kafka/kafka_watcher.cpp
+++ b/common/kafka/kafka_watcher.cpp
@@ -1,0 +1,445 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "common/kafka/kafka_watcher.h"
+
+#include <algorithm>
+#include <atomic>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "boost/functional/hash.hpp"
+#include "common/stats/stats.h"
+#include "common/timeutil/timeutil.h"
+#include "folly/String.h"
+#include "glog/logging.h"
+#include "librdkafka/rdkafkacpp.h"
+#include "common/kafka/stats_enum.h"
+#include "common/kafka/kafka_consumer.h"
+#include "common/kafka/kafka_consumer_pool.h"
+
+namespace {
+
+typedef std::unordered_set<std::pair<std::string, int32_t>,
+                           boost::hash<std::pair<std::string, int32_t>>>
+    TopicPartitionSet;
+template <typename V>
+using TopicPartitionToValueMap = std::
+    unordered_map<std::pair<std::string, int32_t>, V,
+    boost::hash<std::pair<std::string, int32_t>>>;
+
+std::string TopicPartitionSetToString(
+    const TopicPartitionSet& topic_partition_set) {
+  std::string s;
+  for (const auto& pair : topic_partition_set) {
+    s.append("(").append(pair.first).append(",").
+      append(std::to_string(pair.second)).append(") ");
+  }
+  return s;
+}
+
+void VerifyAndUpdateTopicPartitionOffset(
+    TopicPartitionToValueMap<int64_t>* topic_partition_to_prev_offset_map,
+    const std::string& topic_name,
+    const int32_t partition_id,
+    const int64_t offset,
+    const std::string& watcher_name) {
+  CHECK_NOTNULL(topic_partition_to_prev_offset_map);
+
+  const auto topic_partition_pair = std::make_pair(topic_name, partition_id);
+  auto it = topic_partition_to_prev_offset_map->find(topic_partition_pair);
+  if (it == topic_partition_to_prev_offset_map->end()) {
+    CHECK(topic_partition_to_prev_offset_map->emplace(topic_partition_pair,
+        offset).second);
+  } else {
+    const auto prev_offset = it->second;
+    if (prev_offset + 1 != offset) {
+      common::Stats::get()->Incr(getFullCounterName(kKafkaWatcherMessageMissing,
+          {topic_name}));
+    }
+    it->second = offset;
+  }
+}
+
+inline int64_t GetMessageTimestamp(const RdKafka::Message& message) {
+  const auto ts = message.timestamp();
+  if (ts.type == RdKafka::MessageTimestamp::MSG_TIMESTAMP_CREATE_TIME) {
+    return ts.timestamp;
+  }
+
+  // We only expect the timestamp to be create time.
+  return -1;
+}
+
+}  // namespace
+
+KafkaWatcher::KafkaWatcher(const std::string& name,
+                           std::shared_ptr<kafka::KafkaConsumerPool>
+                               kafka_consumer_pool,
+                           int kafka_init_blocking_consume_timeout_ms,
+                           int kafka_consumer_timeout_ms,
+                           int loop_cycle_limit_ms)
+    : KafkaWatcher(
+          name,
+          std::vector<std::shared_ptr<kafka::KafkaConsumerPool>>{
+            std::move(kafka_consumer_pool)},
+          kafka_init_blocking_consume_timeout_ms,
+          kafka_consumer_timeout_ms,
+          loop_cycle_limit_ms) {}
+
+KafkaWatcher::KafkaWatcher(
+    const std::string& name,
+    const std::vector<std::shared_ptr<kafka::KafkaConsumerPool>>&
+      kafka_consumer_pools,
+    int kafka_init_blocking_consume_timeout_ms,
+    int kafka_consumer_timeout_ms,
+    int loop_cycle_limit_ms)
+    : kafka_watcher_metric_tag_("kafka_watcher_name=" + name),
+      name_(name),
+      is_stopped_(false),
+      kafka_consumer_pools_(kafka_consumer_pools),
+      kafka_init_blocking_consume_timeout_ms_(
+          kafka_init_blocking_consume_timeout_ms),
+      kafka_consumer_timeout_ms_(kafka_consumer_timeout_ms),
+      loop_cycle_limit_ms_(loop_cycle_limit_ms) {
+  // Instantiate consumers from pools
+  for (auto pool = kafka_consumer_pools_.begin(); pool !=
+       kafka_consumer_pools_.end(); pool++) {
+    CHECK(*pool != nullptr);
+    const auto& kafka_consumer = (*pool)->Get();
+    kafka_consumers_.push_back(kafka_consumer);
+  }
+}
+
+KafkaWatcher::~KafkaWatcher() {
+  for (int i = 0; i < kafka_consumer_pools_.size(); i++) {
+    const auto& pool = kafka_consumer_pools_[i];
+    const auto& consumer = kafka_consumers_[i];
+    pool->Put(consumer);
+  }
+}
+
+bool KafkaWatcher::InitKafkaConsumerSeek(
+    kafka::KafkaConsumer* const kafka_consumer,
+    int64_t initial_kafka_seek_timestamp_ms) {
+  if (initial_kafka_seek_timestamp_ms == -1) {
+    LOG(INFO) << name_ << ": Initial kafka seek timestamp ms not specified,"
+                          " skipping initial seek";
+    return true;
+  }
+
+  CHECK_NOTNULL(kafka_consumer);
+  for (const auto& topic_name : kafka_consumer->GetTopicNames()) {
+    LOG(INFO) << name_ << ": Seeking kafka consumer";
+    if (!kafka_consumer->Seek(topic_name, initial_kafka_seek_timestamp_ms)) {
+      LOG(ERROR) << name_ << ": Kafka seek failed; Will not watch and ingest"
+                             " new documents";
+      return false;
+    }
+
+    LOG(INFO) << name_ << ": Successfully seeked kafka topic_name: "
+              << topic_name << " to timestamp_ms: "
+              << initial_kafka_seek_timestamp_ms;
+  }
+  return true;
+}
+
+uint32_t KafkaWatcher::ConsumeUpToNow(const kafka::KafkaConsumer& consumer) {
+  // timestamps dealt with in this function are all ms.
+  uint32_t num_msg_consumed = 0;
+  const auto& topic_names = consumer.GetTopicNames();
+  const auto& partition_ids = consumer.GetPartitionIds();
+  // amt of topic names in which we have consumed "enough" messages.
+  const auto num_topic_partitions = topic_names.size() * partition_ids.size();
+  TopicPartitionSet finished_topic_partitions;
+  finished_topic_partitions.reserve(num_topic_partitions);
+  TopicPartitionToValueMap<int64_t> topic_partition_to_prev_offset;
+  topic_partition_to_prev_offset.reserve(topic_names.size());
+  TopicPartitionToValueMap<uint32_t> topic_partition_to_message_num;
+  topic_partition_to_message_num.reserve(topic_names.size());
+  auto timeout_timestamp_ms = timeutil::GetCurrentTimestamp(
+      timeutil::TimeUnit::kMillisecond) +
+      kafka_init_blocking_consume_timeout_ms_;
+
+  // End the loop when finding fresher message or hitting partition end for
+  // all the topics, or it takes longer than the allowed time limit.
+  while (!is_stopped_.load() && finished_topic_partitions.size() !=
+         num_topic_partitions) {
+    const auto message =
+        std::shared_ptr<const RdKafka::Message>(
+            consumer.Consume(kafka_consumer_timeout_ms_));
+    if (message == nullptr) {
+      // This should only happen if kafka consumer is unhealthy.
+      break;
+    }
+    if (message->err() == RdKafka::ERR_NO_ERROR) {
+      const auto msg_timestamp_ms = GetMessageTimestamp(*message);
+      const auto time_now_ms = timeutil::GetCurrentTimestamp(
+          timeutil::kMillisecond);
+      common::Stats::get()->AddMetric(
+          getFullMetricName(kKafkaMsgTimeDiffFromCurrMs,
+              {kafka_watcher_metric_tag_}),
+          time_now_ms - msg_timestamp_ms);
+      common::Stats::get()->AddMetric(
+          getFullMetricName(kKafkaMsgNumBytes, {kafka_watcher_metric_tag_}),
+          message->len());
+      const auto topic_partition_pair = std::make_pair(message->topic_name(),
+          message->partition());
+      HandleKafkaNoErrorMessage(message, true /* replay */);
+      auto it = topic_partition_to_message_num.find(topic_partition_pair);
+      if (it == topic_partition_to_message_num.end()) {
+        CHECK(topic_partition_to_message_num.emplace(topic_partition_pair,
+            1).second);
+      } else {
+        it->second++;
+      }
+
+      // Check if messages are missing between current and previous offset
+      VerifyAndUpdateTopicPartitionOffset(&topic_partition_to_prev_offset,
+                                          message->topic_name(),
+                                          message->partition(),
+                                          message->offset(),
+                                          name_);
+    } else if (message->err() == RdKafka::ERR__PARTITION_EOF) {
+      // Reached the end of the topic+partition queue on the broker.
+      finished_topic_partitions.emplace(message->topic_name(),
+          message->partition());
+    } else if (message->err() == RdKafka::ERR__TIMED_OUT) {
+      // This could happen even before getting ERR__PARTITION_EOF message. It
+      // happens when consumer hasn't got any message from the broker within the
+      // timeout. We should retry in this case.
+    } else {
+      // Abort the initialization when receiving an unexpected error
+      // TODO: We probably need to re-establish Kafka connection here..
+      break;
+    }
+    ++num_msg_consumed;
+    if (num_msg_consumed % 100 == 0) {
+      if (kafka_init_blocking_consume_timeout_ms_ != -1 &&
+          timeutil::GetCurrentTimestamp(timeutil::TimeUnit::kMillisecond) >
+          timeout_timestamp_ms) {
+        common::Stats::get()->Incr(
+            getFullCounterName(kKafkaWatcherBlockingConsumeTimeout,
+                {kafka_watcher_metric_tag_}));
+        LOG(ERROR) << name_
+                   << ": Could not reach the end of partitions: "
+                   << consumer.partition_ids_str_
+                   << " for all topics: " << folly::join(", ", topic_names)
+                   << ". Finished topics partitions: "
+                   << TopicPartitionSetToString(finished_topic_partitions)
+                   << ". Current timeout is: "
+                   << kafka_init_blocking_consume_timeout_ms_ << " ms";
+        break;
+      }
+    }
+  }
+
+  std::string s;
+  for (const auto& pair : topic_partition_to_message_num) {
+    const auto& topic_name = pair.first.first;
+    const auto partition_id = pair.first.second;
+    s += "(" + topic_name + "," + std::to_string(partition_id) +
+         "):" + std::to_string(pair.second) + " ";
+  }
+  LOG(INFO) << name_ << ": Messages consumed per topic partition: " << s;
+  return num_msg_consumed;
+}
+
+void KafkaWatcher::StartWith(int64_t initial_kafka_seek_timestamp_ms,
+    KafkaMessageHandler handler) {
+  CHECK(handler != nullptr);
+  handler_ = handler;
+  Start(initial_kafka_seek_timestamp_ms);
+}
+
+void KafkaWatcher::StartWith(const std::map<std::string, std::map<int32_t,
+                             int64_t>>& last_offsets,
+                             KafkaMessageHandler handler) {
+  CHECK(handler != nullptr);
+  handler_ = handler;
+  Start(last_offsets);
+}
+
+// TODO: merge following two Start functions.
+void KafkaWatcher::Start(const std::map<std::string, std::map<int32_t,
+    int64_t>>& last_offsets) {
+  const auto start_timestamp_ms = timeutil::GetCurrentTimestamp(
+      timeutil::TimeUnit::kMillisecond);
+  if (!Init()) {
+    return;
+  }
+  for (const auto& kafka_consumer : kafka_consumers_) {
+    const auto& topic_names = kafka_consumer->GetTopicsString();
+    if (kafka_consumer != nullptr && kafka_consumer->IsHealthy()) {
+      if (!kafka_consumer->Seek(last_offsets)) {
+        LOG(ERROR) << name_ << ": Kafka seek failed with consumer for topics:"
+                   << topic_names << "Will not watch and ingest new documents";
+        return;
+      }
+
+      if (kafka_init_blocking_consume_timeout_ms_ != 0) {
+        // Synchronously consume the messages up to the current
+        // timestamp from Kafka.
+        const auto num = ConsumeUpToNow(*kafka_consumer);
+        LOG(INFO) << name_ << ": Finished consuming " << num
+                  << " messages from Kafka consumer"
+                  << "for topics:" << topic_names;
+      }
+    } else {
+      LOG(INFO) << name_
+                << ": Skipped consuming from kafka consumer for topics:"
+                << topic_names << "because kafka consumer is not healthy";
+    }
+  }
+  const auto duration_ms =
+      timeutil::GetCurrentTimestamp(timeutil::TimeUnit::kMillisecond)
+      - start_timestamp_ms;
+  common::Stats::get()->AddMetric(
+      getFullMetricName(kKafkaWatcherInitMs, {kafka_watcher_metric_tag_}),
+      duration_ms);
+  LOG(INFO) << name_ << ": Finished init watcher in: "
+            << duration_ms << "ms. Starting watch loop";
+  // We always spawn the watcher thread even though the kafka consumer is
+  // unhealthy, because derived class could potentially watch data from
+  // other sources, e.g. S3
+  thread_ = std::thread(&KafkaWatcher::StartWatchLoop, this);
+}
+
+void KafkaWatcher::Start(int64_t initial_kafka_seek_timestamp_ms) {
+  const auto start_timestamp_ms = timeutil::GetCurrentTimestamp(
+      timeutil::TimeUnit::kMillisecond);
+  if (!Init()) {
+    return;
+  }
+  for (const auto& kafka_consumer : kafka_consumers_) {
+    const auto& topic_names = kafka_consumer->GetTopicsString();
+    if (kafka_consumer != nullptr && kafka_consumer->IsHealthy()) {
+      if (!InitKafkaConsumerSeek(kafka_consumer.get(),
+          initial_kafka_seek_timestamp_ms)) {
+        return;
+      }
+
+      if (kafka_init_blocking_consume_timeout_ms_ != 0) {
+        // Synchronously consume the messages up to the current timestamp
+        // from Kafka.
+        const auto num = ConsumeUpToNow(*kafka_consumer);
+        LOG(INFO) << name_ << ": Finished consuming " << num
+                  << " messages from Kafka consumer"
+                  << "for topics:" << topic_names;
+      }
+    } else {
+      LOG(INFO) << name_
+                << ": Skipped consuming from kafka consumer for topics:"
+                << topic_names
+                << "because kafka consumer is not healthy";
+    }
+  }
+  const auto duration_ms =
+      timeutil::GetCurrentTimestamp(timeutil::TimeUnit::kMillisecond)
+      - start_timestamp_ms;
+  common::Stats::get()->AddMetric(
+      getFullMetricName(kKafkaWatcherInitMs, {kafka_watcher_metric_tag_}),
+      duration_ms);
+  LOG(INFO) << name_ << ": Finished init watcher in: "
+            << duration_ms << "ms. Starting watch loop";
+  // We always spawn the watcher thread even though the kafka consumer is
+  // unhealthy, because derived class could potentially watch data from other
+  // sources, e.g. S3
+  thread_ = std::thread(&KafkaWatcher::StartWatchLoop, this);
+}
+
+void KafkaWatcher::StartWatchLoop() {
+  uint64_t cycle_end_timestamp_ms;
+
+  // ensure all consunmers get
+  while (!is_stopped_.load()) {
+    cycle_end_timestamp_ms =
+        timeutil::GetCurrentTimestamp(timeutil::TimeUnit::kMillisecond)
+        + loop_cycle_limit_ms_;
+    // 1) Pre-processing before kafka operations
+    WatchLoopIterationStart();
+
+    // 2) For each consumer, adjust seek if needed
+    for (const auto& kafka_consumer : kafka_consumers_) {
+      MaybeAdjustKafkaConsumerSeek(kafka_consumer.get());
+    }
+    while (!is_stopped_.load() && timeutil::GetCurrentTimestamp(
+        timeutil::TimeUnit::kMillisecond) <=
+        cycle_end_timestamp_ms) {
+      // Round robin message consumption for each consumer
+      for (const auto& kafka_consumer : kafka_consumers_) {
+        // 3) Consume and apply the kafka updates
+        // kafka consumption uses whatever time budget is left for this cycle.
+        if (kafka_consumer != nullptr && kafka_consumer->IsHealthy()) {
+          const auto& topic_names = kafka_consumer->GetTopicNames();
+          TopicPartitionToValueMap<int64_t> topic_partition_to_prev_offset;
+          topic_partition_to_prev_offset.reserve(topic_names.size());
+          const auto message = std::shared_ptr<const RdKafka::Message>(
+              kafka_consumer->Consume(kafka_consumer_timeout_ms_));
+          if (message == nullptr) {
+            continue;
+          }
+          if (message->err() == RdKafka::ERR_NO_ERROR) {
+            const auto msg_timestamp_ms = GetMessageTimestamp(*message);
+            const auto time_now_ms = timeutil::GetCurrentTimestamp(
+                timeutil::kMillisecond);
+            common::Stats::get()->AddMetric(
+                getFullMetricName(kKafkaMsgTimeDiffFromCurrMs,
+                    {kafka_watcher_metric_tag_}),
+                time_now_ms - msg_timestamp_ms);
+            common::Stats::get()->AddMetric(
+                getFullMetricName(kKafkaMsgNumBytes,
+                    {kafka_watcher_metric_tag_}), message->len());
+            HandleKafkaNoErrorMessage(message, false /* not replay */);
+            // Check if messages are missing between current and previous offset
+            VerifyAndUpdateTopicPartitionOffset(&topic_partition_to_prev_offset,
+                                                message->topic_name(),
+                                                message->partition(),
+                                                message->offset(),
+                                                name_);
+          } else if (message->err() == RdKafka::ERR__TIMED_OUT ||
+                     message->err() == RdKafka::ERR__PARTITION_EOF) {
+            // ERR__PARTITION_EOF: Reached the end of the topic+partition queue
+            // on the broker. Not really an error. ERR__TIMED_OUT: timeout due
+            // to no message or event. This happens after
+            // receiving ERR__PARTITION_EOF and there was still no messages to
+            // be consumed after timeout.
+          } else {
+            // TODO: We probably need to re-establish Kafka connection here..
+            // Sleep here to prevent potential busy loop which exhausts the CPU.
+            if (!is_stopped_.load()) {
+              std::this_thread::sleep_for(
+                  std::chrono::milliseconds(kafka_consumer_timeout_ms_));
+            }
+          }
+        }
+      }
+    }
+    // 4) Post-processing after kafka operations
+    WatchLoopIterationEnd();
+    // Sleep here to prevent while(true) loop from exhausting CPU.
+    auto now_ms = timeutil::GetCurrentTimestamp(
+        timeutil::TimeUnit::kMillisecond);
+    // TODO: Implement an interruptible sleep (e.g. using a condition variable)
+    // so we can exit immediately once stop is called
+    if (!is_stopped_.load() && now_ms < cycle_end_timestamp_ms) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(
+          cycle_end_timestamp_ms - now_ms));
+    }
+  }
+  LOG(INFO) << name_ << ": StartWatchLoop has ended";
+}

--- a/common/kafka/kafka_watcher.h
+++ b/common/kafka/kafka_watcher.h
@@ -1,0 +1,183 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <map>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "boost/functional/hash.hpp"
+
+namespace RdKafka {
+class Message;
+}
+
+namespace kafka {
+class KafkaConsumer;
+
+class KafkaConsumerPool;
+}  // namespace kafka
+
+typedef std::function<void(std::shared_ptr<const RdKafka::Message> message,
+    const bool is_replay)> KafkaMessageHandler;
+
+/**
+ * Base class for watchers that want to consume from kafka. Manages the kafka
+ * consumer and the consuming thread. Derived class just has to implement the
+ * methods to initialize state, handle the messages consumed, and optionally
+ * adjust the seek at each iteration of the loop.
+ *
+ * IMPORTANT: Derived class MUST CALL StopAndWait() IN ITS DESTRUCTOR to stop
+ * the watcher thread before any derived class member variables or methods of
+ * the derived class are destructed.
+ */
+class KafkaWatcher {
+public:
+  KafkaWatcher(const std::string& name,
+               std::shared_ptr<kafka::KafkaConsumerPool> kafka_consumer_pool,
+               int kafka_init_blocking_consume_timeout_ms = 5000,
+               int kafka_consumer_timeout_ms = 0,
+               int loop_cycle_limit_ms = 10000);
+
+  KafkaWatcher(const std::string& name,
+               const std::vector<std::shared_ptr<kafka::KafkaConsumerPool>>&
+                kafka_consumer_pools,
+               int kafka_init_blocking_consume_timeout_ms = 5000,
+               int kafka_consumer_timeout_ms = 0,
+               int loop_cycle_limit_ms = 10000);
+
+  virtual ~KafkaWatcher();
+
+  KafkaWatcher(const KafkaWatcher&) = delete;
+
+  KafkaWatcher& operator=(const KafkaWatcher&) = delete;
+
+  std::string GetTopicString(const kafka::KafkaConsumer& consumer);
+
+  // If set to a value other than -1, will seek kafka consumer to this
+  // timestamp ms during initialization.
+  void Start(int64_t initial_kafka_seek_timestamp_ms = -1);
+
+  // If last_offsets is not empty, will seek kafka consumer to the
+  // last_offsets + 1 during initialization.
+  void Start(const std::map<std::string, std::map<int32_t,
+      int64_t>>& last_offsets);
+
+  void StartWith(int64_t initial_kafka_seek_timestamp_ms,
+      KafkaMessageHandler handler);
+
+  void StartWith(const std::map<std::string, std::map<int32_t,
+      int64_t>>& last_offsets,
+      KafkaMessageHandler handler);
+
+  // Non blocking call to signal the watch loop to terminate at the
+  // next iteration. Can be called to signal multiple KafkaWatchers to
+  // stop in parallel
+  void Stop() { is_stopped_.store(true); }
+
+  // Blocking call which signals the watch loop to terminate at the next
+  // iteration and blocks and waits for the watch thread to end.
+  void StopAndWait() {
+    is_stopped_.store(true);
+    if (thread_.joinable()) {
+      thread_.join();
+    }
+  }
+
+  // Shutdown the watcher.
+  // If graceful is true, block and wait for the watch thread to end.
+  // Otherwise detach the watcher thread.
+  void Shutdown(bool graceful = true) {
+    is_stopped_.store(true);
+    if (thread_.joinable()) {
+      if (graceful) {
+        thread_.join();
+      } else {
+        thread_.detach();
+      }
+    }
+  }
+
+protected:
+  // Tag used when logging metrics, so we can differentiate between
+  // kafka watchers for different use cases
+  const std::string kafka_watcher_metric_tag_;
+  // The name of the kafka watcher
+  const std::string name_;
+
+private:
+  virtual void HandleKafkaNoErrorMessage(
+      std::shared_ptr<const RdKafka::Message> message,
+      const bool is_replay) {
+    if (handler_) {
+      handler_(message, is_replay);
+    }
+  }
+
+  // Derived class should implement if there is code to be run before getting
+  // the kafka consumer from the pool. Return false to abort starting the
+  // watcher
+  virtual bool Init() { return true; }
+
+  // Derived class should implement if there is code that needs to be run at
+  // the start of the watch loop (before messages are consumed)
+  virtual void WatchLoopIterationStart() {}
+
+  // Derived class should implement if there is a need to adjust
+  // the seek of the kafka consumer before messages are consumed
+  virtual void MaybeAdjustKafkaConsumerSeek(
+      kafka::KafkaConsumer* const kafka_consumer) {}
+
+  // Derived class should implement if there is code that needs to be run at
+  // the end of the watch loop (after messages are consumed)
+  virtual void WatchLoopIterationEnd() {}
+
+  // Performs the initial seek of the kafka consumer. Default behavior is to
+  // seek all topics to the initial timestamp ms (if specified). Derived class
+  // can override to implement custom seek operations. Return false to abort
+  // starting the watcher
+  virtual bool InitKafkaConsumerSeek(kafka::KafkaConsumer* const kafka_consumer,
+                                     int64_t initial_kafka_seek_timestamp_ms);
+
+  // Consumes messages up to the current timestamp for a given consumer.
+  // Returns how many messages are consumed.
+  uint32_t ConsumeUpToNow(const kafka::KafkaConsumer& consumer);
+
+  void StartWatchLoop();
+
+  std::thread thread_;
+  std::atomic<bool> is_stopped_;
+
+  const std::vector<std::shared_ptr<kafka::KafkaConsumerPool>>
+    kafka_consumer_pools_;
+  std::vector<std::shared_ptr<kafka::KafkaConsumer>> kafka_consumers_;
+
+  // The time limit used to blocking consume kafka messages until the current
+  // timestamp when initializing index segment manager, -1 means wait for
+  // consuming up to now.
+  const int kafka_init_blocking_consume_timeout_ms_;
+  // The time spent waiting on a consume if data is not available
+  const int kafka_consumer_timeout_ms_;
+  // The time limit for payload update in each loop cycle
+  const int loop_cycle_limit_ms_;
+  // Kafka message handler provided by caller
+  KafkaMessageHandler handler_;
+};

--- a/common/kafka/stats_enum.cpp
+++ b/common/kafka/stats_enum.cpp
@@ -1,0 +1,78 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include "common/kafka/stats_enum.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gflags/gflags.h"
+
+DEFINE_string(corpus_type, "", "The corpus type");
+DEFINE_string(index_type, "", "The index type");
+DEFINE_string(normalized_cluster_name, "", "The normalized cluster name");
+DEFINE_string(stats_prefix, "", "Prefix for the stats");
+
+const std::vector<std::string> kCounterNames = {
+#define NEW_COUNTER_STAT(a, b) b,
+    NEW_COUNTER_STAT(kKafkaConsumerSeek, "kafka_consumer_seek")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorInit, "kafka_consumer_error_init")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorAssign, "kafka_consumer_error_assign")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorSeek, "kafka_consumer_error_seek")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorConsume, "kafka_consumer_error_consume")
+    NEW_COUNTER_STAT(kKafkaConsumerMessageNull, "kafka_consumer_message_null")
+    NEW_COUNTER_STAT(kKafkaWatcherMessageMissing,
+        "kafka_watcher_message_missing")
+    NEW_COUNTER_STAT(kKafkaWatcherBlockingConsumeTimeout,
+        "kafka_watcher_blocking_consume_timeout")
+#undef NEW_COUNTER_STAT
+};
+
+const std::vector<std::string> kMetricNames = {
+#define NEW_COUNTER_STAT(a, b)
+    NEW_COUNTER_STAT(kKafkaConsumerSeek, "kafka_consumer_seek")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorInit, "kafka_consumer_error_init")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorAssign, "kafka_consumer_error_assign")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorSeek, "kafka_consumer_error_seek")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorConsume, "kafka_consumer_error_consume")
+    NEW_COUNTER_STAT(kKafkaConsumerMessageNull, "kafka_consumer_message_null")
+    NEW_COUNTER_STAT(kKafkaWatcherMessageMissing,
+        "kafka_watcher_message_missing")
+    NEW_COUNTER_STAT(kKafkaWatcherBlockingConsumeTimeout,
+        "kafka_watcher_blocking_consume_timeout")
+#undef NEW_COUNTER_STAT
+};
+
+std::string getFullCounterName(const CounterIdx idx,
+                               const std::initializer_list<std::string>& tags) {
+  return getFullMetricName(kCounterNames[idx], tags);
+}
+
+std::string getFullMetricName(const std::string& metric_name,
+                              const std::initializer_list<std::string>& tags) {
+  std::string full_metric_name;
+  full_metric_name.append(FLAGS_stats_prefix)
+      .append(metric_name)
+      .append("_")
+      .append(FLAGS_index_type)
+      .append("_")
+      .append(FLAGS_corpus_type)
+      .append(" cluster=")
+      .append(FLAGS_normalized_cluster_name);
+  for (const auto& tag : tags) {
+    full_metric_name.append(" ").append(tag);
+  }
+  return full_metric_name;
+}

--- a/common/kafka/stats_enum.h
+++ b/common/kafka/stats_enum.h
@@ -1,0 +1,64 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "common/stats/stats.h"
+
+#define STATS_ADD_METRIC common::Stats::get()->AddMetric
+#define STATS_INCR common::Stats::get()->Incr
+
+enum CounterIdx {
+  kCounterIdxMin = -1,
+#define NEW_COUNTER_STAT(a, b) a,
+    NEW_COUNTER_STAT(kKafkaConsumerSeek, "kafka_consumer_seek")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorInit, "kafka_consumer_error_init")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorAssign, "kafka_consumer_error_assign")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorSeek, "kafka_consumer_error_seek")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorConsume, "kafka_consumer_error_consume")
+    NEW_COUNTER_STAT(kKafkaConsumerMessageNull, "kafka_consumer_message_null")
+    NEW_COUNTER_STAT(kKafkaWatcherMessageMissing,
+        "kafka_watcher_message_missing")
+    NEW_COUNTER_STAT(kKafkaWatcherBlockingConsumeTimeout,
+        "kafka_watcher_blocking_consume_timeout")
+#undef NEW_COUNTER_STAT
+  kCounterIdxMax,
+};
+
+enum MetricIdx {
+  kMetricIdxMin = -1,
+#define NEW_COUNTER_STAT(a, b)
+    NEW_COUNTER_STAT(kKafkaConsumerSeek, "kafka_consumer_seek")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorInit, "kafka_consumer_error_init")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorAssign, "kafka_consumer_error_assign")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorSeek, "kafka_consumer_error_seek")
+    NEW_COUNTER_STAT(kKafkaConsumerErrorConsume,
+        "kafka_consumer_error_consume")
+    NEW_COUNTER_STAT(kKafkaConsumerMessageNull, "kafka_consumer_message_null")
+    NEW_COUNTER_STAT(kKafkaWatcherMessageMissing,
+        "kafka_watcher_message_missing")
+    NEW_COUNTER_STAT(kKafkaWatcherBlockingConsumeTimeout,
+        "kafka_watcher_blocking_consume_timeout")
+#undef NEW_COUNTER_STAT
+  kMetricIdxMax,
+};
+
+std::string getFullMetricName(MetricIdx idx,
+    const std::initializer_list<std::string>& tags);
+std::string getFullCounterName(CounterIdx idx,
+    const std::initializer_list<std::string>& tags);
+std::string getFullMetricName(const std::string& metric_name,
+                              const std::initializer_list<std::string>& tags);

--- a/common/kafka/tests/CMakeLists.txt
+++ b/common/kafka/tests/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.1)
+
+FILE(GLOB TEST_SOURCES *.cpp)
+
+SET(kafka_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../)
+SET(kafka_SRCS ${kafka_DIR}/kafka_consumer.cpp
+        ${kafka_DIR}/kafka_consumer_pool.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/mock_kafka_cluster.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/mock_kafka_consumer.h
+        ${kafka_DIR}/stats_enum.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../stats/stats.cpp)
+ADD_LIBRARY(kafka_consumer ${kafka_SRCS})
+
+foreach(testsourcefile ${TEST_SOURCES})
+  get_filename_component(testname ${testsourcefile} NAME_WE)
+  add_executable(${testname} ${testsourcefile})
+  target_link_libraries(${testname} common gtest kafka_consumer rdkafka++)
+  add_test(NAME ${testname} COMMAND ${testname})
+endforeach(testsourcefile ${TEST_SOURCES})
+

--- a/common/kafka/tests/kafka_consumer_test.cpp
+++ b/common/kafka/tests/kafka_consumer_test.cpp
@@ -1,0 +1,296 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include <algorithm>
+#include <string>
+#include <tuple>
+#include <unordered_set>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "librdkafka/rdkafkacpp.h"
+#include "common/kafka/tests/mock_kafka_cluster.h"
+#include "common/kafka/tests/mock_kafka_consumer.h"
+
+namespace kafka {
+
+class KafkaConsumerTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    mock_kafka_cluster_ = std::make_shared<MockKafkaCluster>();
+
+    topic_names_ = {"topic0", "topic1", "topic2", "topic3"};
+    partition_ids_ = {1, 2, 3, 4, 5, 10};
+    records_ = {{"a", 2}, {"b", 4}, {"c", 8}, {"d", 16}, {"e", 32}, {"f", 64}, {"g", 128}};
+
+    for (auto& topic_name : topic_names_) {
+      for (auto partition_id : partition_ids_) {
+        for (auto& record : records_) {
+          mock_kafka_cluster_->AddRecord(
+              topic_name, partition_id, record.payload, record.timestamp_ms);
+        }
+      }
+    }
+  }
+
+  std::shared_ptr<MockKafkaCluster> mock_kafka_cluster_;
+  std::vector<std::string> topic_names_;
+  std::vector<int32_t> partition_ids_;
+  std::vector<MockKafkaCluster::Record> records_;
+};
+
+TEST_F(KafkaConsumerTest, TestSingleTopic) {
+  const int32_t partition_id = 4;
+  const std::string topic_name = "topic0";
+
+  KafkaConsumer kafka_consumer(std::make_shared<RdKafka::MockKafkaConsumer>(mock_kafka_cluster_),
+                               std::unordered_set<uint32_t>({partition_id}),
+                               std::unordered_set<std::string>({topic_name}),
+                               "UnitTestKafkaConsumer");
+
+  ASSERT_TRUE(kafka_consumer.Seek(topic_name, 16 /* timestamp_ms */));
+
+  int offset = 3;
+  RdKafka::Message* message;
+  for (size_t completed_topic_partitions = 0; completed_topic_partitions < 1;) {
+    message = kafka_consumer.Consume(-1 /* timeout_ms */);
+    if (message->err() == RdKafka::ERR__PARTITION_EOF) {
+      completed_topic_partitions++;
+      continue;
+    }
+
+    // Since there's only one topic all consumed messages should be in the same order as the records
+    EXPECT_EQ(RdKafka::ERR_NO_ERROR, message->err());
+    EXPECT_EQ(records_[offset].payload, std::string(static_cast<char*>(message->payload())));
+    EXPECT_EQ(RdKafka::MessageTimestamp::MSG_TIMESTAMP_CREATE_TIME, message->timestamp().type);
+    EXPECT_EQ(records_[offset].timestamp_ms, message->timestamp().timestamp);
+    EXPECT_EQ(offset, message->offset());
+    EXPECT_EQ(topic_name, message->topic_name());
+    EXPECT_EQ(partition_id, message->partition());
+
+    offset++;
+  }
+
+  EXPECT_EQ(records_.size(), offset);
+}
+
+TEST_F(KafkaConsumerTest, TestMultipleTopicPartitions) {
+  const std::unordered_set<uint32_t> partition_ids{1, 2, 10};
+  const std::unordered_set<std::string> topic_names({"topic0", "topic2"});
+
+  KafkaConsumer kafka_consumer(std::make_shared<RdKafka::MockKafkaConsumer>(mock_kafka_cluster_),
+                               partition_ids,
+                               topic_names,
+                               "UnitTestKafkaConsumer");
+
+  // Seek to timestamp
+  ASSERT_TRUE(kafka_consumer.Seek(63 /* timestamp_ms */));
+
+  std::vector<std::tuple<int32_t, std::string, std::string, int64_t>> expected_results{
+      std::make_tuple(1, "topic0", "f", 64),
+      std::make_tuple(1, "topic0", "g", 128),
+      std::make_tuple(1, "topic2", "f", 64),
+      std::make_tuple(1, "topic2", "g", 128),
+      std::make_tuple(2, "topic0", "f", 64),
+      std::make_tuple(2, "topic0", "g", 128),
+      std::make_tuple(2, "topic2", "f", 64),
+      std::make_tuple(2, "topic2", "g", 128),
+      std::make_tuple(10, "topic0", "f", 64),
+      std::make_tuple(10, "topic0", "g", 128),
+      std::make_tuple(10, "topic2", "f", 64),
+      std::make_tuple(10, "topic2", "g", 128)};
+
+  size_t num_records = 0;
+  RdKafka::Message* message;
+  for (size_t completed_topic_partitions = 0; completed_topic_partitions < 6;) {
+    message = kafka_consumer.Consume(-1 /* timeout_ms */);
+    if (message->err() == RdKafka::ERR__PARTITION_EOF) {
+      completed_topic_partitions++;
+      continue;
+    }
+
+    EXPECT_EQ(RdKafka::MessageTimestamp::MSG_TIMESTAMP_CREATE_TIME, message->timestamp().type);
+    std::string str_payload = std::string(static_cast<char*>(message->payload()));
+    std::tuple<int32_t, std::string, std::string, int64_t> result = std::make_tuple(
+        message->partition(), message->topic_name(), str_payload, message->timestamp().timestamp);
+    EXPECT_TRUE(std::find(expected_results.begin(), expected_results.end(), result) !=
+                expected_results.end());
+    num_records++;
+  }
+
+  EXPECT_EQ(expected_results.size(), num_records);
+}
+
+TEST_F(KafkaConsumerTest, TestMultipleTopicPartitionsDiffSeekTimes) {
+  const std::unordered_set<uint32_t> partition_ids{1, 2, 10};
+  const std::unordered_set<std::string> topic_names({"topic0", "topic2"});
+
+  KafkaConsumer kafka_consumer(std::make_shared<RdKafka::MockKafkaConsumer>(mock_kafka_cluster_),
+                               partition_ids,
+                               topic_names,
+                               "UnitTestKafkaConsumer");
+
+  // Seek to timestamp
+  ASSERT_TRUE(kafka_consumer.Seek("topic0", 32 /* timestamp_ms */));
+  ASSERT_TRUE(kafka_consumer.Seek("topic2", 64 /* timestamp_ms */));
+
+  {
+    std::vector<std::tuple<int32_t, std::string, std::string, int64_t>> expected_results{
+        std::make_tuple(1, "topic0", "e", 32),
+        std::make_tuple(1, "topic0", "f", 64),
+        std::make_tuple(1, "topic0", "g", 128),
+        std::make_tuple(1, "topic2", "f", 64),
+        std::make_tuple(1, "topic2", "g", 128),
+        std::make_tuple(2, "topic0", "e", 32),
+        std::make_tuple(2, "topic0", "f", 64),
+        std::make_tuple(2, "topic0", "g", 128),
+        std::make_tuple(2, "topic2", "f", 64),
+        std::make_tuple(2, "topic2", "g", 128),
+        std::make_tuple(10, "topic0", "e", 32),
+        std::make_tuple(10, "topic0", "f", 64),
+        std::make_tuple(10, "topic0", "g", 128),
+        std::make_tuple(10, "topic2", "f", 64),
+        std::make_tuple(10, "topic2", "g", 128)};
+
+    size_t num_records = 0;
+    RdKafka::Message* message;
+    for (size_t completed_topic_partitions = 0; completed_topic_partitions < 6;) {
+      message = kafka_consumer.Consume(-1 /* timeout_ms */);
+      if (message->err() == RdKafka::ERR__PARTITION_EOF) {
+        completed_topic_partitions++;
+        continue;
+      }
+
+      EXPECT_EQ(RdKafka::MessageTimestamp::MSG_TIMESTAMP_CREATE_TIME, message->timestamp().type);
+      std::string str_payload = std::string(static_cast<char*>(message->payload()));
+      std::tuple<int32_t, std::string, std::string, int64_t> result = std::make_tuple(
+          message->partition(), message->topic_name(), str_payload, message->timestamp().timestamp);
+      EXPECT_TRUE(std::find(expected_results.begin(), expected_results.end(), result) !=
+                  expected_results.end());
+      num_records++;
+    }
+
+    EXPECT_EQ(expected_results.size(), num_records);
+  }
+
+  // Seek again after consume to check that reseeking to an earlier position works
+  ASSERT_TRUE(kafka_consumer.Seek("topic0", 16 /* timestamp_ms */));
+  {
+    std::vector<std::tuple<int32_t, std::string, std::string, int64_t>> expected_results{
+        std::make_tuple(1, "topic0", "d", 16),
+        std::make_tuple(1, "topic0", "e", 32),
+        std::make_tuple(1, "topic0", "f", 64),
+        std::make_tuple(1, "topic0", "g", 128),
+        std::make_tuple(2, "topic0", "d", 16),
+        std::make_tuple(2, "topic0", "e", 32),
+        std::make_tuple(2, "topic0", "f", 64),
+        std::make_tuple(2, "topic0", "g", 128),
+        std::make_tuple(10, "topic0", "d", 16),
+        std::make_tuple(10, "topic0", "e", 32),
+        std::make_tuple(10, "topic0", "f", 64),
+        std::make_tuple(10, "topic0", "g", 128)};
+
+    size_t num_records = 0;
+    RdKafka::Message* message;
+    for (size_t completed_topic_partitions = 0; completed_topic_partitions < 3;) {
+      message = kafka_consumer.Consume(-1 /* timeout_ms */);
+      if (message->err() == RdKafka::ERR__PARTITION_EOF) {
+        completed_topic_partitions++;
+        continue;
+      }
+
+      EXPECT_EQ(RdKafka::MessageTimestamp::MSG_TIMESTAMP_CREATE_TIME, message->timestamp().type);
+      std::string str_payload = std::string(static_cast<char*>(message->payload()));
+      std::tuple<int32_t, std::string, std::string, int64_t> result = std::make_tuple(
+          message->partition(), message->topic_name(), str_payload, message->timestamp().timestamp);
+      EXPECT_TRUE(std::find(expected_results.begin(), expected_results.end(), result) !=
+                  expected_results.end());
+      num_records++;
+    }
+
+    EXPECT_EQ(expected_results.size(), num_records);
+  }
+}
+
+TEST_F(KafkaConsumerTest, TestMultipleTopicPartitionsSeekOffset) {
+  const std::unordered_set<uint32_t> partition_ids{1, 2, 10};
+  const std::unordered_set<std::string> topic_names({"topic0", "topic2"});
+
+  KafkaConsumer kafka_consumer(std::make_shared<RdKafka::MockKafkaConsumer>(mock_kafka_cluster_),
+                               partition_ids,
+                               topic_names,
+                               "UnitTestKafkaConsumer");
+
+  // Seek to offset
+  std::map<std::string, std::map<int32_t, int64_t>> last_offsets{
+      {"topic0", {{1, 3}, {2, 4}, {10, 5}}},
+      {"topic2", {{1, 4}, {2, 4}, {10, 4}}},
+  };
+  kafka_consumer.Seek(last_offsets);
+
+  std::vector<std::tuple<int32_t, std::string, std::string, int64_t>> expected_results{
+      std::make_tuple(1, "topic0", "e", 32),
+      std::make_tuple(1, "topic0", "f", 64),
+      std::make_tuple(1, "topic0", "g", 128),
+      std::make_tuple(2, "topic0", "f", 64),
+      std::make_tuple(2, "topic0", "g", 128),
+      std::make_tuple(10, "topic0", "g", 128),
+      std::make_tuple(1, "topic2", "f", 64),
+      std::make_tuple(1, "topic2", "g", 128),
+      std::make_tuple(2, "topic2", "f", 64),
+      std::make_tuple(2, "topic2", "g", 128),
+      std::make_tuple(10, "topic2", "f", 64),
+      std::make_tuple(10, "topic2", "g", 128)};
+
+  size_t num_records = 0;
+  RdKafka::Message* message;
+  for (size_t completed_topic_partitions = 0; completed_topic_partitions < 6;) {
+    message = kafka_consumer.Consume(-1 /* timeout_ms */);
+    if (message->err() == RdKafka::ERR__PARTITION_EOF) {
+      completed_topic_partitions++;
+      continue;
+    }
+
+    EXPECT_EQ(RdKafka::MessageTimestamp::MSG_TIMESTAMP_CREATE_TIME, message->timestamp().type);
+    std::string str_payload = std::string(static_cast<char*>(message->payload()));
+    std::tuple<int32_t, std::string, std::string, int64_t> result = std::make_tuple(
+        message->partition(), message->topic_name(), str_payload, message->timestamp().timestamp);
+    EXPECT_TRUE(std::find(expected_results.begin(), expected_results.end(), result) !=
+                expected_results.end());
+    num_records++;
+  }
+
+  EXPECT_EQ(expected_results.size(), num_records);
+}
+
+TEST_F(KafkaConsumerTest, TestSeekInvalidTopic) {
+  const std::unordered_set<uint32_t> partition_ids{1, 2, 10};
+  const std::unordered_set<std::string> topic_names({"topic0", "topic2"});
+
+  KafkaConsumer kafka_consumer(std::make_shared<RdKafka::MockKafkaConsumer>(mock_kafka_cluster_),
+                               partition_ids,
+                               topic_names,
+                               "UnitTestKafkaConsumer");
+
+  EXPECT_FALSE(kafka_consumer.Seek("topic1", 2));
+}
+
+}  // namespace kafka
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+// Created by Timothy Koh on 4/15/19.
+//

--- a/common/kafka/tests/mock_kafka_cluster.h
+++ b/common/kafka/tests/mock_kafka_cluster.h
@@ -1,0 +1,169 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+namespace kafka {
+
+// This is intended to be used for sequential tests where we initialize the data once and use it for
+// read only after
+// TODO: Implement thread safe writes after initialization if needed
+class MockKafkaCluster {
+  FRIEND_TEST(MockKafkaClusterTest, TestAdd);
+
+public:
+  struct Record {
+    std::string payload;
+    int64_t timestamp_ms;
+    int64_t offset;
+  };
+  using Partition = std::vector<Record>;
+  using Topic = std::unordered_map<int32_t, Partition>;  // partition_id -> partition
+
+  class Iterator {
+  public:
+    Iterator(std::string topic_name, int32_t partition_id, const std::vector<Record>* vec, int idx)
+        : topic_name_(std::move(topic_name)), partition_id_(partition_id), vec_(vec), idx_(idx) {}
+
+    bool HasNext() {
+      if (vec_ == nullptr) {
+        return false;
+      }
+
+      return idx_ + 1 < vec_->size();
+    }
+
+    bool Next() {
+      if (vec_ == nullptr) {
+        return false;
+      }
+
+      idx_++;
+      return idx_ < vec_->size();
+    }
+
+    // Only call if Next() returns true, if not, behavior is not defined
+    Record GetRecord() {
+      CHECK(vec_ != nullptr);
+      CHECK(idx_ < vec_->size());
+      return (*vec_)[idx_];
+    }
+
+    const std::string topic_name_;
+    const int32_t partition_id_;
+    const std::vector<Record>* vec_;
+    int idx_;
+  };
+
+  // Find offset of the first record in the partition with timestamp >= timestamp_ms
+  // Returns -1 if the partition does not exist
+  int64_t offsetForTime(const std::string& topic_name,
+                        const int32_t partition_id,
+                        const int64_t timestamp_ms) {
+    const auto name_topic_pair = topics_.find(topic_name);
+    if (name_topic_pair == topics_.end()) {
+      return -1;
+    }
+
+    const Topic& topic = name_topic_pair->second;
+    auto id_partition_pair = topic.find(partition_id);
+    if (id_partition_pair == topic.end()) {
+      return -1;
+    }
+
+    return offsetForTime(id_partition_pair->second, timestamp_ms);
+  }
+
+  // Find offset of the first record in the partition with timestamp >= timestamp_ms
+  int64_t offsetForTime(const Partition& partition, int64_t timestamp_ms) {
+    for (const auto& record : partition) {
+      if (record.timestamp_ms >= timestamp_ms) {
+        return record.offset;
+      }
+    }
+
+    return partition.size();
+  }
+
+  // Finds the relevant Partition and returns an iterator to that partition which can retrieve
+  // Records >= seek_timestamp_ms. Returns an empty iterator if topic_name or partition_id is not
+  // found
+  std::unique_ptr<Iterator> Seek(const std::string& topic_name,
+                                 int32_t partition_id,
+                                 int64_t seek_timestamp_ms) {
+    // Find topic
+    auto name_topic_pair = topics_.find(topic_name);
+    if (name_topic_pair == topics_.end()) {
+      return std::make_unique<Iterator>(topic_name, partition_id, nullptr, -1);
+    }
+    Topic& topic = name_topic_pair->second;
+
+    // Find partition
+    auto id_partition_pair = topic.find(partition_id);
+    if (id_partition_pair == topic.end()) {
+      return std::make_unique<Iterator>(topic_name, partition_id, nullptr, -1);
+    }
+    Partition& partition = id_partition_pair->second;
+
+    // -1 to offset since Next() will be called first which will do offset++
+    const auto offset = offsetForTime(partition, seek_timestamp_ms) - 1;
+    return std::make_unique<Iterator>(topic_name, partition_id, &partition, offset);
+  }
+
+  std::unique_ptr<Iterator> SeekOffset(const std::string& topic_name,
+                                       int32_t partition_id,
+                                       int64_t last_offset) {
+    // Find topic
+    auto name_topic_pair = topics_.find(topic_name);
+    if (name_topic_pair == topics_.end()) {
+      return std::make_unique<Iterator>(topic_name, partition_id, nullptr, -1);
+    }
+    Topic& topic = name_topic_pair->second;
+
+    // Find partition
+    auto id_partition_pair = topic.find(partition_id);
+    if (id_partition_pair == topic.end()) {
+      return std::make_unique<Iterator>(topic_name, partition_id, nullptr, -1);
+    }
+    Partition& partition = id_partition_pair->second;
+    return std::make_unique<Iterator>(topic_name, partition_id, &partition, last_offset);
+  }
+
+  void AddRecord(const std::string& topic_name,
+                 int32_t partition_id,
+                 std::string payload,
+                 int64_t timestamp_ms) {
+    Partition& partition = topics_[topic_name][partition_id];
+    if (!partition.empty()) {
+      auto last_timestamp_ms = partition.back().timestamp_ms;
+      CHECK(timestamp_ms >= last_timestamp_ms)
+          << "Error adding record, timestamp is not in increasing order. Last timestamp: "
+          << last_timestamp_ms << ", new record timestamp: " << timestamp_ms;
+    }
+
+    partition.push_back(Record{std::move(payload), timestamp_ms, partition.size()});
+  }
+
+private:
+  std::unordered_map<std::string, Topic> topics_;
+};
+
+}  // namespace kafka

--- a/common/kafka/tests/mock_kafka_cluster_test.cpp
+++ b/common/kafka/tests/mock_kafka_cluster_test.cpp
@@ -1,0 +1,147 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include <vector>
+#include <string>
+#include <cstdint>
+#include <unordered_map>
+
+#include "gtest/gtest.h"
+#include "common/kafka/tests/mock_kafka_cluster.h"
+
+namespace kafka {
+
+namespace {
+
+std::string GenerateRecordPayload(const std::string& topic_name,
+                                  int32_t partition_id,
+                                  int64_t timestamp_ms) {
+  return topic_name + ":" + std::to_string(partition_id) + ":" + std::to_string(timestamp_ms);
+}
+
+void MaybeGenerateAndAddRecords(
+    MockKafkaCluster* mock_kafka_cluster,
+    std::unordered_map<std::string, std::unordered_map<int32_t, size_t>>* num_records_tracker,
+    const std::vector<std::string>& topic_names,
+    int32_t partition_id,
+    int64_t mock_timestamp) {
+  for (size_t i = 0; i < topic_names.size(); i++) {
+    if (mock_timestamp % (i + 1) == 0) {
+      // Arbitrary decision to add if mock_timestamp is divisible by the index of the topic + 1
+      auto& topic_name = topic_names[i];
+
+      std::string payload = GenerateRecordPayload(topic_names[i], partition_id, mock_timestamp);
+      mock_kafka_cluster->AddRecord(topic_names[i], partition_id, payload, mock_timestamp);
+
+      (*num_records_tracker)[topic_name][partition_id]++;
+    }
+  }
+}
+
+void VerifyIter(const std::vector<MockKafkaCluster::Record>& reference_vec,
+                size_t start_idx,
+                MockKafkaCluster::Iterator* iter) {
+  for (size_t i = start_idx; i < reference_vec.size(); i++) {
+    EXPECT_TRUE(iter->Next());
+    EXPECT_EQ(reference_vec[i].payload, iter->GetRecord().payload);
+    EXPECT_EQ(reference_vec[i].timestamp_ms, iter->GetRecord().timestamp_ms);
+  }
+}
+
+}  // namespace
+
+
+class MockKafkaClusterTest : public ::testing::Test {};
+
+TEST_F(MockKafkaClusterTest, TestAdd) {
+  MockKafkaCluster mock_kafka_cluster;
+
+  // map of topic_name -> partition_id -> num_records
+  std::unordered_map<std::string, std::unordered_map<int32_t, size_t>> num_records_tracker;
+
+  const std::vector<std::string> topic_names {"topic0", "topic1", "topic2", "topic3", "topic4",
+                                              "topic5"};
+  const std::vector<int32_t> partition_ids {1, 2, 3, 4, 5, 10};
+
+  // Add records
+  for (int64_t mock_timestamp = 0; mock_timestamp < 1000; mock_timestamp++) {
+    for (auto partition_id : partition_ids) {
+      if (mock_timestamp % partition_id == 0) {
+        // Arbitrary decision to add if mock_timestamp is divisible by partition_id
+        MaybeGenerateAndAddRecords(&mock_kafka_cluster, &num_records_tracker, topic_names,
+                                   partition_id, mock_timestamp);
+      }
+    }
+  }
+
+  // Verify
+  for (const auto& name_topic_pair : mock_kafka_cluster.topics_) {
+    const auto& topic_name = name_topic_pair.first;
+    const MockKafkaCluster::Topic& topic = name_topic_pair.second;
+
+    for (const auto& id_partition_pair : topic) {
+      const auto& partition_id = id_partition_pair.first;
+      const MockKafkaCluster::Partition& partition = id_partition_pair.second;
+      EXPECT_EQ(num_records_tracker[topic_name][partition_id], partition.size());
+
+      for (const MockKafkaCluster::Record& record : partition) {
+        EXPECT_EQ(GenerateRecordPayload(topic_name, partition_id, record.timestamp_ms),
+                  record.payload);
+      }
+    }
+  }
+}
+
+TEST_F(MockKafkaClusterTest, TestSeek) {
+  MockKafkaCluster mock_kafka_cluster;
+
+  const std::string topic_name = "topic_name";
+  const int32_t partition_id = 42;
+
+  const std::vector<MockKafkaCluster::Record> records
+      {{"a", 2}, {"b", 4}, {"c", 8}, {"d", 16}, {"e", 32}, {"f", 64}, {"g", 128}, {"h", 256}};
+
+  // Add records
+  for (const auto& record : records) {
+    mock_kafka_cluster.AddRecord(topic_name, partition_id, record.payload, record.timestamp_ms);
+  }
+
+  // Test seek
+  for (size_t i = 0; i < records.size(); i++) {
+    const int64_t before_timestamp = records[i].timestamp_ms - 1;
+    const int64_t at_timestamp = records[i].timestamp_ms;
+    const int64_t after_timestamp = records[i].timestamp_ms + 1;
+
+    auto before_iter = mock_kafka_cluster.Seek(topic_name, partition_id, before_timestamp);
+    auto at_iter = mock_kafka_cluster.Seek(topic_name, partition_id, at_timestamp);
+    auto after_iter = mock_kafka_cluster.Seek(topic_name, partition_id, after_timestamp);
+
+    // Seek should get an iter pointing to a record with timestamp >= seek_timestamp, so seeking
+    // to a seek_timestamp <= timestamp of the current index should return an iter pointing
+    // to the record of the current index
+    VerifyIter(records, i, before_iter.get());
+    VerifyIter(records, i, at_iter.get());
+
+    // Seek to timestamp after should return iter pointing to the record at the next index
+    VerifyIter(records, i + 1, after_iter.get());
+  }
+}
+
+}  // namespace kafka
+
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/common/kafka/tests/mock_kafka_consumer.h
+++ b/common/kafka/tests/mock_kafka_consumer.h
@@ -1,0 +1,352 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+#include "librdkafka/rdkafkacpp.h"
+#include "common/kafka/kafka_consumer.h"
+#include "common/kafka/tests/mock_kafka_cluster.h"
+
+
+namespace RdKafka {
+
+class MockMessage : public Message {
+public:
+  MockMessage(std::string topic_name,
+              int32_t partition_id,
+              std::string payload_str,
+              int64_t timestamp_ms,
+              int64_t offset)
+      : topic_name_(std::move(topic_name)),
+        partition_id_(partition_id),
+        payload_str_(std::move(payload_str)),
+        timestamp_ms_(timestamp_ms),
+        offset_(offset) {}
+  ~MockMessage() {}
+
+  // Mock methods
+  std::string errstr() const override {
+    return "MockMessage error returned from errstr(). code: " + std::to_string(err());
+  }
+  ErrorCode err() const override { return ErrorCode::ERR_NO_ERROR; }
+  std::string topic_name() const override { return topic_name_; }
+  int32_t partition() const override { return partition_id_; }
+  void* payload() const override {
+    const char* data = payload_str_.data();
+    return reinterpret_cast<void*>(const_cast<char*>(data));
+  }
+  size_t len() const override { return payload_str_.size(); }
+  MessageTimestamp timestamp() const override {
+    MessageTimestamp message_timestamp;
+
+    // We only use create time in mock right now
+    message_timestamp.type = RdKafka::MessageTimestamp::MSG_TIMESTAMP_CREATE_TIME;
+    message_timestamp.timestamp = timestamp_ms_;
+    return message_timestamp;
+  }
+
+  // Not implemented methods, implement if you need to use it in a test
+  Topic* topic() const override { return nullptr; }
+  const std::string* key() const override {
+    CHECK(false) << "Not implemented";
+    return nullptr;
+  }
+  const void* key_pointer() const override {
+    CHECK(false) << "Not implemented";
+    return nullptr;
+  }
+  size_t key_len() const override {
+    CHECK(false) << "Not implemented";
+    return 0;
+  }
+  int64_t offset() const override { return offset_; }
+  void* msg_opaque() const override {
+    CHECK(false) << "Not implemented";
+    return nullptr;
+  }
+  int64_t latency() const override {
+    CHECK(false) << "Not implemented";
+    return -1;
+  }
+  struct rd_kafka_message_s* c_ptr() override {
+    CHECK(false) << "Not implemented";
+    return nullptr;
+  }
+
+private:
+  const std::string topic_name_;
+  const int32_t partition_id_;
+  const std::string payload_str_;
+  const int64_t timestamp_ms_;
+  const int64_t offset_;
+};
+
+class MockErrorMessage : public MockMessage {
+public:
+  explicit MockErrorMessage(ErrorCode error_code) : MockErrorMessage(error_code, "", -1) {}
+
+  MockErrorMessage(ErrorCode error_code, const std::string& topic_name, const int32_t partition_id)
+      : MockMessage(topic_name, partition_id, "", -1, -1), error_code_(error_code) {}
+
+  // Mock methods
+  ErrorCode err() const override { return error_code_; }
+
+private:
+  const ErrorCode error_code_;
+};
+
+class MockKafkaConsumer : public KafkaConsumer {
+public:
+  explicit MockKafkaConsumer(std::shared_ptr<::kafka::MockKafkaCluster> mock_kafka_cluster)
+      : mock_kafka_cluster_(std::move(mock_kafka_cluster)) {}
+
+  ////////////////////////////////////////////////////////////////
+  // RdKafka::KafkaConsumer Implemented Methods
+  ErrorCode assign(const std::vector<TopicPartition*>& partitions) override {
+    assigned_topic_partitions_.clear();
+    topic_partition_to_iter_map_.clear();
+
+    for (const auto* input_topic_partition : partitions) {
+      const auto& topic_name = input_topic_partition->topic();
+      const auto partition = input_topic_partition->partition();
+
+      CHECK(assigned_topic_partitions_.emplace(GetTopicPartitionKey(topic_name, partition)).second);
+    }
+
+    return ERR_NO_ERROR;
+  }
+
+  Message* consume(int timeout_ms) override {
+    for (auto it = topic_partition_to_iter_map_.begin();
+         it != topic_partition_to_iter_map_.end();) {
+      const auto& kafka_iter = it->second;
+      const auto& topic_name = kafka_iter->topic_name_;
+      const auto partition_id = kafka_iter->partition_id_;
+
+      // This will fail if the topic partition is assigned but not seeked before consume is called.
+      // This is a stricter check than RdKafka does. Instead of relying on the initial offset, we
+      // want to enforce that a seek MUST happen before consume is called
+      CHECK(kafka_iter != nullptr)
+          << "Kafka iter is nullptr for topic partition: " << it->first
+          << ", make sure you seek all assigned topic partitions before consuming";
+
+      if (kafka_iter->Next()) {
+        ::kafka::MockKafkaCluster::Record record = kafka_iter->GetRecord();
+        return new MockMessage(
+            topic_name, partition_id, record.payload, record.timestamp_ms, record.offset);
+      } else {
+        // Create copy before we delete
+        const auto topic = topic_name;
+
+        // Since we won't write anymore after the data is initialized, it is safe to remove
+        // the kafka_iter if there are no more records in it
+        it = topic_partition_to_iter_map_.erase(it);
+        return new RdKafka::MockErrorMessage(ERR__PARTITION_EOF, topic, partition_id);
+      }
+    }
+
+    // No topic partition to consume from. Instead of waiting unitl a timeout for messages to come
+    // in, we can timeout immediately since we know no more messages will come in
+    return new RdKafka::MockErrorMessage(ERR__TIMED_OUT);
+  }
+
+  ErrorCode seek(const TopicPartition& topic_partition, int timeout_ms) override {
+    const auto& topic_name = topic_partition.topic();
+    const auto partition_id = topic_partition.partition();
+    const auto key = GetTopicPartitionKey(topic_name, partition_id);
+
+    // Do a fatal check if we seek a TopicPartition that is not assigned, this is stricter than
+    // RdKafka which would return an error code instead
+    CHECK(assigned_topic_partitions_.find(key) != assigned_topic_partitions_.end())
+        << "Error. topic : " << topic_name << ", partition: " << partition_id
+        << " is not assigned. Must assign before seek";
+
+    // -1 to offset since Next() will be called first which will do offset++
+    topic_partition_to_iter_map_[key] =
+        mock_kafka_cluster_->SeekOffset(topic_name, partition_id, topic_partition.offset() - 1);
+    return ERR_NO_ERROR;
+  }
+
+  ErrorCode close() override { return ERR_NO_ERROR; }
+
+  ////////////////////////////////////////////////////////////////
+  // RdKafka::Handle Implemented Methods
+  ErrorCode offsetsForTimes(std::vector<TopicPartition*>& offsets, int timeout_ms) override {
+    for (auto* topic_partition : offsets) {
+      const auto& topic_name = topic_partition->topic();
+      const auto partition_id = topic_partition->partition();
+
+      // Timestamp is specified through this function call using offset
+      const auto timestamp_ms = topic_partition->offset();
+      const auto offset =
+          mock_kafka_cluster_->offsetForTime(topic_name, partition_id, timestamp_ms);
+      if (offset != -1) {
+        topic_partition->set_offset(offset);
+      }
+    }
+
+    return ERR_NO_ERROR;
+  }
+
+private:
+  ////////////////////////////////////////////////////////////////
+  // NotImpl error methods
+  ErrorCode NotImplErrorCode() const {
+    LOG(FATAL) << "Mock function not implemented, should not be called";
+    return ERR_UNKNOWN;
+  }
+
+  std::string NotImplStr() const {
+    LOG(FATAL) << "Mock function not implemented, should not be called";
+    return std::string();
+  }
+
+  int NotImplInt() const {
+    LOG(FATAL) << "Mock function not implemented, should not be called";
+    return -1;
+  }
+
+  template <typename T>
+  T* NotImplNullptr() const {
+    LOG(FATAL) << "Mock function not implemented, should not be called";
+    return nullptr;
+  }
+
+  void NotImplVoid() const { LOG(FATAL) << "Mock function not implemented, should not be called"; }
+
+  ////////////////////////////////////////////////////////////////
+  // RdKafka::KafkaConsumer Not Implemented Methods
+  ErrorCode subscription(std::vector<std::string>& topics) override { return NotImplErrorCode(); }
+
+  ErrorCode subscribe(const std::vector<std::string>& topics) override {
+    return NotImplErrorCode();
+  }
+
+  ErrorCode unsubscribe() override { return NotImplErrorCode(); }
+
+  ErrorCode commitSync() override { return NotImplErrorCode(); }
+
+  ErrorCode commitAsync() override { return NotImplErrorCode(); }
+
+  ErrorCode commitSync(Message* message) override { return NotImplErrorCode(); }
+
+  ErrorCode commitAsync(Message* message) override { return NotImplErrorCode(); }
+
+  ErrorCode commitSync(std::vector<TopicPartition*>& offsets) override {
+    return NotImplErrorCode();
+  }
+
+  ErrorCode commitAsync(const std::vector<TopicPartition*>& offsets) override {
+    return NotImplErrorCode();
+  }
+
+  ErrorCode commitSync(OffsetCommitCb* offset_commit_cb) override { return NotImplErrorCode(); }
+
+  ErrorCode commitSync(std::vector<TopicPartition*>& offsets,
+                       OffsetCommitCb* offset_commit_cb) override {
+    return NotImplErrorCode();
+  }
+
+  ErrorCode committed(std::vector<TopicPartition*>& partitions, int timeout_ms) override {
+    return NotImplErrorCode();
+  }
+
+  ErrorCode position(std::vector<TopicPartition*>& partitions) override {
+    return NotImplErrorCode();
+  }
+
+  ErrorCode offsets_store(std::vector<TopicPartition*>& offsets) override {
+    return NotImplErrorCode();
+  }
+
+  ErrorCode assignment(std::vector<RdKafka::TopicPartition*>& partitions) override {
+    return NotImplErrorCode();
+  }
+
+  ErrorCode unassign() override { return NotImplErrorCode(); }
+
+  ////////////////////////////////////////////////////////////////
+  // RdKafka::Handle Not Implemented Methods
+  const std::string name() const override { return NotImplStr(); }
+
+  const std::string memberid() const override { return NotImplStr(); }
+
+  int poll(int timeout_ms) override { return NotImplInt(); }
+
+  int outq_len() override { return NotImplInt(); }
+
+  ErrorCode metadata(bool all_topics,
+                     const Topic* only_rkt,
+                     Metadata** metadatap,
+                     int timeout_ms) override {
+    return NotImplErrorCode();
+  }
+
+  ErrorCode pause(std::vector<TopicPartition*>& partitions) override { return NotImplErrorCode(); }
+
+  ErrorCode resume(std::vector<TopicPartition*>& partitions) override { return NotImplErrorCode(); }
+
+  ErrorCode query_watermark_offsets(const std::string& topic,
+                                    int32_t partition,
+                                    int64_t* low,
+                                    int64_t* high,
+                                    int timeout_ms) override {
+    return NotImplErrorCode();
+  }
+
+  ErrorCode get_watermark_offsets(const std::string& topic,
+                                  int32_t partition,
+                                  int64_t* low,
+                                  int64_t* high) override {
+    return NotImplErrorCode();
+  }
+
+  Queue* get_partition_queue(const TopicPartition* partition) override {
+    return NotImplNullptr<Queue>();
+  }
+
+  ErrorCode set_log_queue(Queue* queue) override { return NotImplErrorCode(); }
+
+  void yield() override { NotImplVoid(); }
+
+  const std::string clusterid(int timeout_ms) override { return NotImplStr(); }
+
+  struct rd_kafka_s* c_ptr() override {
+    return NotImplNullptr<struct rd_kafka_s>();
+  }
+
+  ////////////////////////////////////////////////////////////////
+  // Other private methods
+  std::string GetTopicPartitionKey(const std::string& topic, const int partition) {
+    return topic + ":" + std::to_string(partition);
+  }
+
+  std::shared_ptr<::kafka::MockKafkaCluster> mock_kafka_cluster_;
+
+  std::unordered_set<std::string> assigned_topic_partitions_;
+  std::unordered_map<std::string, std::unique_ptr<::kafka::MockKafkaCluster::Iterator>>
+      topic_partition_to_iter_map_;
+};
+
+}  // namespace RdKafka

--- a/common/kafka/tests/mock_kafka_consumer_test.cpp
+++ b/common/kafka/tests/mock_kafka_consumer_test.cpp
@@ -1,0 +1,164 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "librdkafka/rdkafkacpp.h"
+#include "common/kafka/tests/mock_kafka_cluster.h"
+#include "common/kafka/tests/mock_kafka_consumer.h"
+
+class MockKafkaConsumerTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    mock_kafka_cluster_ = std::make_shared<::kafka::MockKafkaCluster>();
+
+    topic_names_ = {"topic0", "topic1", "topic2", "topic3"};
+    partition_ids_ = {1, 2, 3, 4, 5, 10};
+    records_ = {{"a", 2}, {"b", 4}, {"c", 8}, {"d", 16}, {"e", 32}, {"f", 64}, {"g", 128}};
+
+    for (auto& topic_name : topic_names_) {
+      for (auto partition_id : partition_ids_) {
+        for (auto& record : records_) {
+          mock_kafka_cluster_->AddRecord(
+              topic_name, partition_id, record.payload, record.timestamp_ms);
+        }
+      }
+    }
+  }
+
+  std::shared_ptr<::kafka::MockKafkaCluster> mock_kafka_cluster_;
+  std::vector<std::string> topic_names_;
+  std::vector<int32_t> partition_ids_;
+  std::vector<::kafka::MockKafkaCluster::Record> records_;
+};
+
+TEST_F(MockKafkaConsumerTest, TestSingleTopic) {
+  RdKafka::MockKafkaConsumer consumer(mock_kafka_cluster_);
+
+  // Set up TopicPartition
+  const int32_t partition_id = 4;
+  const std::string topic_name = "topic0";
+  const auto topic_partition = std::unique_ptr<RdKafka::TopicPartition>(
+      RdKafka::TopicPartition::create(topic_name, partition_id, RdKafka::Topic::OFFSET_END));
+
+  consumer.assign({topic_partition.get()});
+
+  // Seek to timestamp
+  const auto seek_timestamp_ms = 16;
+  topic_partition->set_offset(seek_timestamp_ms);
+  std::vector<RdKafka::TopicPartition*> offsets{topic_partition.get()};
+  consumer.offsetsForTimes(offsets, -1 /* timeout_ms */);
+  ASSERT_EQ(3, topic_partition->offset());
+  consumer.seek(*topic_partition, -1 /* timeout_ms */);
+
+  int offset = 3;
+  RdKafka::Message* message;
+  for (size_t completed_topic_partitions = 0; completed_topic_partitions < 1;) {
+    message = consumer.consume(-1 /* timeout_ms */);
+    if (message->err() == RdKafka::ERR__PARTITION_EOF) {
+      completed_topic_partitions++;
+      continue;
+    }
+
+    // Since there's only one topic all consumed messages should be in the same order as the records
+    EXPECT_EQ(RdKafka::ERR_NO_ERROR, message->err());
+    EXPECT_EQ(records_[offset].payload, std::string(static_cast<char*>(message->payload())));
+    EXPECT_EQ(RdKafka::MessageTimestamp::MSG_TIMESTAMP_CREATE_TIME, message->timestamp().type);
+    EXPECT_EQ(records_[offset].timestamp_ms, message->timestamp().timestamp);
+    EXPECT_EQ(offset, message->offset());
+    EXPECT_EQ(topic_name, message->topic_name());
+    EXPECT_EQ(partition_id, message->partition());
+
+    offset++;
+  }
+
+  EXPECT_EQ(records_.size(), offset);
+}
+
+TEST_F(MockKafkaConsumerTest, TestMultipleTopicPartitions) {
+  const std::vector<int32_t> partition_ids{1, 2, 10};
+  const std::unordered_set<std::string> topic_names({"topic0", "topic2"});
+  RdKafka::MockKafkaConsumer consumer(mock_kafka_cluster_);
+
+  // Set up TopicPartitions
+  std::vector<std::unique_ptr<RdKafka::TopicPartition>> topic_partitions;
+  std::vector<RdKafka::TopicPartition*> tmp_topic_partitions;
+  for (const auto partition_id : partition_ids) {
+    for (const auto& topic_name : topic_names) {
+      auto topic_partition = std::unique_ptr<RdKafka::TopicPartition>(
+          RdKafka::TopicPartition::create(topic_name, partition_id, RdKafka::Topic::OFFSET_END));
+      tmp_topic_partitions.push_back(topic_partition.get());
+      topic_partitions.push_back(std::move(topic_partition));
+    }
+  }
+
+  consumer.assign(tmp_topic_partitions);
+
+  // Seek to timestamp
+  const auto seek_timestamp_ms = 63;
+  for (auto* topic_partition : tmp_topic_partitions) {
+    topic_partition->set_offset(seek_timestamp_ms);
+  }
+  consumer.offsetsForTimes(tmp_topic_partitions, -1 /* timeout_ms */);
+  for (const auto* topic_partition : tmp_topic_partitions) {
+    ASSERT_EQ(5, topic_partition->offset());
+    consumer.seek(*topic_partition, -1 /* timeout_ms */);
+  }
+
+  std::vector<std::tuple<int32_t, std::string, std::string, int64_t>> expected_results{
+      std::make_tuple(1, "topic0", "f", 64),
+      std::make_tuple(1, "topic0", "g", 128),
+      std::make_tuple(1, "topic2", "f", 64),
+      std::make_tuple(1, "topic2", "g", 128),
+      std::make_tuple(2, "topic0", "f", 64),
+      std::make_tuple(2, "topic0", "g", 128),
+      std::make_tuple(2, "topic2", "f", 64),
+      std::make_tuple(2, "topic2", "g", 128),
+      std::make_tuple(10, "topic0", "f", 64),
+      std::make_tuple(10, "topic0", "g", 128),
+      std::make_tuple(10, "topic2", "f", 64),
+      std::make_tuple(10, "topic2", "g", 128)};
+
+  size_t num_records = 0;
+  RdKafka::Message* message;
+  for (size_t completed_topic_partitions = 0; completed_topic_partitions < 6;) {
+    message = consumer.consume(-1 /* timeout_ms */);
+    if (message->err() == RdKafka::ERR__PARTITION_EOF) {
+      completed_topic_partitions++;
+      continue;
+    }
+
+    EXPECT_EQ(RdKafka::MessageTimestamp::MSG_TIMESTAMP_CREATE_TIME, message->timestamp().type);
+    std::string str_payload = std::string(static_cast<char*>(message->payload()));
+    std::tuple<int32_t, std::string, std::string, int64_t> result = std::make_tuple(
+        message->partition(), message->topic_name(), str_payload, message->timestamp().timestamp);
+    EXPECT_TRUE(std::find(expected_results.begin(), expected_results.end(), result) !=
+                expected_results.end());
+    num_records++;
+  }
+
+  EXPECT_EQ(expected_results.size(), num_records);
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -342,3 +342,14 @@ RUN cd /opt && \
       ldconfig) && \
     rm -rf /opt/yaml-cpp
 
+# kafka
+RUN cd /opt && \
+    git clone https://github.com/edenhill/librdkafka.git && \
+    (cd librdkafka && \
+     git reset --hard v0.11.4 && \
+     ./configure && \
+     make && \
+     make install && \
+     ldconfig) && \
+    rm -rf librdkafka
+


### PR DESCRIPTION
This is the first change in a series of changes to add the capability of
    tailing kafka messages and ingesting them to rocksdb. The current change
    includes:
    1. KafkaConsumer class: Handles consuming kafka messages using librdkafka
    2. KafkaConsumerPool: Creates a thread pool of KafkaConsumers
    3. KafkaWatcher class: Manages the consumer pools.