### PR TITLE
[Thrift] Add new field to keep track of last kafka message timestamp …

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -310,13 +310,16 @@ bool AdminHandler::clearMetaData(const std::string& db_name) {
   return s.ok();
 }
 
-bool AdminHandler::writeMetaData(const std::string& db_name,
-                                 const std::string& s3_bucket,
-                                 const std::string& s3_path) {
+bool AdminHandler::writeMetaData(
+    const std::string& db_name,
+    const std::string& s3_bucket,
+    const std::string& s3_path,
+    const int64_t last_kafka_msg_timestamp_ms) {
   DBMetaData meta;
   meta.db_name = db_name;
   meta.set_s3_bucket(s3_bucket);
   meta.set_s3_path(s3_path);
+  meta.set_last_kafka_msg_timestamp_ms(last_kafka_msg_timestamp_ms);
 
   std::string buffer;
   apache::thrift::CompactSerializer::serialize(meta, &buffer);

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -134,7 +134,8 @@ class AdminHandler : virtual public AdminSvIf {
   bool clearMetaData(const std::string& db_name);
   bool writeMetaData(const std::string& db_name,
                      const std::string& s3_bucket,
-                     const std::string& s3_path);
+                     const std::string& s3_path,
+                     const int64_t last_kafka_msg_timestamp_ms = -1);
 
   std::unique_ptr<ApplicationDBManager> db_manager_;
   RocksDBOptionsGeneratorType rocksdb_options_;

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -23,6 +23,7 @@ struct DBMetaData {
   # hosted by this DB.
   2: optional string s3_bucket,
   3: optional string s3_path,
+  4: optional i64 last_kafka_msg_timestamp_ms,
 }
 
 enum AdminErrorCode {

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -99,12 +99,14 @@ TEST(AdminHandlerTest, MetaData) {
   const std::string db_name = "test_db";
   const std::string s3_bucket = "test_bucket";
   const std::string s3_path = "test_path";
+  const int64_t timestamp_ms = 1560211388899;
   auto meta = handler.getMetaData(db_name);
   EXPECT_EQ(meta.db_name, db_name);
   EXPECT_FALSE(meta.__isset.s3_bucket);
   EXPECT_FALSE(meta.__isset.s3_path);
+  EXPECT_FALSE(meta.__isset.last_kafka_msg_timestamp_ms);
 
-  EXPECT_TRUE(handler.writeMetaData(db_name, s3_bucket, s3_path));
+  EXPECT_TRUE(handler.writeMetaData(db_name, s3_bucket, s3_path, timestamp_ms));
 
   meta = handler.getMetaData(db_name);
   EXPECT_EQ(meta.db_name, db_name);
@@ -112,6 +114,21 @@ TEST(AdminHandlerTest, MetaData) {
   EXPECT_EQ(meta.s3_bucket, s3_bucket);
   EXPECT_TRUE(meta.__isset.s3_path);
   EXPECT_EQ(meta.s3_path, s3_path);
+  EXPECT_TRUE(meta.__isset.last_kafka_msg_timestamp_ms);
+  EXPECT_EQ(meta.last_kafka_msg_timestamp_ms, timestamp_ms);
+
+  EXPECT_TRUE(handler.clearMetaData(db_name));
+
+  // Test last_kafka_msg_timestamp_ms's default value
+  EXPECT_TRUE(handler.writeMetaData(db_name, s3_bucket, s3_path));
+  meta = handler.getMetaData(db_name);
+  EXPECT_EQ(meta.db_name, db_name);
+  EXPECT_TRUE(meta.__isset.s3_bucket);
+  EXPECT_EQ(meta.s3_bucket, s3_bucket);
+  EXPECT_TRUE(meta.__isset.s3_path);
+  EXPECT_EQ(meta.s3_path, s3_path);
+  EXPECT_TRUE(meta.__isset.last_kafka_msg_timestamp_ms);
+  EXPECT_EQ(meta.last_kafka_msg_timestamp_ms, -1);
 
   EXPECT_TRUE(handler.clearMetaData(db_name));
 
@@ -119,6 +136,7 @@ TEST(AdminHandlerTest, MetaData) {
   EXPECT_EQ(meta.db_name, db_name);
   EXPECT_FALSE(meta.__isset.s3_bucket);
   EXPECT_FALSE(meta.__isset.s3_path);
+  EXPECT_FALSE(meta.__isset.last_kafka_msg_timestamp_ms);
 }
 
 TEST(AdminHandlerTest, CheckDB) {


### PR DESCRIPTION
…consumed.

Adding a field to DbMetaData to keep track of the last message timestamp
consumed from kafka. This will be updated periodically in the boostrap model.
It will be unused in Online-Offline model.