### PR TITLE
[rocksdb_env_s3] rocksdb s3 enviroment methods body implementation

### DIFF
--- a/common/rocksdb_env_s3.cpp
+++ b/common/rocksdb_env_s3.cpp
@@ -1,0 +1,457 @@
+/// Copyright 2018 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author ghan (ghan@pinterest.com)
+//
+
+#include "common/rocksdb_env_s3.h"
+
+#include <string>
+
+#include "boost/filesystem.hpp"
+#include "common/rocksdb_glogger/rocksdb_glogger.h"
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+#include "rocksdb/status.h"
+
+DECLARE_bool(s3_direct_io);
+
+namespace rocksdb {
+
+// open a file for sequential reading
+Status S3Env::NewSequentialFile(const std::string& fname,
+                                std::unique_ptr<SequentialFile>* result,
+                                const EnvOptions& options) {
+  assert(s3_util_ != nullptr);
+  result->reset();
+
+  // We read first from local storage and then from S3.
+  auto local_full_path = local_directory_ + GetRelativePath(fname);
+  auto st = posix_env_->NewSequentialFile(local_full_path, result, options);
+
+  if (!st.ok()) {
+    // If file doesnt exist in local, we copy the file to the local storage from S3
+    size_t slash = local_full_path.find_last_of('/');
+    assert(slash != std::string::npos);
+    boost::system::error_code create_err;
+    boost::filesystem::create_directories(local_full_path.substr(0, slash), create_err);
+    if (create_err) {
+      LOG(ERROR) << "Cant create dir in local: " << local_full_path;
+      return Status::IOError();
+    }
+
+    auto resp = s3_util_->getObject(fname, local_full_path, FLAGS_s3_direct_io);
+    if (!resp.Error().empty()) {
+      LOG(ERROR) << "Error happened when copying the file from S3 to local: "
+                 << resp.Error();
+      return Status::IOError();
+    }
+  }
+
+  // we successfully copied the file, try opening it locally now
+  return posix_env_->NewSequentialFile(local_full_path, result, options);
+}
+
+// open a file for random reading
+Status S3Env::NewRandomAccessFile(const std::string& fname,
+                                  std::unique_ptr<RandomAccessFile>* result,
+                                  const EnvOptions& options) {
+  assert(s3_util_ != nullptr);
+  result->reset();
+
+  // We read first from local storage and then from S3.
+  auto local_full_path = local_directory_ + GetRelativePath(fname);
+  auto st = posix_env_->NewRandomAccessFile(local_full_path, result, options);
+
+  if (!st.ok()) {
+    // If file doesnt exist in local, we copy the file to the local storage from S3
+    size_t slash = local_full_path.find_last_of('/');
+    assert(slash != std::string::npos);
+    boost::system::error_code create_err;
+    boost::filesystem::create_directories(local_full_path.substr(0, slash), create_err);
+    if (create_err) {
+      LOG(ERROR) << "Cant create dir in local: " << local_full_path;
+      return Status::IOError();
+    }
+
+    auto resp = s3_util_->getObject(fname, local_full_path, FLAGS_s3_direct_io);
+    if (!resp.Error().empty()) {
+      LOG(ERROR) << "Error happened when copying the file from S3 to local: "
+                 << resp.Error();
+      return Status::IOError();
+    }
+  }
+
+  // we successfully copied the file, try opening it locally now
+  return posix_env_->NewRandomAccessFile(local_full_path, result, options);
+}
+
+// S3WritableFile is a wrapper for writing a file in S3. We will perform the
+// operations in a local tmp file and upload to S3 when closing the file.
+class S3WritableFile : public WritableFile {
+
+ public:
+  S3WritableFile(const std::string& local_fname,
+                 const std::string& s3_fname,
+                 const EnvOptions& options,
+                 S3Env* env,
+                 std::shared_ptr<common::S3Util> s3_util) :
+      fname_(local_fname),
+      s3_fname_(s3_fname),
+      env_(env),
+      s3_util_(s3_util) {
+    auto local_env = env_->GetBaseEnv();
+    auto s = local_env->NewWritableFile(local_fname, &local_file_, options);
+    if (!s.ok()) {
+      LOG(ERROR) << "Error happened when creating writable file in local: " << s.ToString();
+      status_ = s;
+    }
+  }
+
+  virtual ~S3WritableFile() {
+    if (local_file_ != nullptr) {
+      Close();
+    }
+  }
+
+  virtual Status Append(const Slice& data) {
+    assert(status_.ok());
+    // write to the temporary local file
+    return local_file_->Append(data);
+  }
+
+  Status PositionedAppend(const Slice& data, uint64_t offset) {
+    return local_file_->PositionedAppend(data, offset);
+  }
+
+  Status Truncate(uint64_t size) {
+    return local_file_->Truncate(size);
+  }
+
+  Status Fsync() {
+    return local_file_->Fsync();
+  }
+
+  bool IsSyncThreadSafe() const {
+    return local_file_->IsSyncThreadSafe();
+  }
+
+  bool use_direct_io() const {
+    return local_file_->use_direct_io();
+  }
+
+  size_t GetRequiredBufferAlignment() const {
+    return local_file_->GetRequiredBufferAlignment();
+  }
+
+  uint64_t GetFileSize() {
+    return local_file_->GetFileSize();
+  }
+
+  size_t GetUniqueId(char* id, size_t max_size) const {
+    return local_file_->GetUniqueId(id, max_size);
+  }
+
+  Status InvalidateCache(size_t offset, size_t length) {
+    return local_file_->InvalidateCache(offset, length);
+  }
+
+  Status RangeSync(uint64_t offset, uint64_t nbytes) {
+    return local_file_->RangeSync(offset, nbytes);
+  }
+
+  Status Allocate(uint64_t offset, uint64_t len) {
+    return local_file_->Allocate(offset, len);
+  }
+
+  virtual Status Flush() {
+    return local_file_->Flush();
+  }
+
+  virtual Status Sync() {
+    return local_file_->Sync();
+  }
+
+  virtual Status status() {
+    return status_;
+  }
+
+  virtual Status Close() {
+    if (local_file_ == nullptr) {  // already closed
+      return status_;
+    }
+    assert(status_.ok());
+
+    // close local file
+    auto st = local_file_->Close();
+    if (!st.ok()) {
+      LOG(ERROR) << "Error happened when closing the writable file in local: "
+                 << st.ToString();
+      return st;
+    }
+    local_file_.reset();
+
+    // upload local file to S3
+    auto resp = s3_util_->putObject(s3_fname_, fname_);
+    if (!resp.Error().empty()) {
+      LOG(ERROR) << "Error happened when uploading the writable file to S3: "
+                 << resp.Error();
+      return Status::IOError();
+    }
+
+    return Status::OK();
+  }
+
+ private:
+  const std::string fname_;
+  const std::string s3_fname_;
+  S3Env* env_;
+  std::shared_ptr<common::S3Util> s3_util_;
+  Status status_;
+  std::unique_ptr<WritableFile> local_file_;
+};
+
+Status S3Env::NewWritableFile(const std::string& fname,
+                              std::unique_ptr<WritableFile>* result,
+                              const EnvOptions& options) {
+  assert(s3_util_ != nullptr);
+  result->reset();
+
+  std::unique_ptr<S3WritableFile> f(
+      new S3WritableFile(local_directory_ + GetRelativePath(fname), fname, options, this, s3_util_));
+  auto s = f->status();
+  if (!s.ok()) {
+    LOG(ERROR) << "Error happened when creating S3WritableFile: " << s.ToString();;
+    return s;
+  }
+
+  result->reset(dynamic_cast<WritableFile*>(f.release()));
+  return Status::OK();
+}
+
+class S3Directory : public Directory {
+ public:
+  explicit S3Directory(S3Env* env, const std::string& name) : env_(env){
+    status_ = env_->GetBaseEnv()->NewDirectory(name, &posix_dir_);
+  }
+
+  ~S3Directory() {}
+
+  virtual Status Fsync() {
+    if (!status_.ok()) {
+      return status_;
+    }
+    return posix_dir_->Fsync();
+  }
+
+  virtual Status status() { return status_; }
+
+ private:
+  S3Env* env_;
+  Status status_;
+  std::unique_ptr<Directory> posix_dir_;
+};
+
+// S3 has no concepts of directories, so we just have to forward the request to
+// posix_env_ under the S3Directory
+Status S3Env::NewDirectory(const std::string& name,
+                           std::unique_ptr<Directory>* result) {
+  result->reset(nullptr);
+
+  auto local_dir_path = local_directory_ + GetRelativePath(name);
+  // create new object.
+  std::unique_ptr<S3Directory> d(new S3Directory(this, local_dir_path));
+
+  // Check if the path exists in local dir
+  if (!d->status().ok()) {
+    LOG(ERROR) << "Unable to create local dir: " << local_dir_path;
+    return d->status();
+  }
+
+  result->reset(d.release());
+  return Status::OK();
+}
+
+Status S3Env::FileExists(const std::string& fname) {
+  // We read first from local storage and then from S3
+  auto st = posix_env_->FileExists(local_directory_ + GetRelativePath(fname));
+  if (st.IsNotFound()) {
+    auto resp = s3_util_->listObjects(fname);
+    if (!resp.Error().empty() || resp.Body().empty()) {
+      return Status::NotFound();
+    }
+  }
+
+  return Status::OK();
+}
+
+inline std::string ensure_ends_with_pathsep(const std::string& s) {
+  if (!s.empty() && s.back() != '/') {
+    return s + '/';
+  }
+  return s;
+}
+
+Status S3Env::GetChildren(const std::string& path,
+                          std::vector<std::string>* result) {
+  auto formated_path = ensure_ends_with_pathsep(path);
+  // fetch all files using the given path as the key prefix in S3
+  auto resp = s3_util_->listObjects(formated_path);
+  if (!resp.Error().empty()) {
+    LOG(ERROR) << "Error happened when fetching files from S3: "
+               << resp.Error() << " under path: " << formated_path;
+    return Status::IOError();
+  }
+
+  // trim the file name
+  for (auto& v : resp.Body()) {
+    // the path should be a prefix of the fetched value
+    if (v.find(formated_path) == 0) {
+      result->push_back(v.substr(formated_path.size()));
+    }
+  }
+
+  return Status::OK();
+}
+
+Status S3Env::DeleteFile(const std::string& fname) {
+  // first delete the file from s3
+  auto resp = s3_util_->deleteObject(fname);
+  if (!resp.Error().empty()) {
+    LOG(ERROR) << "Error happened when deleting file from S3: "
+               << resp.Error();
+    return Status::IOError();
+  }
+
+  // Do the delete from local filesystem too and ignore the error
+  posix_env_->DeleteFile(local_directory_ + GetRelativePath(fname));
+  return Status::OK();
+}
+
+// S3 has no concepts of directories, so we just have to forward the request to
+// posix_env_
+Status S3Env::CreateDir(const std::string& name) {
+  return posix_env_->CreateDir(local_directory_ + GetRelativePath(name));
+};
+
+// S3 has no concepts of directories, so we just have to forward the request to
+// posix_env_
+Status S3Env::CreateDirIfMissing(const std::string& name) {
+  return posix_env_->CreateDirIfMissing(local_directory_ + GetRelativePath(name));
+};
+
+// S3 has no concepts of directories, so we just have to forward the request to
+// posix_env_
+Status S3Env::DeleteDir(const std::string& name) {
+  return posix_env_->DeleteDir(local_directory_ + GetRelativePath(name));
+};
+
+Status S3Env::GetFileSize(const std::string& fname, uint64_t* size) {
+  Status st;
+  auto local_path = local_directory_ + GetRelativePath(fname);
+  if (posix_env_->FileExists(local_path).ok()) {
+    st = posix_env_->GetFileSize(local_path, size);
+  } else {
+    st = Status::NotFound();
+    auto meta_resp = s3_util_->getObjectSizeAndModTime(fname);
+    if (!meta_resp.Error().empty()) {
+      LOG(ERROR) << "Error happened when querying object size from S3: "
+                 << meta_resp.Error();
+    }
+
+    const auto& size_itr = meta_resp.Body().find("size");
+    if (size_itr != meta_resp.Body().end()) {
+      *size = size_itr->second;
+      st = Status::OK();
+    }
+  }
+
+  return st;
+}
+
+Status S3Env::GetFileModificationTime(const std::string& fname,
+                                      uint64_t* file_mtime) {
+  Status st;
+  auto local_path = local_directory_ + GetRelativePath(fname);
+  if (posix_env_->FileExists(local_path).ok()) {
+    st = posix_env_->GetFileModificationTime(local_path, file_mtime);
+  } else {
+    st = Status::NotFound();
+    auto meta_resp = s3_util_->getObjectSizeAndModTime(fname);
+    if (!meta_resp.Error().empty()) {
+      LOG(ERROR) << "Error happened when querying object ModTime from S3: "
+                 << meta_resp.Error();
+    }
+
+    const auto& mtime_itr = meta_resp.Body().find("last-modified");
+    if (mtime_itr != meta_resp.Body().end()) {
+      *file_mtime = mtime_itr->second;
+      st = Status::OK();
+    }
+  }
+
+  return st;
+}
+
+// The rename is not atomic. S3 does not support renaming natively, so
+// we need to copy all the objects with src path as prefix to the ones with target
+// path as prefix and then delete the original files
+Status S3Env::RenameFile(const std::string& src, const std::string& target) {
+  // first fetch all files using the given src path as the key prefix in S3
+  auto resp = s3_util_->listObjects(src);
+  if (!resp.Error().empty()) {
+    LOG(ERROR) << "Error happened when fetching files from S3: "
+               << resp.Error() << " under path: " << src;
+    return Status::IOError();
+  }
+
+  // copy the files to the target position
+  for (auto& v : resp.Body()) {
+    // Our path should be a prefix of the fetched value
+    if (v.find(src) == 0) {
+      s3_util_->copyObject(v, target + v.substr(src.size()));
+    }
+  }
+
+  // delete the files in the old position
+  for (auto& v : resp.Body()) {
+    // Our path should be a prefix of the fetched value
+    if (v.find(src) == 0) {
+      s3_util_->deleteObject(v);
+    }
+  }
+
+  // Do the rename on local filesystem too
+  return posix_env_->RenameFile(local_directory_ + GetRelativePath(src), local_directory_ + GetRelativePath(target));
+}
+
+Status S3Env::LockFile(const std::string& fname, FileLock** lock) {
+  // there isn's a very good way to atomically check and create
+  // a file via libs3
+  *lock = nullptr;
+  return Status::OK();
+}
+
+Status S3Env::UnlockFile(FileLock* lock) {
+  return Status::OK();
+}
+
+Status S3Env::NewLogger(const std::string& fname, std::shared_ptr<Logger>* result) {
+  common::RocksdbGLogger* logger = new common::RocksdbGLogger();
+  result->reset(logger);
+  return Status::OK();
+}
+
+}  // namespace rocksdb

