### PR TITLE
Explicitly set https central repositories in pom.xml

### DIFF
--- a/cluster_management/pom.xml
+++ b/cluster_management/pom.xml
@@ -104,4 +104,18 @@
       <version>1.7.25</version>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>central</id>
+      <url>https://repo1.maven.org/maven2/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>


### PR DESCRIPTION
If repositories are not set then maven defaults to fetch from the central repo. Set central repositories with https URL for old versions of maven that don't use http.