### PR TITLE
added a NOOP replication db when replication should not be performed

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/BootstrapStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/BootstrapStateModelFactory.java
@@ -124,7 +124,7 @@ public class BootstrapStateModelFactory extends StateModelFactory<StateModel> {
       Utils.checkSanity("OFFLINE", "BOOTSTRAP", message, resourceName, partitionName);
       Utils.logTransitionMessage(message);
 
-      Utils.addDB(Utils.getDbName(partitionName), adminPort);
+      Utils.addDB(Utils.getDbName(partitionName), adminPort, "NOOP");
 
       try {
         zkClient.sync().forPath(Utils.getMetaLocation(cluster, resourceName));

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -119,18 +119,20 @@ public class Utils {
   }
 
   /**
-   * Add a DB as a Slave, and set it upstream to be itself. Do nothing if the DB already exists
+   * Add a db with a specific role.
    * @param dbName
    * @param adminPort
+   * @param dbRole one of SLAVE or NOOP
    */
-  public static void addDB(String dbName, int adminPort) {
-    LOG.error("Add local DB: " + dbName);
+  public static void addDB(String dbName, int adminPort, String dbRole) {
+    LOG.error("Add local DB: " + dbName + " with role " + dbRole);
     Admin.Client client = null;
     AddDBRequest req = null;
     try {
       try {
         client = getLocalAdminClient(adminPort);
         req = new AddDBRequest(dbName, "127.0.0.1");
+        req.setDb_role(dbRole);
         client.addDB(req);
       } catch (AdminException e) {
         if (e.errorCode == AdminErrorCode.DB_EXIST) {
@@ -150,6 +152,14 @@ public class Utils {
     } catch (TException e) {
       LOG.error("AddDB() request failed", e);
     }
+  }
+  /**
+   * Add a DB as a Slave, and set it upstream to be itself. Do nothing if the DB already exists
+   * @param dbName
+   * @param adminPort
+   */
+  public static void addDB(String dbName, int adminPort) {
+    addDB(dbName, adminPort, "SLAVE");
   }
 
   /**

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -124,7 +124,10 @@ public class Utils {
    * @param adminPort
    * @param dbRole one of SLAVE or NOOP
    */
-  public static void addDB(String dbName, int adminPort, String dbRole) {
+  public static void addDB(String dbName, int adminPort, String dbRole) throws RuntimeException {
+    if ((dbRole != "SLAVE") && (dbRole != "NOOP")) {
+      throw new RuntimeException("Invalid db role requested for new db " + dbName + " : " + dbRole);
+    }
     LOG.error("Add local DB: " + dbName + " with role " + dbRole);
     Admin.Client client = null;
     AddDBRequest req = null;

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -473,13 +473,13 @@ void AdminHandler::async_tm_addDB(
   if (request->__isset.db_role) {
     if (request->db_role == "SLAVE") {
       role = replicator::DBRole::SLAVE;
-    } else if (request->db_role == "MASTER") {
-      role = replicator::DBRole::MASTER;
     } else if (request->db_role == "NOOP") {
       role = replicator::DBRole::NOOP;
     } else {
-      // Default behavior is to use SLAVE, so keep that
-      LOG(INFO) << "Invalid role requested to addDB " << request->db_role;
+      e.errorCode = AdminErrorCode::INVALID_DB_ROLE;
+      e.message = std::move(request->db_role);
+      callback.release()->exceptionInThread(std::move(e));
+      return;
     }
   }
 

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -47,6 +47,8 @@ struct AddDBRequest {
   2: required string upstream_ip,
   # if overwrite is true, destroy any rocksdb instance under db_name
   3: optional bool overwrite = false,
+  # if set, add the db to the db_manager with the specified role. one of MASTER, SLAVE, NOOP
+  4: optional string db_role = "SLAVE",
 }
 
 struct AddDBResponse {

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -63,6 +63,7 @@ struct LogExtractor : public rocksdb::WriteBatch::Handler {
 enum class DBRole {
   MASTER,
   SLAVE,
+  NOOP, // Don't perform any replication with this DB
 };
 
 enum class ReturnCode {


### PR DESCRIPTION
For kafka in rocksplicator use cases, we have been noticing that there is some replication latency stats reported. Since the WAL is used when we merge the kafka messages, and by default we add a DB as a slave with itself as upstream, the DBs on a kafka in rocksplicator host will try to periodically pull updates from themselves. With OnlineOffline use cases, the global seqno is never changed, so we don't run into this issue.

The call stack that produces this self replication is

AdminHandler::async_tm_addDB() calls ApplicationDBManager::addDB()
ApplicationDBManager::addDB() calls ApplicationDB::ApplicationDB() 
ApplicationDB::ApplicationDB() constructor calls addDB if (!IsSlave() || upstream_addr_)
RocksDBReplicator::addDB() calls pullFromUpstream() in line 90 if (db::role == SLAVE)	

Thus adding db::role = NOOP will prevent thiss from happening. The other option is to not set the upstream address, but I feel that this reads more cleanly when we explicitly tell rocksplicator not to replicate