### PR TITLE
[kafka-consumer] Remove anonymized namespace and give unique names fo…

### DIFF
--- a/common/kafka/kafka_broker_file_watcher.cpp
+++ b/common/kafka/kafka_broker_file_watcher.cpp
@@ -22,7 +22,7 @@
 #include "glog/logging.h"
 #include "common/file_watcher.h"
 
-namespace {
+namespace kafka {
 
 // Return CSV list of broker("host:port") from the broker serverset local file
 // content. An empty string is returned if it failed to parse the content.
@@ -80,5 +80,5 @@ const std::string& KafkaBrokerFileWatcher::GetKafkaBrokerList() const {
   return kafka_broker_list_;
 }
 
-}  // namespace
+}  // namespace kafka
 

--- a/common/kafka/kafka_broker_file_watcher.h
+++ b/common/kafka/kafka_broker_file_watcher.h
@@ -19,7 +19,7 @@
 #include "folly/RWSpinLock.h"
 
 
-namespace {
+namespace kafka{
 
 class KafkaBrokerFileWatcher {
  public:
@@ -40,4 +40,4 @@ class KafkaBrokerFileWatcher {
   mutable folly::RWSpinLock kafka_broker_list_rw_lock_;
 };
 
-}  // namespace
+}  // kafka namespace

--- a/common/kafka/stats_enum.cpp
+++ b/common/kafka/stats_enum.cpp
@@ -20,9 +20,9 @@
 
 #include "gflags/gflags.h"
 
-DEFINE_string(corpus_type, "", "The corpus type");
-DEFINE_string(index_type, "", "The index type");
-DEFINE_string(normalized_cluster_name, "", "The normalized cluster name");
+DEFINE_string(corpus_type_kafka, "", "The corpus type");
+DEFINE_string(index_type_kafka, "", "The index type");
+DEFINE_string(normalized_cluster_name_kafka, "", "The normalized cluster name");
 DEFINE_string(stats_prefix, "", "Prefix for the stats");
 
 std::string getFullStatsName(const std::string& metric_name,
@@ -31,11 +31,11 @@ std::string getFullStatsName(const std::string& metric_name,
   full_metric_name.append(FLAGS_stats_prefix)
       .append(metric_name)
       .append("_")
-      .append(FLAGS_index_type)
+      .append(FLAGS_index_type_kafka)
       .append("_")
-      .append(FLAGS_corpus_type)
+      .append(FLAGS_corpus_type_kafka)
       .append(" cluster=")
-      .append(FLAGS_normalized_cluster_name);
+      .append(FLAGS_normalized_cluster_name_kafka);
   for (const auto& tag : tags) {
     full_metric_name.append(" ").append(tag);
   }

--- a/common/kafka/stats_enum.cpp
+++ b/common/kafka/stats_enum.cpp
@@ -20,22 +20,15 @@
 
 #include "gflags/gflags.h"
 
-DEFINE_string(corpus_type_kafka, "", "The corpus type");
-DEFINE_string(index_type_kafka, "", "The index type");
-DEFINE_string(normalized_cluster_name_kafka, "", "The normalized cluster name");
-DEFINE_string(stats_prefix, "", "Prefix for the stats");
+DEFINE_string(kafka_stats_prefix, "", "Prefix for the kafka stats");
+DEFINE_string(kafka_stats_suffix, "", "Suffix for the kafka stats");
 
 std::string getFullStatsName(const std::string& metric_name,
-                              const std::initializer_list<std::string>& tags) {
+                             const std::initializer_list<std::string>& tags) {
   std::string full_metric_name;
-  full_metric_name.append(FLAGS_stats_prefix)
+  full_metric_name.append(FLAGS_kafka_stats_prefix)
       .append(metric_name)
-      .append("_")
-      .append(FLAGS_index_type_kafka)
-      .append("_")
-      .append(FLAGS_corpus_type_kafka)
-      .append(" cluster=")
-      .append(FLAGS_normalized_cluster_name_kafka);
+      .append(FLAGS_kafka_stats_suffix);
   for (const auto& tag : tags) {
     full_metric_name.append(" ").append(tag);
   }


### PR DESCRIPTION
…r gflags

1. The anonymous namespace for KafkaWatcher is causing issues, so adding it to the
kafka namespace.
2. Making the gflag names unique so that they don't clash with gflags defined
   by individual services.