### PR TITLE
Add tags argument to support attach tags when uploading objects to s3

### DIFF
--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -314,7 +314,10 @@ GetObjectMetadataResponse S3Util::getObjectMetadata(const string &key) {
 
 PutObjectResponse S3Util::putObject(const string& key, const string& local_path, const string& tags) {
   PutObjectRequest object_request;
-  object_request.WithBucket(bucket_).WithKey(key).WithTagging(tags);
+  object_request.WithBucket(bucket_).WithKey(key);
+  if (!tags.empty()) {
+    object_request.WithTagging(tags);
+  }
   auto input_data = Aws::MakeShared<Aws::FStream>("PutObjectInputStream",
                                                   local_path.c_str(),
                                                   std::ios_base::in | std::ios_base::binary);

--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -312,9 +312,9 @@ GetObjectMetadataResponse S3Util::getObjectMetadata(const string &key) {
   return GetObjectMetadataResponse(std::move(metadata), "");
 }
 
-PutObjectResponse S3Util::putObject(const string& key, const string& local_path) {
+PutObjectResponse S3Util::putObject(const string& key, const string& local_path, const string& tags) {
   PutObjectRequest object_request;
-  object_request.WithBucket(bucket_).WithKey(key);
+  object_request.WithBucket(bucket_).WithKey(key).WithTagging(tags);
   auto input_data = Aws::MakeShared<Aws::FStream>("PutObjectInputStream",
                                                   local_path.c_str(),
                                                   std::ios_base::in | std::ios_base::binary);

--- a/common/s3util.h
+++ b/common/s3util.h
@@ -213,7 +213,9 @@ class S3Util {
   GetObjectMetadataResponse getObjectMetadata(const string& key);
 
   // Upload a local file to S3.
-  PutObjectResponse putObject(const string& key, const string& local_path);
+  // Tags: The tag-set for the object. The tag-set must be encoded as URL Query
+  // parameters. (For example, "Key1=Value1")
+  PutObjectResponse putObject(const string& key, const string& local_path, const string& tags="");
 
   // Upload a local file to S3 in async mode and return a future to the operation.
   Aws::S3::Model::PutObjectOutcomeCallable


### PR DESCRIPTION
This can enable s3 tagging to support s3 objects expiration with tags