### PR TITLE
Periodically write last kafka message's timestamp to meta_db

### DIFF
--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -28,6 +28,7 @@
 #include "common/object_lock.h"
 #include "common/s3util.h"
 #include "rocksdb_admin/application_db_manager.h"
+#include "rocksdb_admin/detail/kafka_spec_manager.h"
 #ifdef PINTEREST_INTERNAL
 // NEVER SET THIS UNLESS PINTEREST INTERNAL USAGE.
 #include "schemas/gen-cpp2/Admin.h"
@@ -151,11 +152,8 @@ class AdminHandler : virtual public AdminSvIf {
   std::unordered_set<std::string> allow_overlapping_keys_segments_;
   // number of the current concurrenty s3 downloadings
   std::atomic<int> num_current_s3_sst_downloadings_;
-  // Map of db_name to kafka watcher
-  std::unordered_map<std::string, std::shared_ptr<KafkaWatcher>>
-    kafka_watcher_map_;
-  // Lock for synchronizing access to kafka_watcher_map_
-  std::mutex kafka_watcher_lock_;
+  folly::FunctionScheduler kafka_ts_updater_;
+  detail::KafkaSpecManager kafka_spec_manager_;
 };
 
 }  // namespace admin

--- a/rocksdb_admin/detail/kafka_spec_manager.h
+++ b/rocksdb_admin/detail/kafka_spec_manager.h
@@ -67,14 +67,14 @@ public:
     return kafka_spec;
   }
 
-  std::shared_ptr<KafkaWatcher> getKafkaWatcher(const std::string& db_name) {
-    std::lock_guard<std::mutex> lock(lock_);
-    return kafka_spec_map_[db_name]->getKafkaWatcher();
-  }
-
   void removeSpec(const std::string& db_name) {
     std::lock_guard<std::mutex> lock(lock_);
     kafka_spec_map_.erase(db_name);
+  }
+
+  std::shared_ptr<KafkaSpec> getSpec(const std::string& db_name) {
+    std::lock_guard<std::mutex> lock(lock_);
+    return kafka_spec_map_[db_name];
   }
 
   bool isSpecPresent(const std::string& db_name) {

--- a/rocksdb_admin/detail/kafka_spec_manager.h
+++ b/rocksdb_admin/detail/kafka_spec_manager.h
@@ -1,0 +1,92 @@
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author rajathprasad (rajathprasad@pinterest.com)
+//
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+class KafkaWatcher;
+
+namespace admin {
+namespace detail {
+
+// Class which contains the kafka variables needed per db.
+class KafkaSpec {
+public:
+  KafkaSpec(std::shared_ptr<KafkaWatcher> kafka_watcher,
+      const int64_t timestamp_ms)
+    : kafka_watcher_(kafka_watcher),
+    last_kafka_message_timestamp_ms_(timestamp_ms) {}
+
+  int64_t getTimestamp() {
+    return last_kafka_message_timestamp_ms_.load();
+  }
+
+  void storeTimestamp(const int64_t timestamp) {
+    last_kafka_message_timestamp_ms_.store(timestamp);
+  }
+
+  std::shared_ptr<KafkaWatcher> getKafkaWatcher() {
+    return kafka_watcher_;
+  }
+
+private:
+  std::shared_ptr<KafkaWatcher> kafka_watcher_;
+  std::atomic<int64_t> last_kafka_message_timestamp_ms_;
+};
+
+// Manages the KafkaSpecs for all db's
+class KafkaSpecManager {
+public:
+  KafkaSpecManager() {};
+
+  std::shared_ptr<KafkaSpec> addSpec(const std::string& db_name,
+      std::shared_ptr<KafkaWatcher> kafka_watcher, const int64_t timestamp_ms) {
+    std::lock_guard<std::mutex> lock(lock_);
+    auto kafka_spec = std::make_shared<KafkaSpec>(kafka_watcher, timestamp_ms);
+    kafka_spec_map_[db_name] = kafka_spec;
+    return kafka_spec;
+  }
+
+  std::shared_ptr<KafkaWatcher> getKafkaWatcher(const std::string& db_name) {
+    std::lock_guard<std::mutex> lock(lock_);
+    return kafka_spec_map_[db_name]->getKafkaWatcher();
+  }
+
+  void removeSpec(const std::string& db_name) {
+    std::lock_guard<std::mutex> lock(lock_);
+    kafka_spec_map_.erase(db_name);
+  }
+
+  bool isSpecPresent(const std::string& db_name) {
+    std::lock_guard<std::mutex> lock(lock_);
+    return kafka_spec_map_.find(db_name) != kafka_spec_map_.end();
+  }
+
+private:
+  std::unordered_map<std::string, std::shared_ptr<KafkaSpec>> kafka_spec_map_;
+  // Lock for synchronizing access to kafka_watcher_map_
+  std::mutex lock_;
+};
+
+} //namespace detail
+} // namespace admin


### PR DESCRIPTION
1. Implement a new KafkaSpecManager class to manage all the objects which are
   required per db (kafka_watcher, last consumed timestamp).
2. Setup a function scheduler to periodically write the last consumed timestamp
   to meta_db. If required in the future, we can have the interval of the
   scheduler to be a config so that each use case can define it's own
   frequency of update.