### PR TITLE
[helix_client] added functionality for helix_client to disconnect Paticipant from helixManager

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -173,7 +173,7 @@ public class Participant {
   }
 
 
-  public Participant(String zkConnectString, String clusterName, String instanceName,
+  private Participant(String zkConnectString, String clusterName, String instanceName,
                      String stateModelType, int port, String postUrl, boolean runSpectator) throws Exception {
     helixManager = HelixManagerFactory.getZKHelixManager(clusterName, instanceName,
         InstanceType.PARTICIPANT, zkConnectString);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -18,9 +18,6 @@
 
 package com.pinterest.rocksplicator;
 
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.cli.CommandLine;
@@ -62,8 +59,6 @@ public class Participant {
   private static final String stateModel = "stateModelType";
   private static final String configPostUrl = "configPostUrl";
   private static final String disableSpectator = "disableSpectator";
-  private static final Lock lock = new ReentrantLock();
-  private static final Condition condition = lock.newCondition();
 
   private static HelixManager helixManager;
   private StateModelFactory<StateModel> stateModelFactory;
@@ -168,19 +163,13 @@ public class Participant {
     properties.put("DOMAIN", domainName + ",instance=" + instanceName);
     helixAdmin.setConfig(scope, properties);
 
-    LOG.error("Participant running, wait for signal before disconnect from helixManager");
-    lock.lock();
-    condition.await();
-    lock.unlock();
-    LOG.error("Disconnect from helixManager");
-    helixManager.disconnect();
+    LOG.error("Participant running");
+    Thread.currentThread().join();
   }
 
-  public static void exitmain() throws Exception {
-    lock.lock();
-    LOG.error("Signal to main");
-    condition.signal();
-    lock.unlock();
+  public static void disconnectHelixManager() throws Exception {
+    LOG.error("Disconnect the helixManager");
+    helixManager.disconnect();
   }
 
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -169,7 +169,9 @@ public class Participant {
 
   public static void disconnectHelixManager() throws Exception {
     LOG.error("Disconnect the helixManager");
-    helixManager.disconnect();
+    if (helixManager != null) {
+      helixManager.disconnect();
+    }
   }
 
 

--- a/rocksdb_admin/helix_client.cpp
+++ b/rocksdb_admin/helix_client.cpp
@@ -117,7 +117,7 @@ void invokeClass(JNIEnv* env,
 
   // The participant main function should never exit
   env->ExceptionDescribe();
-  LOG(ERROR) << "Participant main() exited";
+  CHECK(false) << "Participant main() exited";
 }
 
 } // namespace

--- a/rocksdb_admin/helix_client.cpp
+++ b/rocksdb_admin/helix_client.cpp
@@ -148,11 +148,11 @@ void JoinCluster(const std::string& zk_connect_str,
 }
 
 // Destroy the JVM, which will call the shutdown handler registers
-void ShutdownJVM() {
+void DisconnectHelixManager() {
     JNIEnv* env;
     JavaVM* jvm;
     jclass ParticipantClass;
-    jmethodID exitmainMethod;
+    jmethodID disconnectHelixManagerMethod;
     jsize nVMs;
 
     // Get the a reference to the created javaVM
@@ -161,7 +161,7 @@ void ShutdownJVM() {
     JNI_GetCreatedJavaVMs(buffer, nVMs, &nVMs);
 
     if (nVMs != 1) {
-        LOG(ERROR) << "There are " < nVMs << " created, expected 1";
+        LOG(ERROR) << "There are " << nVMs << " created, expected 1";
         return;
     }
     jvm = buffer[0];
@@ -184,17 +184,17 @@ void ShutdownJVM() {
         return;
     }
 
-    exitmainMethod = env->GetStaticMethodID(ParticipantClass,
-                                            "exitmain",
+    disconnectHelixManagerMethod = env->GetStaticMethodID(ParticipantClass,
+                                            "disconnectHelixManager",
                                             "()V");
-    if (!exitmainMethod) {
+    if (!disconnectHelixManagerMethod) {
         LOG(ERROR) << "Failed to GetStaticMethodID";
         env->ExceptionDescribe();
         return;
     }
 
     LOG(INFO) << "Disconnecting helix manager";
-    env->CallStaticVoidMethod(ParticipantClass, exitmainMethod);
+    env->CallStaticVoidMethod(ParticipantClass, disconnectHelixManagerMethod);
 }
 
 }  // namespace admin

--- a/rocksdb_admin/helix_client.h
+++ b/rocksdb_admin/helix_client.h
@@ -45,4 +45,11 @@ void JoinCluster(const std::string& zk_connect_str,
                  const std::string& config_post_url,
                  const bool disable_spectator = false);
 
+/*
+ * If the participant class is running its main() this function is called, this
+ * function will flip a condition variable in Participant.java that will cause the
+ * main() function to exit and the Participant to disconnect from helix
+ */
+void ShutdownJVM();
+
 }  // namespace admin

--- a/rocksdb_admin/helix_client.h
+++ b/rocksdb_admin/helix_client.h
@@ -46,10 +46,9 @@ void JoinCluster(const std::string& zk_connect_str,
                  const bool disable_spectator = false);
 
 /*
- * If the participant class is running its main() this function is called, this
- * function will flip a condition variable in Participant.java that will cause the
- * main() function to exit and the Participant to disconnect from helix
+ * This function will call helixManager.disconnect() on the static helixManager shared by
+ * the jvm launched in JoinCluster()
  */
-void ShutdownJVM();
+void DisconnectHelixManager();
 
 }  // namespace admin


### PR DESCRIPTION
Tested via private build on canary, here is sample log output (will update when I change the code per Bo's comments)
16:28:40.026 [Thread-9] ERROR rest.rocksplicator.Participant - Signal to main
16:28:40.026 [main] ERROR rest.rocksplicator.Participant - Signal received, unlock the lock
16:28:40.027 [main] ERROR rest.rocksplicator.Participant - Disconnect from helixManager
E0924 16:28:40.051600 17892 helix_client.cpp:113] Participant main() exited