### PR TITLE
add includes in prep for folly upgrade

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -37,6 +37,7 @@
 #include "common/thrift_router.h"
 #include "common/timeutil.h"
 #include "folly/FileUtil.h"
+#include "folly/MoveWrapper.h"
 #include "folly/ScopeGuard.h"
 #include "folly/String.h"
 #include "librdkafka/rdkafkacpp.h"

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -17,6 +17,7 @@
 //
 
 #include <gflags/gflags.h>
+#include "folly/MoveWrapper.h"
 
 #include <chrono>
 #include <string>


### PR DESCRIPTION
This unblocks a folly upgrade for our internal monorepo and is compatible with the current version of Folly that rocksplicator is using.