--- a/common/rocksdb_env_s3.h
+++ b/common/rocksdb_env_s3.h
@@ -26,7 +26,6 @@
 #include <pthread.h>
 
 #include "common/s3util.h"
-#include "common/sys_time.h"
 #include "rocksdb/env.h"
 #include "rocksdb/status.h"
 
@@ -49,16 +48,27 @@ class S3FatalException : public std::exception {
 /**
  * The S3 environment for rocksdb. This class overrides all the
  * file/dir access methods and delegates the thread-mgmt methods to the
- * default posix environment, which is similar as rocksdb::HdfsEnv.
+ * default posix environment, which is similar as rocksdb::HdfsEnv. The S3Env
+ * could be only used for the rocksdb backup/restore process by rocksdb::BackupEngine,
+ * and can't be used as an env in the purpose of creating the rocksdb instance in the cloud.
+ * During the process,  all the file are immutable, so there are file operations like read,
+ * copy and delete but no modification. The implementation is very straight-forward, for the
+ * backup, it will first backup files to a local dir and then upload to s3. And for restore,
+ * it will first download latest backup to a local dir from s3, then perform the restore.
  */
 class S3Env : public Env {
 
  public:
-  explicit S3Env(std::shared_ptr<common::S3Util> s3_util) : s3_util_(std::move(s3_util)) {
+  explicit S3Env(const std::string& s3_key_prefix,
+                 const std::string& local_directory,
+                 std::shared_ptr<common::S3Util> s3_util) :
+      s3_key_prefix_(s3_key_prefix),
+      local_directory_(local_directory),
+      s3_util_(std::move(s3_util)) {
     posix_env_ = Env::Default();
   }
 
-  virtual ~S3Env();
+  virtual ~S3Env() {}
 
   Status NewSequentialFile(const std::string& fname,
                            std::unique_ptr<SequentialFile>* result,
@@ -173,7 +183,13 @@ class S3Env : public Env {
 
   uint64_t GetThreadID() const override { return S3Env::gettid(); }
 
+  Env* GetBaseEnv() { return posix_env_; }
+
  private:
+  // s3 object key prefix
+  const std::string s3_key_prefix_;
+  // Local directory to temporarily store the files downloaded from/uploading to S3
+  const std::string local_directory_;
   // S3 util used for accessing AWS S3
   std::shared_ptr<common::S3Util> s3_util_;
   // This object is derived from Env, but not from
@@ -181,6 +197,12 @@ class S3Env : public Env {
   // object here so that we can use posix timers,
   // posix threads, etc.
   Env* posix_env_;
+
+  inline std::string GetRelativePath(
+      const std::string &absolute_path = "") const {
+    assert(absolute_path.size() > s3_key_prefix_.size() + 1);
+    return absolute_path.substr(s3_key_prefix_.size() + 1);
+  }
 
 };
 

--- a/common/s3util.h
+++ b/common/s3util.h
@@ -152,7 +152,9 @@ using ListObjectsResponse = S3UtilResponse<vector<string>>;
 using ListObjectsResponseV2 = S3UtilResponse<ListObjectsResponseV2Body>;
 using GetObjectsResponse = S3UtilResponse<vector<GetObjectResponse>>;
 using GetObjectMetadataResponse = S3UtilResponse<map<string, string>>;
-
+using GetObjectSizeAndModTimeResponse = S3UtilResponse<map<string, uint64_t>>;
+using CopyObjectResponse = S3UtilResponse<bool>;
+using DeleteObjectResponse = S3UtilResponse<bool>;
 
 class S3Util {
  public:
@@ -212,6 +214,9 @@ class S3Util {
   // Now contains md5 and content-length of the s3 object
   GetObjectMetadataResponse getObjectMetadata(const string& key);
 
+  // Get the size and last modified time(ms) of an object.
+  GetObjectSizeAndModTimeResponse getObjectSizeAndModTime(const string& key);
+
   // Upload a local file to S3.
   // Tags: The tag-set for the object. The tag-set must be encoded as URL Query
   // parameters. (For example, "Key1=Value1")
@@ -220,6 +225,12 @@ class S3Util {
   // Upload a local file to S3 in async mode and return a future to the operation.
   Aws::S3::Model::PutObjectOutcomeCallable
   putObjectCallable(const string& key, const string& local_path);
+
+  // Copy the object from one location to another location in the same bucket of S3.
+  CopyObjectResponse copyObject(const string& src, const string& target);
+
+  // Delete an object from S3.
+  DeleteObjectResponse deleteObject(const string& key);
 
 
   // Some utility methods

--- a/rocksdb_admin/tests/CMakeLists.txt
+++ b/rocksdb_admin/tests/CMakeLists.txt
@@ -4,8 +4,9 @@ add_executable(sst_binary sst_binary.cpp)
 target_link_libraries(sst_binary rocksdb_admin rocksdb_admin_detail)
 
 file(GLOB TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*_test.cpp)
-get_filename_component(EXCLUDE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/hbase_backup_integration_test.cpp ABSOLUTE)
-list(REMOVE_ITEM TEST_SOURCES "${EXCLUDE_FILES}")
+get_filename_component(EXCLUDE_HBASE_TEST_FILE ${CMAKE_CURRENT_SOURCE_DIR}/hbase_backup_integration_test.cpp ABSOLUTE)
+get_filename_component(EXCLUDE_S3_TEST_FILE ${CMAKE_CURRENT_SOURCE_DIR}/s3_backup_integration_test.cpp ABSOLUTE)
+list(REMOVE_ITEM TEST_SOURCES "${EXCLUDE_HBASE_TEST_FILE}" "${EXCLUDE_S3_TEST_FILE}")
 
 foreach(testsourcefile ${TEST_SOURCES})
   get_filename_component(testname ${testsourcefile} NAME_WE)
@@ -16,3 +17,6 @@ endforeach(testsourcefile ${TEST_SOURCES})
 
 add_executable(hbase_backup_integration_test hbase_backup_integration_test.cpp)
 target_link_libraries(hbase_backup_integration_test gtest rocksdb_admin boost_filesystem rocksdb_glogger kafka_consumer rdkafka++)
+
+add_executable(s3_backup_integration_test s3_backup_integration_test.cpp)
+target_link_libraries(s3_backup_integration_test common gtest rocksdb_admin boost_filesystem rocksdb_glogger kafka_consumer rdkafka++)

--- a/rocksdb_admin/tests/s3_backup_integration_test.cpp
+++ b/rocksdb_admin/tests/s3_backup_integration_test.cpp
@@ -1,0 +1,149 @@
+/// Copyright 2016 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author ghan (ghan@pinterest.com)
+//
+
+#include "rocksdb_admin/admin_handler.h"
+
+#include "common/rocksdb_env_s3.h"
+#include "common/rocksdb_glogger/rocksdb_glogger.h"
+#include "common/s3util.h"
+#include "boost/filesystem.hpp"
+#include "gtest/gtest.h"
+#include "rocksdb/db.h"
+#include "rocksdb/env.h"
+#include "rocksdb/utilities/backupable_db.h"
+
+using rocksdb::BackupableDBOptions;
+using rocksdb::BackupEngine;
+using rocksdb::DB;
+using rocksdb::DestroyDB;
+using rocksdb::Env;
+using rocksdb::S3Env;
+using rocksdb::Options;
+using rocksdb::ReadOptions;
+using rocksdb::SequenceNumber;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+
+
+DEFINE_string(s3_backup_dir, "tmp/backup_test", "The s3 key prefix for backup");
+
+DEFINE_string(s3_bucket, "pinterest-realpin", "The s3 bucket");
+
+DEFINE_string(local_backup_dir, "/tmp/backup_test/backup/", "");
+
+DEFINE_string(local_restore_dir, "/tmp/backup_test/restore/", "");
+
+DEFINE_string(original_db_path, "/tmp/test_s3_backup_original",
+              "The dir for the original rocksdb instance");
+
+DEFINE_string(restored_db_path, "/tmp/test_s3_backup_copy",
+              "The dir for the restored racksdb instance");
+
+// helper function to open a rocksdb instance
+unique_ptr<DB> OpenDB(const string& path, bool error_if_exists = false) {
+  Options options;
+  options.create_if_missing = true;
+  options.error_if_exists = error_if_exists;
+  options.WAL_size_limit_MB = 100;
+  DB* db;
+  auto status = DB::Open(options, path, &db);
+  EXPECT_TRUE(status.ok());
+  return unique_ptr<DB>(db);
+}
+
+unique_ptr<DB> CleanAndOpenDB(const string& path) {
+  Options options;
+  auto status = DestroyDB(path, options);
+  EXPECT_TRUE(status.ok());
+  return OpenDB(path, true);
+}
+
+TEST(S3BackupRestoreTest, Basics) {
+  boost::system::error_code remove_err;
+  boost::system::error_code create_err;
+  boost::filesystem::remove_all(FLAGS_local_backup_dir, remove_err);
+  boost::filesystem::create_directories(FLAGS_local_backup_dir, create_err);
+  boost::filesystem::remove_all(FLAGS_local_restore_dir, remove_err);
+  boost::filesystem::create_directories(FLAGS_local_restore_dir, create_err);
+  EXPECT_FALSE(remove_err || create_err);
+  SCOPE_EXIT {
+      boost::filesystem::remove_all(FLAGS_local_backup_dir, remove_err);
+      boost::filesystem::remove_all(FLAGS_local_restore_dir, remove_err);
+  };
+  EXPECT_FALSE(remove_err || create_err);
+
+  int expected_seq_no = 10;
+
+  // create a new db
+  auto original_db = CleanAndOpenDB(FLAGS_original_db_path);
+  for (int i = 0; i < expected_seq_no; ++i) {
+    EXPECT_EQ(original_db->GetLatestSequenceNumber(), i);
+    auto status = original_db->Put(rocksdb::WriteOptions(),
+                    "key" + to_string(i), "value" + to_string(i));
+    EXPECT_TRUE(status.ok());
+  }
+
+  // back up db. backup can be found in the s3 by using the following command
+  // aws s3 ls s3://FLAGS_s3_bucket/FLAGS_s3_backup_dir
+  auto local_s3_util = common::S3Util::BuildS3Util(50, FLAGS_s3_bucket);
+  Env* backup_s3_env = new rocksdb::S3Env(FLAGS_s3_backup_dir, FLAGS_local_backup_dir, local_s3_util);
+  unique_ptr<Env> backup_s3_env_holder(backup_s3_env);
+
+  BackupableDBOptions backup_options(FLAGS_s3_backup_dir);
+  backup_options.backup_env = backup_s3_env;
+  common::RocksdbGLogger logger;
+  backup_options.info_log = &logger;
+  backup_options.max_background_operations = 1;
+
+  BackupEngine* backup_engine;
+  auto status = BackupEngine::Open(Env::Default(), backup_options, &backup_engine);
+  EXPECT_TRUE(status.ok());
+  unique_ptr<BackupEngine> backup_engine_holder(backup_engine);
+
+  status = backup_engine->CreateNewBackup(original_db.get());
+  EXPECT_TRUE(status.ok());
+
+  // restore db
+  Env* restore_s3_env = new rocksdb::S3Env(FLAGS_s3_backup_dir, FLAGS_local_restore_dir, local_s3_util);
+  unique_ptr<Env> restore_s3_env_holder(restore_s3_env);
+  backup_options.backup_env = restore_s3_env;
+
+  BackupEngine* restore_engine;
+  status = BackupEngine::Open(Env::Default(), backup_options, &restore_engine);
+  EXPECT_TRUE(status.ok());
+  unique_ptr<BackupEngine> restore_engine_holder(restore_engine);
+  status = restore_engine->RestoreDBFromLatestBackup(FLAGS_restored_db_path, FLAGS_restored_db_path);
+  EXPECT_TRUE(status.ok());
+
+  // compare the original db with the restored db
+  auto restored_db = OpenDB(FLAGS_restored_db_path);
+  EXPECT_EQ(restored_db->GetLatestSequenceNumber(), expected_seq_no);
+  for (int i = 0; i < expected_seq_no; ++i) {
+    string value;
+    status = restored_db->Get(ReadOptions(), "key" + to_string(i), &value);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(value, "value" + to_string(i));  
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
1. We will rely on the local posix env for file opeartions: read, write,
creating, deletion etc
2. For read operations, we will first copy the files from S3 to local then
perform the read via posix_env
3. For write operations, we will first perform the write in the local tmp files,
and then copy them to s3 before closing. Due to the this s3 env will be only
used for storing backups, so this behaviour should be safe.