### PR TITLE
[StatusServer] Fix query params parsing

### DIFF
--- a/common/stats/status_server.h
+++ b/common/stats/status_server.h
@@ -48,9 +48,8 @@ class StatusServer {
    * (arrays can be passed in as delimited values) and returns a
    * std::string.
    */
-  using EndPointToOPMap =
-      std::map<std::string, std::function<std::string(
-              const std::vector<std::pair<std::string, std::string>>* )>>;
+  using Arguments = std::vector<std::pair<std::string, std::string>>;
+  using EndPointToOPMap = std::map<std::string, std::function<std::string(const Arguments*)>>;
 
   /*!
    * \brief Instantiate a StatusServer.
@@ -81,7 +80,7 @@ class StatusServer {
    * @param end_point The requested end point, including the query.
    * @return The result of the funciton call.
    */
-  std::string GetPageContent(const std::string& end_point);
+  std::string GetPageContent(const std::string& end_point, Arguments* args);
 
   // Stop the HTTP serving daemon. Not currently used.
   // Add to shutdown hook when available.

--- a/common/stats/tests/status_server_test.cpp
+++ b/common/stats/tests/status_server_test.cpp
@@ -87,10 +87,8 @@ TEST(StatusServerTest, BasicTest) {
 
   // Sum
   c = curl_easy_init();
-  std::string str = "?a=10&b=2";
-  std::string url = curl_easy_escape(c, str.c_str(), str.size());
-  std::string server = "http://localhost:9999/sum";
-  curl_easy_setopt(c, CURLOPT_URL, server.append(url).c_str());
+  std::string url = "http://localhost:9999/sum?a=10&b=2";
+  curl_easy_setopt(c, CURLOPT_URL, url.c_str());
   curl_easy_setopt(c, CURLOPT_WRITEFUNCTION, WriteResponse);
   curl_easy_setopt(c, CURLOPT_WRITEDATA, &s);
 
@@ -106,10 +104,46 @@ TEST(StatusServerTest, BasicTest) {
 
   // Divide
   c = curl_easy_init();
-  str = "?divident=10&divisor=2";
-  url = curl_easy_escape(c, str.c_str(), str.size());
+  url = "http://localhost:9999/divide?divident=10&divisor=2";
+  curl_easy_setopt(c, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(c, CURLOPT_WRITEFUNCTION, WriteResponse);
+  curl_easy_setopt(c, CURLOPT_WRITEDATA, &s);
+
+  errornum = curl_easy_perform(c);
+  EXPECT_EQ(errornum, CURLE_OK);
+
+  curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &resp);
+  EXPECT_EQ(resp, MHD_HTTP_OK);
+  EXPECT_EQ(s, "5");
+
+  curl_easy_cleanup(c);
+  s.clear();
+
+  // Sum with escaped query params
+  c = curl_easy_init();
+  std::string params = "?a=10&b=2";
+  params = curl_easy_escape(c, params.c_str(), params.size());
+  std::string server = "http://localhost:9999/sum";
+  curl_easy_setopt(c, CURLOPT_URL, server.append(params).c_str());
+  curl_easy_setopt(c, CURLOPT_WRITEFUNCTION, WriteResponse);
+  curl_easy_setopt(c, CURLOPT_WRITEDATA, &s);
+
+  errornum = curl_easy_perform(c);
+  EXPECT_EQ(errornum, CURLE_OK);
+
+  curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &resp);
+  EXPECT_EQ(resp, MHD_HTTP_OK);
+  EXPECT_EQ(s, "12");
+
+  curl_easy_cleanup(c);
+  s.clear();
+
+  // Divide with escaped query params
+  c = curl_easy_init();
+  params = "?divident=10&divisor=2";
+  params = curl_easy_escape(c, params.c_str(), params.size());
   server = "http://localhost:9999/divide";
-  curl_easy_setopt(c, CURLOPT_URL, server.append(url).c_str());
+  curl_easy_setopt(c, CURLOPT_URL, server.append(params).c_str());
   curl_easy_setopt(c, CURLOPT_WRITEFUNCTION, WriteResponse);
   curl_easy_setopt(c, CURLOPT_WRITEDATA, &s);
 
@@ -134,7 +168,7 @@ TEST(StatusServerTest, BasicTest) {
 
   curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &resp);
   EXPECT_EQ(resp, MHD_HTTP_OK);
-  EXPECT_EQ(s, "Unsupported http path.\n");
+  EXPECT_EQ(s, "Unsupported http path: /failure!\n");
 
   curl_easy_cleanup(c);
 }


### PR DESCRIPTION
microhttpd already handled uri parsing, hence the url `ServeCallback` received already only contains the endpoint string. To gather the query params, we have to use MHD_get_connection_values.

This change has been locally tested on Scorpion.