### PR TITLE
Add 'is_kafka_payload_serialized' flag as a function argument instead…

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/BootstrapStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/BootstrapStateModelFactory.java
@@ -211,10 +211,11 @@ public class BootstrapStateModelFactory extends StateModelFactory<StateModel> {
         long replay_timestamp_ms = jsonObject.get("replay_timestamp_ms").getAsLong();
         String kafkaBrokerServersetPath = jsonObject.get("kafka_broker_serverset_path").getAsString();
         String topicName = jsonObject.get("topic_name").getAsString();
+        boolean isKafkaPayloadSerialized = jsonObject.get("is_kafka_payload_serialized").getAsBoolean();
 
         StartMessageIngestionRequest req =
                 new StartMessageIngestionRequest(Utils.getDbName(partitionName), topicName,
-                        kafkaBrokerServersetPath, replay_timestamp_ms);
+                        kafkaBrokerServersetPath, replay_timestamp_ms, isKafkaPayloadSerialized);
         Admin.Client client = Utils.getLocalAdminClient(adminPort);
         client.startMessageIngestion(req);
       } catch (Exception e) {

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1101,7 +1101,7 @@ void AdminHandler::async_tm_startMessageIngestion(
   }
 
   int64_t message_count = 0;
-  const auto should_deserialize = meta.should_deserialize_kafka_payload;
+  const auto should_deserialize = request->is_kafka_payload_serialized;
 
   // With kafka_init_blocking_consume_timeout_ms set to -1, messages from
   // replay_timestamp_ms to the current are synchronously consumed. The

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -23,8 +23,7 @@ struct DBMetaData {
   # hosted by this DB.
   2: optional string s3_bucket,
   3: optional string s3_path,
-  4: optional i64 last_kafka_msg_timestamp_ms,
-  5: optional bool should_deserialize_kafka_payload = false
+  4: optional i64 last_kafka_msg_timestamp_ms
 }
 
 enum AdminErrorCode {
@@ -156,7 +155,8 @@ struct StartMessageIngestionRequest {
   2: required string topic_name,
   3: required string kafka_broker_serverset_path,
   # timestamp which the kafka consumer seeks to
-  4: required i64 replay_timestamp_ms
+  4: required i64 replay_timestamp_ms,
+  5: required bool is_kafka_payload_serialized = false
 }
 
 struct StartMessageIngestionResponse {


### PR DESCRIPTION
… of storing in meta_db.

The convention we want to follow is:
1. For cluster wide configs, use gflags
2. For per segment configs, store it in zk

Since 'is_kafka_payload_serialized' is a per-segment config, read it from zookeeper.