### PR TITLE
[cluster management] add helix task into rocksplicator cluster management

### DIFF
--- a/cluster_management/pom.xml
+++ b/cluster_management/pom.xml
@@ -1,5 +1,6 @@
-<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.pinterest.rocksplicator</groupId>
@@ -68,6 +69,11 @@
       <version>1.1.1</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.8</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.1</version>
@@ -80,7 +86,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -102,6 +108,47 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.25</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>6.0.1</version>
+    </dependency>
+    <!--<dependency>-->
+      <!--<groupId>org.mockito</groupId>-->
+      <!--<artifactId>mockito-all</artifactId>-->
+      <!--<version>1.9.5</version>-->
+    <!--</dependency>-->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.8.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.7.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>1.7.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-easymock</artifactId>
+      <version>1.7.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.helix</groupId>
+      <artifactId>helix-core</artifactId>
+      <version>0.8.4</version>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigAndJobStateGenerator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigAndJobStateGenerator.java
@@ -1,0 +1,64 @@
+package com.pinterest.rocksplicator;
+
+import org.apache.helix.HelixConstants;
+import org.apache.helix.HelixManager;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.api.listeners.PreFetch;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.task.TaskDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class ConfigAndJobStateGenerator extends Generator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JobStateGenerator.class);
+
+  // params to update task related states
+  private final String configPostUrl;
+  private final String statePostUrl;
+
+  public ConfigAndJobStateGenerator(String clusterName, HelixManager helixManager,
+                                    String configPostUrl, String statePostUrl) {
+    super(clusterName, helixManager);
+
+    this.dataParameters.put("author", "WorkflowSateGenerator");
+    this.dataParameters.put("comment", "new shard config and job states");
+    // FIXME: add as general provied url
+    this.configPostUrl = configPostUrl;
+    this.statePostUrl = statePostUrl;
+    this.driver = new TaskDriver(helixManager);
+  }
+
+  @Override
+  public void onCallback(NotificationContext notificationContext) {
+    LOG.error("Received notification: " + notificationContext.getChangeType());
+    if (notificationContext.getChangeType() == HelixConstants.ChangeType.EXTERNAL_VIEW) {
+      generateConfigAndJobState();
+    } else if (notificationContext.getChangeType() == HelixConstants.ChangeType.INSTANCE_CONFIG) {
+      if (updateDisabledHosts()) {
+        generateShardConfig();
+      }
+    }
+  }
+
+  @Override
+  @PreFetch(enabled = false)
+  public void onExternalViewChange(List<ExternalView> externalViewList,
+                                   NotificationContext changeContext) {
+    generateConfigAndJobState();
+  }
+
+  private void generateConfigAndJobState() {
+    String newConfigContent = getShardConfig();
+    postToUrl(newConfigContent, configPostUrl);
+    String newJobStateContent = getJobStateConfig();
+    postToUrl(newJobStateContent, statePostUrl);
+  }
+  
+  private void generateShardConfig() {
+    String newContent = getShardConfig();
+    postToUrl(newContent, configPostUrl);
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
@@ -19,54 +19,26 @@
 package com.pinterest.rocksplicator;
 
 import org.apache.helix.api.listeners.PreFetch;
-import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixConstants;
 import org.apache.helix.HelixManager;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
-import org.apache.helix.participant.CustomCodeCallbackHandler;
-import org.apache.helix.spectator.RoutingTableProvider;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
-public class ConfigGenerator extends RoutingTableProvider implements CustomCodeCallbackHandler {
+public class ConfigGenerator extends Generator {
   private static final Logger LOG = LoggerFactory.getLogger(ConfigGenerator.class);
-
-  private final String clusterName;
-  private HelixManager helixManager;
-  private Map<String, String> hostToHostWithDomain;
-  private final String postUrl;
-  private JSONObject dataParameters;
-  private String lastPostedContent;
-  private Set<String> disabledHosts;
+  
+  private final String configPostUrl;
 
   public ConfigGenerator(String clusterName, HelixManager helixManager, String configPostUrl) {
-    this.clusterName = clusterName;
-    this.helixManager = helixManager;
-    this.hostToHostWithDomain = new HashMap<String, String>();
-    this.postUrl = configPostUrl;
-    this.dataParameters = new JSONObject();
-    this.dataParameters.put("config_version", "v3");
+    super(clusterName, helixManager);
+    this.configPostUrl = configPostUrl;
     this.dataParameters.put("author", "ConfigGenerator");
     this.dataParameters.put("comment", "new shard config");
-    this.dataParameters.put("content", "{}");
-    this.lastPostedContent = null;
-    this.disabledHosts = new HashSet<>();
   }
 
   @Override
@@ -97,144 +69,8 @@ public class ConfigGenerator extends RoutingTableProvider implements CustomCodeC
   }
 
   private void generateShardConfig() {
-    HelixAdmin admin = helixManager.getClusterManagmentTool();
-
-    List<String> resources = admin.getResourcesInCluster(clusterName);
-
-    Set<String> existingHosts = new HashSet<String>();
-
-    // compose cluster config
-    JSONObject config = new JSONObject();
-    for (String resource : resources) {
-      // Resources starting with PARTICIPANT_LEADER is for HelixCustomCodeRunner
-      if (resource.startsWith("PARTICIPANT_LEADER")) {
-        continue;
-      }
-
-      ExternalView externalView = admin.getResourceExternalView(clusterName, resource);
-      Set<String> partitions = externalView.getPartitionSet();
-
-      // compose resource config
-      JSONObject resourceConfig = new JSONObject();
-      String partitionsStr = externalView.getRecord().getSimpleField("NUM_PARTITIONS");
-      resourceConfig.put("num_shards", Integer.parseInt(partitionsStr));
-
-      // build host to partition list map
-      Map<String, List<String>> hostToPartitionList = new HashMap<String, List<String>>();
-      for (String partition : partitions) {
-        String[] parts = partition.split("_");
-        String partitionNumber =
-            String.format("%05d", Integer.parseInt(parts[parts.length - 1]));
-        Map<String, String> hostToState = externalView.getStateMap(partition);
-        for (Map.Entry<String, String> entry : hostToState.entrySet()) {
-          existingHosts.add(entry.getKey());
-
-          if (disabledHosts.contains(entry.getKey())) {
-            // exclude disabled hosts from the shard map config
-            continue;
-          }
-
-          String state = entry.getValue();
-          if (!state.equalsIgnoreCase("ONLINE") &&
-              !state.equalsIgnoreCase("MASTER") &&
-              !state.equalsIgnoreCase("SLAVE")) {
-            // Only ONLINE, MASTER and SLAVE states are ready for serving traffic
-            continue;
-          }
-
-          String hostWithDomain = getHostWithDomain(entry.getKey());
-          List<String> partitionList = hostToPartitionList.get(hostWithDomain);
-          if (partitionList == null) {
-            partitionList = new ArrayList<String>();
-            hostToPartitionList.put(hostWithDomain, partitionList);
-          }
-
-          if (state.equalsIgnoreCase("SLAVE")) {
-            partitionList.add(partitionNumber + ":S");
-          } else if (state.equalsIgnoreCase("MASTER")) {
-            partitionList.add(partitionNumber + ":M");
-          } else {
-            partitionList.add(partitionNumber);
-          }
-        }
-      }
-
-      // Add host to partition list map to the resource config
-      for (Map.Entry<String, List<String>> entry : hostToPartitionList.entrySet()) {
-        JSONArray jsonArray = new JSONArray();
-        for (String p : entry.getValue()) {
-          jsonArray.add(p);
-        }
-
-        resourceConfig.put(entry.getKey(), jsonArray);
-      }
-
-      // add the resource config to the cluster config
-      config.put(resource, resourceConfig);
-    }
-
-    // remove host that doesn't exist in the ExternalView from hostToHostWithDomain
-    hostToHostWithDomain.keySet().retainAll(existingHosts);
-
-    String newContent = config.toString();
-    if (lastPostedContent != null && lastPostedContent.equals(newContent)) {
-      LOG.error("Identical external view observed, skip updating config.");
-      return;
-    }
-
-    // Write the config to ZK
-    LOG.error("Generating a new shard config...");
-
-    this.dataParameters.remove("content");
-    this.dataParameters.put("content", newContent);
-    HttpPost httpPost = new HttpPost(this.postUrl);
-    try {
-      httpPost.setEntity(new StringEntity(this.dataParameters.toString()));
-      HttpResponse response = new DefaultHttpClient().execute(httpPost);
-      if (response.getStatusLine().getStatusCode() == 200) {
-        lastPostedContent = newContent;
-        LOG.error("Succeed to generate a new shard config, sleep for 2 seconds");
-        TimeUnit.SECONDS.sleep(2);
-      } else {
-        LOG.error(response.getStatusLine().getReasonPhrase());
-      }
-    } catch (Exception e) {
-      LOG.error("Failed to post the new config", e);
-    }
+    String newContent = getShardConfig();
+    postToUrl(newContent, configPostUrl);
   }
 
-  private String getHostWithDomain(String host) {
-    String hostWithDomain = hostToHostWithDomain.get(host);
-    if (hostWithDomain != null) {
-      return hostWithDomain;
-    }
-
-    // local cache missed, read from ZK
-    HelixAdmin admin = helixManager.getClusterManagmentTool();
-    InstanceConfig instanceConfig = admin.getInstanceConfig(clusterName, host);
-    String domain = instanceConfig.getDomain();
-    String[] parts = domain.split(",");
-    String az = parts[0].split("=")[1];
-    String pg = parts[1].split("=")[1];
-    hostWithDomain = host.replace('_', ':') + ":" + az + "_" + pg;
-    hostToHostWithDomain.put(host, hostWithDomain);
-    return hostWithDomain;
-  }
-
-  // update disabledHosts, return true if there is any changes
-  private boolean updateDisabledHosts() {
-    HelixAdmin admin = helixManager.getClusterManagmentTool();
-
-    Set<String> latestDisabledInstances = new HashSet<>(
-        admin.getInstancesInClusterWithTag(clusterName, "disabled"));
-
-    if (disabledHosts.equals(latestDisabledInstances)) {
-      // no changes
-      LOG.error("No changes to disabled instances");
-      return false;
-    }
-
-    disabledHosts = latestDisabledInstances;
-    return true;
-  }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Generator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Generator.java
@@ -1,0 +1,380 @@
+package com.pinterest.rocksplicator;
+
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.participant.CustomCodeCallbackHandler;
+import org.apache.helix.spectator.RoutingTableProvider;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.task.WorkflowContext;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public abstract class Generator extends RoutingTableProvider implements CustomCodeCallbackHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Generator.class);
+
+  protected final String clusterName;
+  protected HelixManager helixManager;
+  protected TaskDriver driver;
+  protected Map<String, String> hostToHostWithDomain;
+  protected Set<String> disabledHosts;
+  protected JSONObject dataParameters;
+  protected Map<String, String> lastPostedContents;
+
+  public Generator(String clusterName, HelixManager helixManager) {
+    this.clusterName = clusterName;
+    this.helixManager = helixManager;
+    this.driver = null;
+    this.hostToHostWithDomain = new HashMap<>();
+    this.disabledHosts = new HashSet<>();
+    this.dataParameters = new JSONObject();
+    this.dataParameters.put("config_version", "v3");
+    this.dataParameters.put("author", "Generator");
+    this.dataParameters.put("comment", "new config");
+    this.dataParameters.put("content", "{}");
+    this.lastPostedContents = new HashMap<>();
+  }
+
+  /**
+   * generate db resources shard map
+   */
+  public String getShardConfig() {
+    HelixAdmin admin = helixManager.getClusterManagmentTool();
+
+    // get the resource from idealstate
+    List<String> resources = admin.getResourcesInCluster(clusterName);
+    List<String> db_resources = filterOutWfAndJobs(resources);
+
+    Set<String> existingHosts = new HashSet<String>();
+
+    // compose cluster config
+    JSONObject config = new JSONObject();
+    for (String resource : db_resources) {
+      // Resources starting with PARTICIPANT_LEADER is for HelixCustomCodeRunner
+      if (resource.startsWith("PARTICIPANT_LEADER")) {
+        continue;
+      }
+
+      LOG.error(
+          "Config generator try to get partitions from externalView for resource: " + resource);
+
+      ExternalView externalView = admin.getResourceExternalView(clusterName, resource);
+      Set<String> partitions = externalView.getPartitionSet();
+
+      // compose resource config
+      JSONObject resourceConfig = new JSONObject();
+      String partitionsStr = externalView.getRecord().getSimpleField("NUM_PARTITIONS");
+      resourceConfig.put("num_shards", Integer.parseInt(partitionsStr));
+
+      // build host to partition list map
+      Map<String, List<String>> hostToPartitionList = new HashMap<String, List<String>>();
+      for (String partition : partitions) {
+        String[] parts = partition.split("_");
+        String partitionNumber =
+            String.format("%05d", Integer.parseInt(parts[parts.length - 1]));
+        Map<String, String> hostToState = externalView.getStateMap(partition);
+        for (Map.Entry<String, String> entry : hostToState.entrySet()) {
+          existingHosts.add(entry.getKey());
+
+          if (disabledHosts.contains(entry.getKey())) {
+            // exclude disabled hosts from the shard map config
+            continue;
+          }
+
+          String state = entry.getValue();
+          if (!state.equalsIgnoreCase("ONLINE") &&
+              !state.equalsIgnoreCase("MASTER") &&
+              !state.equalsIgnoreCase("SLAVE")) {
+            // Only ONLINE, MASTER and SLAVE states are ready for serving traffic
+            continue;
+          }
+
+          String hostWithDomain = getHostWithDomain(entry.getKey());
+          List<String> partitionList = hostToPartitionList.get(hostWithDomain);
+          if (partitionList == null) {
+            partitionList = new ArrayList<String>();
+            hostToPartitionList.put(hostWithDomain, partitionList);
+          }
+
+          if (state.equalsIgnoreCase("SLAVE")) {
+            partitionList.add(partitionNumber + ":S");
+          } else if (state.equalsIgnoreCase("MASTER")) {
+            partitionList.add(partitionNumber + ":M");
+          } else {
+            partitionList.add(partitionNumber);
+          }
+        }
+      }
+
+      // Add host to partition list map to the resource config
+      for (Map.Entry<String, List<String>> entry : hostToPartitionList.entrySet()) {
+        JSONArray jsonArray = new JSONArray();
+        for (String p : entry.getValue()) {
+          jsonArray.add(p);
+        }
+
+        resourceConfig.put(entry.getKey(), jsonArray);
+      }
+
+      // add the resource config to the cluster config
+      config.put(resource, resourceConfig);
+    }
+
+    // remove host that doesn't exist in the ExternalView from hostToHostWithDomain
+    hostToHostWithDomain.keySet().retainAll(existingHosts);
+
+    return config.toString();
+  }
+
+  public String getHostWithDomain(String host) {
+    String hostWithDomain = hostToHostWithDomain.get(host);
+    if (hostWithDomain != null) {
+      return hostWithDomain;
+    }
+
+    // local cache missed, read from ZK
+    HelixAdmin admin = helixManager.getClusterManagmentTool();
+    InstanceConfig instanceConfig = admin.getInstanceConfig(clusterName, host);
+    String domain = instanceConfig.getDomain();
+    String[] parts = domain.split(",");
+    String az = parts[0].split("=")[1];
+    String pg = parts[1].split("=")[1];
+    hostWithDomain = host.replace('_', ':') + ":" + az + "_" + pg;
+    hostToHostWithDomain.put(host, hostWithDomain);
+    return hostWithDomain;
+  }
+
+
+  /**
+   * update disabledHosts, return true if there is any changes
+   *
+   * when host tagged with "disabled", new config generate to exclude the disabled host.
+   * However, if cluster is in maintenance mode, no new config generate, need first clean up
+   * disabled hosts, then, disable maintenance mode to rebalance resources.
+   * TODO: if cluster is not in maintenance mode, "disabled" hosts have already been excluded
+   * during resource rebalance; shouldn't rebalance again upon "disabled" hosts clean up.
+   */
+  public boolean updateDisabledHosts() {
+    HelixAdmin admin = helixManager.getClusterManagmentTool();
+
+    Set<String> latestDisabledInstances = new HashSet<>(
+        admin.getInstancesInClusterWithTag(clusterName, "disabled"));
+
+    if (disabledHosts.equals(latestDisabledInstances)) {
+      // no changes
+      LOG.error("No changes to disabled instances");
+      return false;
+    }
+
+    disabledHosts = latestDisabledInstances;
+    return true;
+  }
+
+  /**
+   * filter out workflows and jobs from helix resources, only return db resources from ideal states
+   *
+   * db_resource and wf are guaranteed to be unique, bcz wf is treated as "resource" in helix,
+   * no db_resource and wf are allowed with same name during db_resource or wf creation
+   */
+  public List<String> filterOutWfAndJobs(List<String> resources) {
+    List<String> db_resources = new ArrayList<>();
+
+    Map<String, WorkflowConfig> workflowConfigMap = (driver == null ? null : driver.getWorkflows());
+
+    if (driver != null && workflowConfigMap != null && !workflowConfigMap.isEmpty()) {
+      Set<String> workflows = workflowConfigMap.keySet();
+      for (String resource : resources) {
+        boolean isWfOrJob = false;
+        for (String workflow : workflows) {
+          if (!workflow.isEmpty() && resource.startsWith(workflow)) {
+            isWfOrJob = true;
+            break;
+          }
+        }
+        if (!isWfOrJob) {
+          db_resources.add(resource);
+        }
+      }
+    } else {
+      db_resources.addAll(resources);
+    }
+
+    return db_resources;
+  }
+
+  /**
+   * generate job status of resource versions
+   *
+   * currently, for those resource versions still managed by the cluster (workflow will be removed
+   * after completion in 2 days, thus only resource versions in 2 days will be reported), we use
+   * ConfigV3 managedhashmap to store the state map of resource versions.
+   *
+   * it will go through each workflow, and for each job in workflow: get job version, resource
+   * name, resource cluster from job config; get resource version from Job level userStore; get
+   * job state from job context through driver.
+   * And, generate state map:
+   * resourceName -> {resourceVersion -> {jobVersion -> jobState}}
+   *
+   * store jobVersion along with resourceVersion, bcz diff versions of export job might try to
+   * export the version of resource. This is not allowed unless old version of export job failed.
+   */
+  public String getJobStateConfig() {
+
+    // after job creation, the wf state generator won't be triggered immediately, thus, we can't
+    // have
+    // a "SCHEDULED/NOT_STARTED" state for resource-version.
+    // TODO: need to listen to other change besides EXTERNAL_VIEW
+
+    Map<String, Map<String, Map<String, String>>> stateMap = new HashMap<>();
+
+    Map<String, WorkflowConfig> workflowConfigMap = (driver == null ? null : driver.getWorkflows());
+
+    if (workflowConfigMap != null) {
+      for (String wf : workflowConfigMap.keySet()) {
+        WorkflowConfig wfConfig = workflowConfigMap.get(wf);
+        WorkflowContext wfContext = driver.getWorkflowContext(wf);
+
+        if (wfConfig != null && wfContext != null) {
+          Set<String> jobs = wfConfig.getJobDag().getAllNodes();
+
+          for (String job : jobs) {
+            // each job is responsible to "action" on one version of a resource
+
+            // job is already namespaced from WorkflowConfig
+            JobConfig jobConfig = driver.getJobConfig(job);
+
+            // get resource
+            Map<String, String> jobCmdMap = jobConfig.getJobCommandConfigMap();
+            String resourceName;
+            if (jobCmdMap != null && !jobCmdMap.isEmpty()) {
+              resourceName = jobCmdMap.get("RESOURCE");
+            } else {
+              LOG.error(
+                  String.format("JobCommandConfig for job: %s does not contain RESOURCE", job));
+              continue;
+            }
+            if (!stateMap.containsKey(resourceName)) {
+              stateMap.put(resourceName, new HashMap<String, Map<String, String>>());
+            }
+
+            // get jobVersion
+            String jobVersion = String.valueOf(jobConfig.getStat().getCreationTime());
+
+            // get resourceVersion
+            // resource version default to be job version, unless Job level userStore provide
+            // different resource version, i.e during dedupJob execution, store source resource
+            // version and own job version into Job level userStore
+            String resourceVersion = jobVersion;
+            String jobDeName = TaskUtil.getDenamespacedJobName(wf, job);
+            Map<String, String> contentMap = driver.getJobUserContentMap(wf, jobDeName);
+            if (contentMap != null && !contentMap.isEmpty() && contentMap
+                .containsKey("resourceVersion")) {
+              // useStore only available after 1 task begin to run
+              String userStoreResourceVersion = contentMap.get("resourceVersion");
+              if (!userStoreResourceVersion.isEmpty() && !resourceVersion
+                  .equals(userStoreResourceVersion)) {
+                LOG.error(
+                    String.format(
+                        "resourceVersion {%s} from job userStore mismatch resourceVersion"
+                            + "(jobVersion) {%s} from jobConfig, use resourceVersion from "
+                            + "userStore",
+                        userStoreResourceVersion, resourceVersion));
+                resourceVersion = userStoreResourceVersion;
+              }
+              // String resourceCluster = contentMap.get("resourceCluster");
+            } else {
+              LOG.error("Can't get userContent for DeNameSpaced job: " + jobDeName);
+            }
+
+            // get state
+            TaskState jobState = wfContext.getJobState(job);
+
+            if (!stateMap.get(resourceName).containsKey(resourceVersion)) {
+              stateMap.get(resourceName).put(resourceVersion, new HashMap<String, String>());
+            }
+
+            // map TaskState enum to Backup/Export Status enum
+            if (jobState == null) {
+              // no jobState found for the job, default to be NOT_STARTED
+              // FIXME: could probably mean in pending, not scheduled yet
+              LOG.error(String.format("JobState is not found. Job: %s is probably cancelled", job));
+              stateMap.get(resourceName).get(resourceVersion).put(jobVersion, "NOT_STARTED");
+            } else if (jobState == TaskState.STOPPED) {
+              // map jobState (STOPPED) to backup/dedup state PAUSED
+              stateMap.get(resourceName).get(resourceVersion).put(jobVersion, "PAUSED");
+            } else if (jobState == TaskState.ABORTED || jobState == TaskState.TIMED_OUT
+                || jobState == TaskState.TIMING_OUT || jobState == TaskState.FAILING
+                || jobState == TaskState.FAILED) {
+              stateMap.get(resourceName).get(resourceVersion).put(jobVersion, "FAILED");
+            } else {
+              stateMap.get(resourceName).get(resourceVersion).put(jobVersion, jobState.name());
+            }
+
+          }
+        } else {
+          // no workflow context or config found
+          LOG.error(String.format(
+              "WorkflowContext or WorkflowConfig is not found. Workflow: %s is probably cancelled",
+              wf));
+        }
+      }
+    }
+    // compare curt clusterStateReport to last
+    return JSONValue.toJSONString(stateMap);
+  }
+
+  /**
+   * post generated config into url and update cache accordingly
+   */
+  public void postToUrl(String newContent, String postUrl) {
+
+    if (lastPostedContents != null && lastPostedContents.containsKey(postUrl) && lastPostedContents
+        .get(postUrl).equals(newContent)) {
+      LOG.error("Identical external view observed, skip updating config.");
+      return;
+    }
+
+    // Write the config to ZK
+    LOG.error("Generating a new job state or config to " + postUrl);
+
+    this.dataParameters.remove("content");
+    this.dataParameters.put("content", newContent);
+    HttpPost httpPost = new HttpPost(postUrl);
+    try {
+      httpPost.setEntity(new StringEntity(this.dataParameters.toString()));
+      HttpResponse response = new DefaultHttpClient().execute(httpPost);
+      if (response.getStatusLine().getStatusCode() == 200) {
+        lastPostedContents.put(postUrl, newContent);
+        LOG.error("Succeed to generate a new shard config, sleep for 2 seconds");
+        TimeUnit.SECONDS.sleep(2);
+      } else {
+        LOG.error(response.getStatusLine().getReasonPhrase());
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to post the new config", e);
+    }
+  }
+
+}
+

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/JobStateGenerator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/JobStateGenerator.java
@@ -1,0 +1,52 @@
+package com.pinterest.rocksplicator;
+
+import org.apache.helix.HelixConstants;
+import org.apache.helix.HelixManager;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.api.listeners.PreFetch;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.task.TaskDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class JobStateGenerator extends Generator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JobStateGenerator.class);
+
+  // params to update task related states
+  protected final String statePostUrl;
+
+  public JobStateGenerator(String clusterName, HelixManager helixManager,
+                           String statePostUrl) {
+    super(clusterName, helixManager);
+
+    this.dataParameters.put("author", "WorkflowSateGenerator");
+    this.dataParameters.put("comment", "new shard config and workflow states");
+    this.statePostUrl = statePostUrl;
+    this.driver = new TaskDriver(helixManager);
+  }
+
+  @Override
+  public void onCallback(NotificationContext notificationContext) {
+    LOG.error("Received notification: " + notificationContext.getChangeType());
+    if (notificationContext.getChangeType() == HelixConstants.ChangeType.EXTERNAL_VIEW) {
+      generateJobStateConfig();
+    }
+  }
+
+  @Override
+  @PreFetch(enabled = false)
+  public void onExternalViewChange(List<ExternalView> externalViewList,
+                                   NotificationContext changeContext) {
+    generateJobStateConfig();
+  }
+
+
+  private void generateJobStateConfig() {
+    String newContent = getJobStateConfig();
+    postToUrl(newContent, statePostUrl);
+  }
+
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/TaskUtils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/TaskUtils.java
@@ -1,0 +1,309 @@
+package com.pinterest.rocksplicator;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * brief: rocksdbsnap
+ *
+ * we will add Jobs (backup/restore/export segment) and their schedule (one-time or recurrent)
+ * through helixrest/UI since we don't do scheduling from TaskDriver in java directly.
+ *
+ * Helix Task framework will pick up the added jobs (containing tasks) from zk, and distribute
+ * tasks to the cluster for execution.
+ *
+ * (?) spectator monitor job status, and update KV Manager service
+ */
+
+/**
+ * Utils to initiate tasks, check source status, report task status
+ *
+ * Backup:
+ *  tasks will get the Job scheduling time as the universal curt "version" for segment. It will
+ *  check the interval (curt version - last backup version), if over, eg 10min, execute the task;
+ *  otherwise skip curt task. One-time job need to specify ts as "version"; recurrent job will
+ *  use the recurrent time as "version".
+ *  s3 path: /rocksplicator/backup/[cluster]/[segment]/version/[partition]
+ *  last backup version: use s3 utils to get the last version with _SUCCESS
+ *
+ *  (?) spectator will monitor the job status, and update KV manager service
+ *
+ * Restore:
+ *  tasks will get the specified version, and  execution restore from s3
+ *
+ *  (?) spectator will monitor the restore job status, and update KV manager
+ *
+ * Export:
+ *  tasks will first get the latest un-exported backuped version (or specified version from Task
+ *  config) and update zNode: /rocksdbsnap/export/[cluster]/[segmentName]: {version:1234}. The
+ *  first Task
+ *
+ *  (?) spectator monitor job status, and update KV manager
+ */
+
+
+public class TaskUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TaskUtils.class);
+
+  // TODO: move this enum into KV Manager service
+  public enum BackupStatus {
+    /**
+     * The task has yet to start
+     */
+    NOT_STARTED,
+    /**
+     * The task is in progress.
+     */
+    IN_PROGRESS,
+    /**
+     * The task has been paused. It may be resumed later.
+     */
+    PAUSED,
+    /**
+     * The task is in stopping process. Will complete if subtasks are paused or completed
+     */
+    STOPPING,
+    /**
+     * The task has failed. It cannot be resumed.
+     */
+    FAILED,
+    /**
+     * All the task partitions have completed normally.
+     */
+    COMPLETED,
+  }
+
+  public enum ExportStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    PAUSED,
+    STOPPING,
+    FAILED,
+    COMPLETED,
+  }
+
+  /**
+   * endpoint to get the latest version
+   * TODO: move this to KV Manager service
+   */
+  public static long getLatestResourceVersion(String cluster, String segmentName)
+      throws RuntimeException {
+    // if not existed, return -1
+
+    String srcStateUrl =
+        String
+            .format(
+                "http://zkservice.pinadmin.com:8082/manageddata/map/rocksplicator/%s_state?",
+                cluster);
+
+    HttpGet httpGet = new HttpGet(srcStateUrl);
+    HttpClient httpclient = new DefaultHttpClient();
+
+    try {
+      HttpResponse response = httpclient.execute(httpGet);
+      if (response.getStatusLine().getStatusCode() == 200) {
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+          String json = EntityUtils.toString(entity);
+          Map<String, Map<String, Map<String, String>>> stateMap = jobStateJsonToMap(json);
+
+          if (stateMap.containsKey(segmentName)) {
+            Map<String, Map<String, String>> resVersionStates =
+                new TreeMap<>(Collections.reverseOrder());
+            resVersionStates.putAll(stateMap.get(segmentName));
+            for (String resVersion : resVersionStates.keySet()) {
+              Set<String> jobStates = new HashSet<>(resVersionStates.get(resVersion).values());
+              if (jobStates.contains("COMPLETED")) {
+                return Long.parseLong(resVersion);
+              }
+            }
+          } else {
+            System.out.println("state map does not contain versions for segment: " + segmentName);
+          }
+        } else {
+          LOG.error("HttpGet entity is empty");
+        }
+      } else {
+        LOG.error(response.getStatusLine().getReasonPhrase());
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to get the state map, ", e);
+      throw new RuntimeException(e);
+    }
+
+    return -1;
+  }
+
+  /**
+   * endpoint to retrieve Backup status from KVManager service
+   * ToDO: get status from KV manager service
+   */
+  public static BackupStatus getBackupStatus(String cluster, String segmentName, long version)
+      throws RuntimeException {
+    // if not existed, return BackupStatus.NONINIT
+
+    LOG.error(String
+        .format("get Backup Status for {cluster: %s, segment: %s, version: %d}", cluster,
+            segmentName, version));
+
+    return BackupStatus.COMPLETED;
+  }
+
+  /**
+   * endpoint to update Backup status
+   * ToDO: get status from KV manager service
+   */
+  public static void updateBackupStatus(String cluster, String segmentName, long version,
+                                        BackupStatus status) {
+
+  }
+
+  /**
+   * endpoint to retrieve export job status from ConfigV3
+   * TODO: get status from KVManager service
+   *
+   * if for resource version, other job version is in {IN_PROGRESS, COMPLETED}, curt job abandoned
+   * return COMPLETED else if for resource version, curt job version is not COMPLETED, then,
+   * continue execute
+   */
+  public static ExportStatus getExportStatus(String cluster, String segmentName,
+                                             long resourceVersion, long jobVersion)
+      throws RuntimeException {
+
+    LOG.error(String
+        .format("get Export Status for {cluster: %s, segment: %s, version: %d}", cluster,
+            segmentName, resourceVersion));
+
+    String srcStateUrl =
+        String
+            .format(
+                "http://zkservice.pinadmin.com:8082/manageddata/map/rocksplicator/%s_state?",
+                cluster);
+
+    HttpGet httpGet = new HttpGet(srcStateUrl);
+    HttpClient httpclient = new DefaultHttpClient();
+
+    try {
+      HttpResponse response = httpclient.execute(httpGet);
+      if (response.getStatusLine().getStatusCode() == 200) {
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+          String json = EntityUtils.toString(entity);
+          Map<String, Map<String, Map<String, String>>> stateMap = jobStateJsonToMap(json);
+
+          if (stateMap.containsKey(segmentName)) {
+            Map<String, Map<String, String>> resVersionStates = stateMap.get(segmentName);
+            String resVersion = String.valueOf(resourceVersion);
+
+            if (resVersionStates.containsKey(resVersion)) {
+
+              // if other job version is running task on the same resource version, skip curt job
+              for (String jobV : resVersionStates.get(resVersion).keySet()) {
+                if (!jobV.equals(String.valueOf(jobVersion))) {
+                  String jobState = resVersionStates.get(resVersion).get(jobV);
+                  if (jobState.equals("COMPLETED") || jobState.equals("IN_PROGRESS")) {
+                    return ExportStatus.COMPLETED;
+                  }
+                }
+              }
+
+              // return curt job version 's job state
+              if (resVersionStates.get(resVersion).containsKey(jobVersion)) {
+                String jobState = resVersionStates.get(resVersion).get(jobVersion);
+
+                if (jobState.equals("COMPLETED")) {
+                  return ExportStatus.COMPLETED;
+                }
+                if (jobState.equals("IN_PROGRESS")) {
+                  return ExportStatus.IN_PROGRESS;
+                }
+                if (jobState.equals("PAUSED")) {
+                  return ExportStatus.PAUSED;
+                }
+              }
+
+            } else {
+              LOG.error("state map does not contain version " + resVersion + " for segment: "
+                  + segmentName);
+            }
+          } else {
+            LOG.error("state map does not contain segment: " + segmentName);
+          }
+        } else {
+          LOG.error("HttpGet entity is empty");
+        }
+      } else {
+        LOG.error(response.getStatusLine().getReasonPhrase());
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to get the state map", e);
+      throw new RuntimeException(e);
+    }
+
+    return ExportStatus.NOT_STARTED;
+  }
+
+  /**
+   * endpoint to update export status
+   * ToDO: update status from KV manager service
+   */
+  public static void updateExportStatus(String cluster, String segmentName, long version,
+                                        ExportStatus status) {
+
+  }
+
+  /**
+   * lock segment by segment and job creation time
+   */
+  public static String getSegmentLockPath(String taskCluster, String resourceCluster,
+                                          String segment, long jobCreationTime) {
+    return String
+        .format("/dedup-test/rocksplicator/%s/%s/%s/%s/lock", taskCluster, resourceCluster,
+            segment,
+            String.valueOf(jobCreationTime));
+  }
+
+  /**
+   * build statePostUrl from configPostUrl
+   * e.g. configPostUrl: String.format("http://[prefix]/%s?mode=overwrite", cluster)
+   *      statePostUrl: String.format("http://[prefix]/%s_state?mode=overwrite", cluster)
+   * if some other statePostUrl wanted, overrite this build function
+   */
+  public static String buildStatePostUrl(String configPostUrl) {
+    int questMarkIndex = configPostUrl.indexOf('?');
+    String statePostUrl =
+        configPostUrl.substring(0, questMarkIndex) + "_state" + configPostUrl
+            .substring(questMarkIndex);
+    return statePostUrl;
+  }
+
+  public static Map<String, Map<String, Map<String, String>>> jobStateJsonToMap(String json)
+      throws Exception {
+    ObjectMapper jsonMapper = new ObjectMapper();
+    TypeReference<Map<String, Map<String, Map<String, String>>>> typeRef =
+        new TypeReference<Map<String, Map<String, Map<String, String>>>>() {};
+    Map<String, Map<String, Map<String, String>>>
+        stateMap =
+        jsonMapper.readValue(json, typeRef);
+    return stateMap;
+  }
+
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTask.java
@@ -1,0 +1,141 @@
+package com.pinterest.rocksplicator.task;
+
+import com.pinterest.rocksplicator.TaskUtils;
+import com.pinterest.rocksplicator.Utils;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.locks.InterProcessMutex;
+import org.apache.curator.framework.recipes.locks.Locker;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.UserContentStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BackupTask extends UserContentStore implements Task {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BackupTask.class);
+
+  private final String taskCluster;
+  private final String partitionName;
+  private final int backupLimitMbs;
+  private long resourceVersion;
+  private final String job;
+  private final String host;
+  private final int adminPort;
+  private CuratorFramework zkClient;
+  private InterProcessMutex jobVersionMutext;
+
+  public BackupTask(String taskCluster, String resourceName, String partitionName,
+                    int backupLimitMbs, long jobVersion, String job,
+                    String host, int adminPort,
+                    CuratorFramework zkClient) {
+    this.taskCluster = taskCluster;
+    this.partitionName = partitionName;
+    this.backupLimitMbs = backupLimitMbs;
+    this.resourceVersion = jobVersion;
+    this.job = job;
+    this.host = host;
+    this.adminPort = adminPort;
+    this.zkClient = zkClient;
+    this.jobVersionMutext = new InterProcessMutex(zkClient,
+        TaskUtils.getSegmentLockPath(taskCluster, taskCluster, resourceName, jobVersion));
+  }
+
+  /**
+   * Execute the task.
+   * @return A {@link TaskResult} object indicating the status of the task and any additional
+   *         context information that can be interpreted by the specific {@link Task}
+   *         implementation.
+   */
+  @Override
+  public TaskResult run() {
+
+    String dbName = Utils.getDbName(partitionName);
+    String segmentName = partitionName.substring(0, partitionName.lastIndexOf("_"));
+
+    // backup does not need inter-process lock, since jobVersion equal resourceVersion and
+    // jobVersion is already unified at jobConfig level. put into userStore for state map generation
+    try (Locker locker = new Locker(jobVersionMutext)) {
+      String curtBackupVersion = getUserContent("resourceVersion", UserContentStore.Scope.JOB);
+      if (curtBackupVersion == null || curtBackupVersion.isEmpty()) {
+        putUserContent("resourceVersion", String.valueOf(resourceVersion),
+            UserContentStore.Scope.JOB);
+        // for backup, jobVersion is resourceVersion; taskCluster is resourceCluster
+        putUserContent("jobVersion", String.valueOf(resourceVersion), Scope.JOB);
+        putUserContent("resourceCluster", taskCluster, UserContentStore.Scope.JOB);
+      } else {
+        if (!curtBackupVersion.equals(resourceVersion)) {
+          LOG.error(String.format(
+              "Current backup resourceVersion {%s} stored at Job level userStore differ from "
+                  + "Task's resourceVersion {%d}", curtBackupVersion, resourceVersion));
+        }
+        try {
+          resourceVersion = Long.parseLong(curtBackupVersion);
+        } catch (NumberFormatException e) {
+          LOG.error("Failed to parse resource version from userStore", e);
+        }
+      }
+    } catch (Exception e) {
+      String errMsg =
+          String.format("Failed to release the mutex for {resource: %s, jobVersion: %d}, %s",
+              segmentName,
+              resourceVersion,
+              e.getMessage());
+      LOG.error(errMsg);
+      return new TaskResult(TaskResult.Status.FAILED, errMsg);
+    }
+
+    try {
+
+      String hdfsPath =
+          String.format("/backup_test/rocksplicator/%s/%s/%s/%s", taskCluster, segmentName,
+              String.valueOf(resourceVersion),
+              dbName);
+
+      LOG.error(String.format(
+          "BackupTask run to backup partition: %s to hdfsPath: %s at host: %s, port: %d. Other info"
+              + " {taskCluster: %s, job: %s, version: %d}", partitionName, hdfsPath, host,
+          adminPort, taskCluster, job, resourceVersion));
+
+      executeBackup("127.0.0.1", 9090, dbName, hdfsPath, backupLimitMbs);
+
+      return new TaskResult(TaskResult.Status.COMPLETED, "BackupTask is completed!");
+    } catch (Exception e) {
+      LOG.error("Task backup failed");
+      return new TaskResult(TaskResult.Status.FAILED, "BackupTask failed");
+    }
+
+  }
+
+  protected void executeBackup(String host, int port, String dbName, String hdfsPath,
+                               int backupLimitMbs) throws RuntimeException {
+    try {
+      Utils.backupDBWithLimit(host, port, dbName, hdfsPath, backupLimitMbs);
+    } catch (Exception e){
+      LOG.error("Failed to execute backup", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Signals the task to stop execution. The task implementation should carry out any clean up
+   * actions that may be required and return from the {@link #run()} method.
+   *
+   * with default TaskStateModel, "cancel()" invoked by {@link org.apache.helix.task.TaskRunner
+   * #cancel()} during state transitions: running->stopped /task_aborted /dropped /init, and during
+   * {@link org.apache.helix.task.TaskStateModel #reset()}
+   */
+  @Override
+  public void cancel() {
+    // TODO: delete the db from cloud when cancel
+    // bakcup might be interrupted by host unreachable or termination or issued cancellation; after
+    // cancel, partial backup files remained on cloud by rocksdb backupEngine.
+    // Two options: 1. remove unfinished shard, so that new backup can start over; 2. leave
+    // untouched, if Task resume on same replica, then, wont re-upload those files, if Task
+    // resume on another replica, will ignore(?) leftovers since checksum of files are verified
+
+    // options2: leave leftovers untouched
+    LOG.error("BackupTask cancelled");
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
@@ -1,0 +1,102 @@
+package com.pinterest.rocksplicator.task;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * An implementation of {@link TaskFactory} that create Tasks upload job launching.
+ *
+ * This class takes in {@param adminPort}, {@param cluster}, {@param zkClient} from
+ * {@link com.pinterest.rocksplicator.Participant} used to identify job (tasks) belonging.
+ * {@param zkClient} used to access zNode from zk cluster
+ *
+ * Upon Job creation, take the {@link JobConfig} instantiation time from {@link TaskCallbackContext}
+ * as a universal version for tasks of the job.
+ * jobVersion == resourceVersion
+ *
+ * Upon Task creation, take in params from JobConfig which could be passed at job creation;
+ * JobCommandConfigMap: (optional)BACKUP_LIMIT_MBS, specify backup limit by mbs;
+ * Upon Task execution, store resourceVersion, resourceCluster, jobVersion in userStore at Job level
+ */
+
+public class BackupTaskFactory implements TaskFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BackupTaskFactory.class);
+
+  private String host;
+  private int adminPort;
+  private String cluster;
+  private CuratorFramework zkClient;
+
+  private static final int DEFAULT_BACKUP_LIMIT_MBS = 64;
+
+  public BackupTaskFactory(String host, int adminPort, String zkConnectString, String cluster) {
+    this.host = host;
+    this.cluster = cluster;
+    this.adminPort = adminPort;
+    this.zkClient = CuratorFrameworkFactory.newClient(zkConnectString,
+        new ExponentialBackoffRetry(1000, 3));
+    zkClient.start();
+  }
+
+  /**
+   * Returns a {@link Task} instance.
+   * @param context Contextual information for the task, including task and job configurations
+   */
+  @Override
+  public Task createNewTask(TaskCallbackContext context) {
+
+    TaskConfig taskConfig = context.getTaskConfig();
+    JobConfig jobConfig = context.getJobConfig();
+
+    LOG.error("Create task with TaskConfig: " + taskConfig.toString());
+
+    // get job name and version; job name is namespaced
+    String job = jobConfig.getJobId();
+    long jobVersion = jobConfig.getStat().getCreationTime();
+
+    // get backup upload rate limit
+    int backupLimitMbs = DEFAULT_BACKUP_LIMIT_MBS;
+    try {
+      Map<String, String> jobCmdMap = jobConfig.getJobCommandConfigMap();
+      if (jobCmdMap != null && !jobCmdMap.isEmpty()) {
+        if (jobCmdMap.containsKey("BACKUP_LIMIT_MBS")) {
+          backupLimitMbs = Integer.parseInt(jobCmdMap.get("BACKUP_LIMIT_MBS"));
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to parse backup_limit_mbs from job command config map");
+    }
+
+    // get target partition and resource name
+    String targetPartition = taskConfig.getTargetPartition();
+    String resourceName = targetPartition.substring(0, targetPartition.lastIndexOf("_"));
+
+    LOG.error(String.format(
+        "Create Task for cluster: %s, targetPartition: %s from job: %s at jobVersion: %d to "
+            + "execute at host: %s, port: %d", cluster, targetPartition, job, jobVersion, host,
+        adminPort));
+
+    return getTask(cluster, resourceName, targetPartition, backupLimitMbs, jobVersion, job, host,
+        adminPort, zkClient);
+  }
+
+  protected Task getTask(String cluster, String resourceName, String targetPartition,
+                         int backupLimitMbs, long jobVersion, String job,
+                         String host, int port, CuratorFramework zkClient) {
+    return new BackupTask(cluster, resourceName, targetPartition, backupLimitMbs, jobVersion, job,
+        host, port, zkClient);
+  }
+
+} 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTask.java
@@ -1,0 +1,218 @@
+package com.pinterest.rocksplicator.task;
+
+import com.pinterest.rocksplicator.TaskUtils;
+import com.pinterest.rocksplicator.Utils;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.locks.InterProcessMutex;
+import org.apache.curator.framework.recipes.locks.Locker;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.UserContentStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DedupTask extends UserContentStore implements Task {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DedupTask.class);
+
+  private final String taskCluster;
+  private final String resourceCluster;
+  private final String resourceName;
+  private final String partitionName;
+  private long resourceVersion;
+  private final long jobVersion;
+  private String job;
+  private final String host;
+  private final int adminPort;
+  private CuratorFramework zkClient;
+  private InterProcessMutex jobVersionMutex;
+
+  public DedupTask(String taskCluster, String resourceCluster, String resourceName,
+                   String partitionName, long resourceVersion,
+                   long jobVersion, String job, String host, int adminPort,
+                   CuratorFramework zkClient) {
+    this.taskCluster = taskCluster;
+    this.resourceCluster = resourceCluster;
+    this.resourceName = resourceName;
+    this.partitionName = partitionName;
+    this.resourceVersion = resourceVersion;
+    this.jobVersion = jobVersion;
+    this.job = job;
+    this.host = host;
+    this.adminPort = adminPort;
+    this.zkClient = zkClient;
+    this.jobVersionMutex = new InterProcessMutex(zkClient,
+        TaskUtils.getSegmentLockPath(taskCluster, resourceCluster, resourceName, jobVersion));
+  }
+
+  /**
+   * Execute the task.
+   * @return A {@link TaskResult} object indicating the status of the task and any additional
+   *         context information that can be interpreted by the specific {@link Task}
+   *         implementation.
+   */
+  @Override
+  public TaskResult run() {
+
+    // check task created with resource cluster
+    if (resourceCluster.isEmpty()) {
+      String errMsg = "resource cluster is not empty, not provided from jobConfig";
+      LOG.error(errMsg);
+      return new TaskResult(TaskResult.Status.CANCELED, errMsg);
+    }
+
+    // check task created with resource name and match prefix of target partition
+    String dbName = Utils.getDbName(partitionName);
+    String segmentName = partitionName.substring(0, partitionName.lastIndexOf('_'));
+    if (!resourceName.equals(segmentName)) {
+      String errMsg = String.format("RESOURCE {%s} provided from jobConfig is different from "
+          + "targetPartition {%s}'s prefix", resourceName, partitionName);
+      LOG.error(errMsg);
+      return new TaskResult(TaskResult.Status.CANCELED, errMsg);
+    }
+
+    // check task created with a valid resource version
+    if (resourceVersion == -1) {
+      // no valid version (e.g. no backup version ready, failed to retrieve state of resource)
+      return new TaskResult(TaskResult.Status.CANCELED, "No valid resource version found");
+    }
+
+    // unify resource version to among tasks in the same job
+    try (Locker locker = new Locker(jobVersionMutex)) {
+      String curtDedupResourceVersion = getUserContent("resourceVersion", Scope.JOB);
+      if (curtDedupResourceVersion == null || curtDedupResourceVersion.isEmpty()) {
+        putUserContent("resourceVersion", String.valueOf(resourceVersion), Scope.JOB);
+        putUserContent("jobVersion", String.valueOf(jobVersion), Scope.JOB);
+        putUserContent("resourceCluster", resourceCluster, Scope.JOB);
+      } else {
+        try {
+          resourceVersion = Long.parseLong(curtDedupResourceVersion);
+        } catch (NumberFormatException e) {
+          LOG.error("Failed to parse resource version from userStore", e);
+        }
+      }
+    } catch (Exception e) {
+      String errMsg =
+          String.format("Failed to release the mutex for {resource: %s, jobVersion: %d}, %s",
+              resourceName,
+              jobVersion,
+              e.getMessage());
+      LOG.error(errMsg);
+      return new TaskResult(TaskResult.Status.FAILED, errMsg);
+    }
+
+    try {
+
+      // only execute dedup when: 1. backup has completed version; 2. the version is not
+      // successfully exported yet (e.g. NOT_STARTED, FAILED). if export is in
+      // (IN_PROGRESS, STOPPING, PAUSED, COMPLETED) state, skip curt export job.
+      // there could only have 1 job version executed for same resource version at one time
+      TaskUtils.BackupStatus
+          backupStatus =
+          getBackupStatus(resourceCluster, resourceName, resourceVersion);
+
+      if (backupStatus == TaskUtils.BackupStatus.COMPLETED) {
+
+        TaskUtils.ExportStatus exportStatus =
+            getExportStatus(taskCluster, segmentName, resourceVersion, jobVersion);
+
+        if (exportStatus != TaskUtils.ExportStatus.COMPLETED) {
+
+          String src_hdfsPath =
+              String.format("/backup_test/rocksplicator/%s/%s/%s/%s", resourceCluster, segmentName,
+                  String.valueOf(resourceVersion), dbName);
+
+          String dest_hdfsPath =
+              String.format("/backup_test/compacted/rocksplicator/%s/%s/%s/%s", resourceCluster,
+                  segmentName, String.valueOf(resourceVersion), dbName);
+
+          LOG.error(
+              String.format(
+                  "DedupTask run to deup partition: %s from hdfsPath: %s at host: %s, port: %d. "
+                      + "Other info {cluster: %s, job: %s, resourceVersion: %d}", partitionName,
+                  src_hdfsPath, host, adminPort, resourceCluster, job, resourceVersion));
+
+          executeDedup(dbName, adminPort, src_hdfsPath, dest_hdfsPath);
+
+          LOG.error("DedupTask completed, with: success");
+          return new TaskResult(TaskResult.Status.COMPLETED, "DedupTask is completed!");
+        } else {
+          String errLog = String.format(
+              "Cluster: %s, db: %s, version: %d has already been exported, skip the dedup task",
+              resourceCluster,
+              dbName,
+              resourceVersion);
+          LOG.error(errLog);
+          return new TaskResult(TaskResult.Status.CANCELED, errLog);
+        }
+      } else {
+        String errLog =
+            String.format("Backup data not ready for cluster: %s, segment: %s, resourceVersion: %d",
+                resourceCluster,
+                segmentName, resourceVersion);
+        LOG.error(errLog);
+        return new TaskResult(TaskResult.Status.CANCELED, errLog);
+      }
+    } catch (Exception e) {
+      LOG.error("Task dedup failed", e);
+      return new TaskResult(TaskResult.Status.FAILED, "DedupTask failed");
+    }
+
+  }
+
+  protected TaskUtils.BackupStatus getBackupStatus(String cluster, String segment,
+                                                   long resVersion) throws RuntimeException {
+    try {
+      return TaskUtils.getBackupStatus(cluster, segment, resVersion);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected TaskUtils.ExportStatus getExportStatus(String taskCluster, String segment,
+                                                   long resourceVersion, long jobVersion)
+      throws RuntimeException {
+    try {
+      return TaskUtils.getExportStatus(taskCluster, segment, resourceVersion, jobVersion);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected void executeDedup(String dbName, int adminPort, String src_hdfsPath,
+                              String dest_hdfsPath) throws RuntimeException {
+    try {
+      Utils.addDB(dbName, adminPort);
+      Utils.closeDB(dbName, adminPort);
+      Utils.restoreLocalDB(adminPort, dbName, src_hdfsPath, "127.0.0.1", adminPort);
+      LOG.error("restoreDB is done, begin compactDB");
+
+      Utils.compactDB(adminPort, dbName);
+      LOG.error("compactDB is done");
+
+      // TODO(kangnan) check db integration before backup
+
+      Utils.backupDB("127.0.0.1", adminPort, dbName, dest_hdfsPath);
+      Utils.clearDB(dbName, adminPort);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Signals the task to stop execution. The task implementation should carry out any clean up
+   * actions that may be required and return from the {@link #run()} method.
+   *
+   * with default TaskStateModel, "cancel()" invoked by {@link org.apache.helix.task.TaskRunner
+   * #cancel()} during state transitions: running->stopped /task_aborted /dropped /init, and during
+   * {@link org.apache.helix.task.TaskStateModel #reset()}
+   */
+  @Override
+  public void cancel() {
+    // upon cancel, clear db from local
+    String dbName = Utils.getDbName(partitionName);
+    Utils.clearDB(dbName, adminPort);
+    LOG.error("DedupTask cancelled");
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
@@ -1,0 +1,136 @@
+package com.pinterest.rocksplicator.task;
+
+import com.pinterest.rocksplicator.TaskUtils;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * an implementation of {@link TaskFactory} that creates Tasks to dedup rocksdb instances
+ *
+ * This class takes in {@param adminPort}, {@param cluster}, {@param zkClient} from
+ * {@link com.pinterest.rocksplicator.Participant} used to identify job (tasks) belonging.
+ * {@param zkClient} used to access zNode from zk cluster
+ *
+ * tasks get the source data version and download to local and execute compaction, backup to s3.
+ * two options to get source data version: 1. get the specified version from TaskConfig, suitable
+ * for ad-hoc tasks; 2. get the latest backup-completed version from KVManager service, suitable
+ * for recurrent scheduled tasks.
+ * for 2: each Task will query KVManager independently, different versions might return. thus,
+ * tasks will use jobVersion to create a zk lock and update the source data version to job
+ * userContentStore. The 1st Task get the lock will update the source data version, other tasks
+ * will use this version to replace their queried source data version.
+ * job version zk lock: /[some_prefix]/rocksplicator/[task_cluster]/[src_cluster]/segment
+ * /jobVersion/lock
+ *
+ * jobVersion != resourceVersion
+ *
+ * Upon Task creation, take in params from JobConfig which could be passed at job creation.
+ * JobCommandConfigMap: RESOURCE_CLUSTER, RESOURCE, (optional)RESOURCE_VERSION
+ * Upon Task execution, store resourceVersion, jobVersion, resourceCluster into Job level userStore
+ */
+
+public class DedupTaskFactory implements TaskFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DedupTaskFactory.class);
+
+  private final String host;
+  private final int adminPort;
+  private final String cluster;
+  private CuratorFramework zkClient;
+
+  public DedupTaskFactory(String host, int adminPort, String zkConnectString, String cluster) {
+    this.host = host;
+    this.adminPort = adminPort;
+    this.cluster = cluster;
+    this.zkClient = CuratorFrameworkFactory.newClient(zkConnectString,
+        new ExponentialBackoffRetry(1000, 3));
+    zkClient.start();
+  }
+
+  /**
+   * @param context Contextual information for the task, including task and job configurations
+   * @return A {@link Task} instance.
+   */
+  @Override
+  public Task createNewTask(TaskCallbackContext context) {
+
+    // TaskConfig: task_id, task_cmd (the cmd to run, e.g. rm), target_partition, configMap
+    TaskConfig taskConfig = context.getTaskConfig();
+    JobConfig jobConfig = context.getJobConfig();
+
+    LOG.error("Create task with TaskConfig: " + taskConfig.toString());
+
+    // get job name and version
+    String job = jobConfig.getJobId();
+    long jobVersion = jobConfig.getStat().getCreationTime();
+
+    // get target partition
+    String targetPartition = taskConfig.getTargetPartition();
+
+    // get resource level info from jobConfig
+    String resourceCluster = "";
+    String resourceName = "";
+    long resourceVersion = -1;
+
+    try {
+
+      Map<String, String> jobCmdMap = jobConfig.getJobCommandConfigMap();
+      if (jobCmdMap != null && !jobCmdMap.isEmpty()) {
+        if (jobCmdMap.containsKey("RESOURCE_CLUSTER")) {
+          resourceCluster = jobCmdMap.get("RESOURCE_CLUSTER");
+        }
+        if (jobCmdMap.containsKey("RESOURCE")) {
+          resourceName = jobCmdMap.get("RESOURCE");
+        }
+        if (jobCmdMap.containsKey("RESOURCE_VERSION")) {
+          resourceVersion = Long.parseLong(jobCmdMap.get("RESOURCE_VERSION"));
+        }
+      }
+
+      if (resourceVersion == -1) {
+        // if no version provided, e.g. recurrent job
+        // TODO: get the resource latest version from KVManager service
+        resourceVersion = getLatestVersion(resourceCluster, resourceName);
+      }
+
+    } catch (NumberFormatException e) {
+      LOG.error("Failed to parse resource_version from job command config map", e);
+    } catch (Exception e) {
+      LOG.error("CreateNewTask failed, fail to get resource version for task for partition: "
+          + targetPartition);
+    }
+
+    LOG.error(String.format(
+        "Create Task for cluster: %s, targetPartition: %s from job: %s at jobVersion: %d to "
+            + "execute at host: %s, port: %d", cluster, targetPartition, job, jobVersion, host,
+        adminPort));
+
+    return getTask(cluster, resourceCluster, resourceName, targetPartition, resourceVersion,
+        jobVersion, job, host, adminPort, zkClient);
+  }
+
+  protected Task getTask(String cluster, String resourceCluster, String resourceName,
+                         String targetPartition,
+                         long resourceVersion, long jobVersion, String job,
+                         String host, int port, CuratorFramework zkClient) {
+    return new DedupTask(cluster, resourceCluster, resourceName, targetPartition, resourceVersion,
+        jobVersion, job, host, port, zkClient);
+  }
+
+  // separate the static call for testing mock; not able to directly mock TaskUtils
+  // .getLatestResourceVersion since Factory registered @BeforeClass during test
+  protected long getLatestVersion(String cluster, String resource) {
+    return TaskUtils.getLatestResourceVersion(cluster, resource);
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTask.java
@@ -1,0 +1,22 @@
+package com.pinterest.rocksplicator.task;
+
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RestoreTask implements Task {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RestoreTask.class);
+
+  @Override
+  public TaskResult run() {
+    LOG.error("RestoreTask run");
+    return new TaskResult(TaskResult.Status.COMPLETED, "RestoreTask is completed!");
+  }
+
+  @Override
+  public void cancel() {
+    LOG.error("RestoreTask cancel");
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTaskFactory.java
@@ -1,0 +1,13 @@
+package com.pinterest.rocksplicator.task;
+
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskFactory;
+
+public class RestoreTaskFactory implements TaskFactory {
+
+  @Override
+  public Task createNewTask(TaskCallbackContext taskCallbackContext) {
+    return new RestoreTask();
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/ServerContext.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/ServerContext.java
@@ -1,0 +1,124 @@
+package com.pinterest.rocksplicator.task;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.ConfigAccessor;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.InstanceType;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZNRecordSerializer;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.manager.zk.ZkClient;
+import org.apache.helix.manager.zk.client.HelixZkClient;
+import org.apache.helix.manager.zk.client.SharedZkClientFactory;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.tools.ClusterSetup;
+
+public class ServerContext {
+  private final String _zkAddr;
+  private HelixZkClient _zkClient;
+  private ZKHelixAdmin _zkHelixAdmin;
+  private ClusterSetup _clusterSetup;
+  private ConfigAccessor _configAccessor;
+
+  // 1 Cluster name will correspond to 1 helix data accessor
+  private final Map<String, HelixDataAccessor> _helixDataAccessorPool;
+
+  // 1 Cluster name will correspond to 1 task driver
+  private final Map<String, TaskDriver> _taskDriverPool;
+
+  public ServerContext(String zkAddr) {
+    _zkAddr = zkAddr;
+
+    // We should NOT initiate _zkClient and anything that depends on _zkClient in
+    // constructor, as it is reasonable to start up HelixRestServer first and then
+    // ZooKeeper. In this case, initializing _zkClient will fail and HelixRestServer
+    // cannot be started correctly.
+    _helixDataAccessorPool = new HashMap<>();
+    _taskDriverPool = new HashMap<>();
+  }
+
+  public HelixZkClient getHelixZkClient() {
+    if (_zkClient == null) {
+      HelixZkClient.ZkClientConfig clientConfig = new HelixZkClient.ZkClientConfig();
+      clientConfig.setZkSerializer(new ZNRecordSerializer());
+      _zkClient = SharedZkClientFactory
+          .getInstance().buildZkClient(new HelixZkClient.ZkConnectionConfig(_zkAddr), clientConfig);
+    }
+    return _zkClient;
+  }
+
+  @Deprecated
+  public ZkClient getZkClient() {
+    return (ZkClient) getHelixZkClient();
+  }
+
+  public HelixAdmin getHelixAdmin() {
+    if (_zkHelixAdmin == null) {
+      _zkHelixAdmin = new ZKHelixAdmin(getHelixZkClient());
+    }
+    return _zkHelixAdmin;
+  }
+
+  public ClusterSetup getClusterSetup() {
+    if (_clusterSetup == null) {
+      _clusterSetup = new ClusterSetup(getHelixZkClient(), getHelixAdmin());
+    }
+    return _clusterSetup;
+  }
+
+  public TaskDriver getTaskDriver(String clusterName) {
+    synchronized (_taskDriverPool) {
+      if (!_taskDriverPool.containsKey(clusterName)) {
+        _taskDriverPool.put(clusterName, new TaskDriver(getHelixZkClient(), clusterName));
+      }
+      return _taskDriverPool.get(clusterName);
+    }
+  }
+
+  public ConfigAccessor getConfigAccessor() {
+    if (_configAccessor == null) {
+      _configAccessor = new ConfigAccessor(getHelixZkClient());
+    }
+    return _configAccessor;
+  }
+
+  public HelixDataAccessor getDataAccssor(String clusterName) {
+    synchronized (_helixDataAccessorPool) {
+      if (!_helixDataAccessorPool.containsKey(clusterName)) {
+        ZkBaseDataAccessor<ZNRecord> baseDataAccessor = new ZkBaseDataAccessor<>(getHelixZkClient());
+        _helixDataAccessorPool.put(clusterName,
+            new ZKHelixDataAccessor(clusterName, InstanceType.ADMINISTRATOR, baseDataAccessor));
+      }
+      return _helixDataAccessorPool.get(clusterName);
+    }
+  }
+
+  public void close() {
+    if (_zkClient != null) {
+      _zkClient.close();
+    }
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTask.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTask.java
@@ -1,0 +1,242 @@
+package com.pinterest.rocksplicator.task;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.tools.ClusterSetup;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+@RunWith(PowerMockRunner.class)
+public class TestBackupTask extends TaskTestBase {
+
+  private static final String JOB_COMMAND = "DummyCommand";
+  private static final int NUM_TASK = 2;
+  private Map<String, String> _jobCommandMap;
+
+  private final CountDownLatch allTasksReady = new CountDownLatch(NUM_TASK);
+  private final CountDownLatch adminReady = new CountDownLatch(1);
+
+
+  @Before
+  public void setUp() throws Exception {
+  }
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _participants = new MockParticipantManager[_numNodes];
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursively(namespace);
+    }
+
+    // Setup cluster and instances
+    ClusterSetup setupTool = new ClusterSetup(ZK_ADDR);
+    setupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < _numNodes; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    // start dummy participants
+    for (int i = 0; i < _numNodes; i++) {
+      final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+
+      // Set task callbacks
+      Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
+      taskFactoryReg.put("Backup", new DummyBackupTaskFactory(instanceName.split("_")[0],
+          Integer.parseInt(instanceName.split("_")[1]),
+          ZK_ADDR, CLUSTER_NAME));
+
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      // Register a Task state model factory.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      stateMachine.registerStateModelFactory("Task",
+          new TaskStateModelFactory(_participants[i], taskFactoryReg));
+      _participants[i].syncStart();
+    }
+
+    // Start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    // Start an admin connection
+    _manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+
+    _jobCommandMap = new HashMap<>();
+  }
+
+  @Test
+  public void testBackupTasksInSameJobPossessUnifiedResourceVersion() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 1 jobs with 2 Backup Task
+    List<TaskConfig> taskConfigs = new ArrayList<>();
+    for (int i = 0; i < NUM_TASK; i++) {
+      Map<String, String> taskConfigMap = new HashMap<>();
+      taskConfigMap.put("TASK_TARGET_PARTITION", "test_segment_" + String.valueOf(i));
+      taskConfigs.add(new TaskConfig("Backup", taskConfigMap));
+    }
+    _jobCommandMap.put("BACKUP_LIMIT_MBS", String.valueOf(10));
+    JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+        .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+    String jobName = "JOB" + 0;
+    workflowBuilder.addJob(jobName, jobConfigBulider);
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    String job = "JOB" + 0;
+    String namespacedJobName = TaskUtil.getNamespacedJobName(workflowName, job);
+    Map<String, String> jobUserStore = _driver.getJobUserContentMap(workflowName, job);
+    for (int i = 0; i < NUM_TASK; i++) {
+      // verify Job Command remained as dummy
+      Assert.assertEquals(_driver.getJobConfig(namespacedJobName).getCommand(), JOB_COMMAND);
+      // verify Task Command is passed in: Backup
+      Map<String, String>
+          taskUserStore =
+          _driver.getTaskUserContentMap(workflowName, job, String.valueOf(i));
+      for (String store : taskUserStore.keySet()) {
+        Assert.assertTrue(jobUserStore.containsKey(store));
+        Assert.assertEquals(jobUserStore.get(store), taskUserStore.get(store));
+      }
+    }
+    _jobCommandMap.clear();
+  }
+
+
+  //*****************************************************
+  // dummy TaskFactory, Task to limit testing scope
+  //
+  // Varied behavior based on specific testing class:
+  // - populate Task level userStore
+  //****************************************************/
+
+  protected class DummyBackupTaskFactory extends BackupTaskFactory {
+
+    public DummyBackupTaskFactory(String host, int adminPort, String zkConnectString,
+                                  String cluster) {
+      super(host, adminPort, zkConnectString, cluster);
+    }
+
+    @Override
+    protected Task getTask(String cluster, String resourceName, String targetPartition,
+                           int backupLimitMbs,
+                           long jobVersion, String job,
+                           String host, int port, CuratorFramework zkClient) {
+      return new DummyBackupTask(cluster, resourceName, targetPartition, backupLimitMbs, jobVersion,
+          job, host,
+          port,
+          zkClient);
+    }
+  }
+
+  protected class DummyBackupTask extends BackupTask {
+
+    public DummyBackupTask(String cluster, String resourceName, String partitionName,
+                           int backupLimitMbs,
+                           long resourceVersion,
+                           String job, String host, int adminPort,
+                           CuratorFramework zkClient) {
+      super(cluster, resourceName, partitionName, backupLimitMbs, resourceVersion, job, host,
+          adminPort, zkClient);
+    }
+
+    @Override
+    public TaskResult run() {
+      allTasksReady.countDown();
+      try {
+        adminReady.await();
+      } catch (Exception e) {
+        return new TaskResult(TaskResult.Status.FATAL_FAILED, e.getMessage());
+      }
+      super.run();
+
+      // store resourceVersion, jobVersion, resourceCluster into Task userStore to compare with
+      // Job level userStore populated by backup task execution
+      try {
+        // use Java reflection to access supper class's private members, only for testing
+        long resVersion = readPrivateSuperClassLongField("resourceVersion");
+        // resVersion == jobVersion
+        long jobVersion = resVersion;
+        // taskCluster == resourceCluster
+        String resCluster = readPrivateSuperClassStringField("taskCluster");
+        putUserContent("resourceVersion", String.valueOf(resVersion), Scope.TASK);
+        putUserContent("jobVersion", String.valueOf(jobVersion), Scope.TASK);
+        putUserContent("resourceCluster", resCluster, Scope.TASK);
+      } catch (Exception e) {
+        System.out.println(
+            "Failed to read super class's private filed or fail to pur userStore" + e.getMessage());
+      }
+
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+
+    @Override
+    protected void executeBackup(String host, int port, String dbName, String hdfsPath,
+                                 int backupLimitMbs) throws RuntimeException {
+      System.out.println("mock execute backup");
+    }
+
+    @Override
+    public void cancel() {
+
+    }
+
+    // helper function for testing
+    // java refection: http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
+    private String readPrivateSuperClassStringField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (String) field.get(this);
+    }
+
+    private long readPrivateSuperClassLongField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.getLong(this);
+    }
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTaskFactory.java
@@ -1,0 +1,308 @@
+package com.pinterest.rocksplicator.task;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.tools.ClusterSetup;
+import org.junit.Before;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+@RunWith(PowerMockRunner.class)
+public class TestBackupTaskFactory extends TaskTestBase {
+
+  private static final String JOB_COMMAND = "DummyCommand";
+  private static final int NUM_TASK = 2;
+  private Map<String, String> _jobCommandMap;
+
+  private final CountDownLatch allTasksReady = new CountDownLatch(NUM_TASK);
+  private final CountDownLatch adminReady = new CountDownLatch(1);
+
+
+  @Before
+  public void setUp() throws Exception {
+
+  }
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _participants = new MockParticipantManager[_numNodes];
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursively(namespace);
+    }
+
+    // Setup cluster and instances
+    ClusterSetup setupTool = new ClusterSetup(ZK_ADDR);
+    setupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < _numNodes; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    // start dummy participants
+    for (int i = 0; i < _numNodes; i++) {
+      final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+
+      // Set task callbacks
+      Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
+      taskFactoryReg.put("Backup", new DummyBackupTaskFactory(instanceName.split("_")[0],
+          Integer.parseInt(instanceName.split("_")[1]),
+          ZK_ADDR, CLUSTER_NAME));
+
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      // Register a Task state model factory.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      stateMachine.registerStateModelFactory("Task",
+          new TaskStateModelFactory(_participants[i], taskFactoryReg));
+      _participants[i].syncStart();
+    }
+
+    // Start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    // Start an admin connection
+    _manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+
+    _jobCommandMap = new HashMap<>();
+  }
+
+  @Test
+  public void testBackupTaskFactoryCreateNewTask() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 2 jobs with 1 Backup Task each
+    for (int i = 0; i < NUM_TASK; i++) {
+      List<TaskConfig> taskConfigs = new ArrayList<>();
+      Map<String, String> taskConfigMap = new HashMap<>();
+      taskConfigMap.put("TASK_TARGET_PARTITION", "test_segment_" + String.valueOf(i));
+      taskConfigs.add(new TaskConfig("Backup", taskConfigMap));
+      _jobCommandMap.put("BACKUP_LIMIT_MBS", String.valueOf(10));
+      JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+          .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+      String jobName = "JOB" + i;
+      workflowBuilder.addJob(jobName, jobConfigBulider);
+    }
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    Assert.assertEquals(_driver.getWorkflowConfig(workflowName).getWorkflowId(), workflowName);
+    for (int i = 0; i < NUM_TASK; i++) {
+      String job = "JOB" + i;
+      String namespacedJobName = TaskUtil.getNamespacedJobName(workflowName, job);
+      // verify Job Command remained as dummy
+      Assert.assertEquals(_driver.getJobConfig(namespacedJobName).getCommand(), JOB_COMMAND);
+      // verify Task Command is passed in: Backup
+      for (TaskConfig taskConfig : _driver.getJobConfig(namespacedJobName).getTaskConfigMap()
+          .values()) {
+        Assert.assertEquals(taskConfig.getCommand(), "Backup");
+        Assert.assertEquals(taskConfig.getTargetPartition(), "test_segment_" + i);
+      }
+    }
+  }
+
+  @Test
+  public void testJobVersionDifferAmongTasksFromDiffJobs() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 2 jobs with 1 Backup Task each
+    for (int i = 0; i < NUM_TASK; i++) {
+      List<TaskConfig> taskConfigs = new ArrayList<>();
+      Map<String, String> taskConfigMap = new HashMap<>();
+      taskConfigMap.put("TASK_TARGET_PARTITION", "test_segment_" + String.valueOf(i));
+      taskConfigs.add(new TaskConfig("Backup", taskConfigMap));
+      _jobCommandMap.put("BACKUP_LIMIT_MBS", String.valueOf(10));
+      JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+          .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+      String jobName = "JOB" + i;
+      workflowBuilder.addJob(jobName, jobConfigBulider);
+    }
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    Set<String> jobVersions = new HashSet<>();
+    for (int i = 0; i < NUM_TASK; i++) {
+      String job = "JOB" + i;
+      // note: for backup, resVersion == jobVersion
+      String resVersion = _driver.getTaskUserContentMap(workflowName, job, "0")
+          .get("resourceVersion");
+      // assert diff resVersions
+      Assert.assertTrue(jobVersions.add(resVersion));
+    }
+    Assert.assertEquals(jobVersions.size(), 2);
+  }
+
+  @Test
+  public void testJobVersionSameAmongTasksFromSameJob() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 1 jobs with 2 Backup Task
+    List<TaskConfig> taskConfigs = new ArrayList<>();
+    for (int i = 0; i < NUM_TASK; i++) {
+      Map<String, String> taskConfigMap = new HashMap<>();
+      taskConfigMap.put("TASK_TARGET_PARTITION", "test_segment_" + String.valueOf(i));
+      taskConfigs.add(new TaskConfig("Backup", taskConfigMap));
+    }
+    _jobCommandMap.put("BACKUP_LIMIT_MBS", String.valueOf(10));
+    JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+        .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+    String jobName = "JOB" + 0;
+    workflowBuilder.addJob(jobName, jobConfigBulider);
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    Set<String> jobVersions = new HashSet<>();
+    String job = "JOB" + 0;
+    for (int i = 0; i < NUM_TASK; i++) {
+      jobVersions.add(_driver.getTaskUserContentMap(workflowName, job, "0")
+          .get("resourceVersion"));
+    }
+    Assert.assertEquals(jobVersions.size(), 1);
+  }
+
+
+  //*****************************************************
+  // dummy TaskFactory, Task to limit testing scope
+  //
+  // Varied behavior based on specific testing class:
+  // - populate Task level userStore
+  //****************************************************/
+
+  private class DummyBackupTaskFactory extends BackupTaskFactory {
+
+    public DummyBackupTaskFactory(String host, int adminPort, String zkConnectString,
+                                  String cluster) {
+      super(host, adminPort, zkConnectString, cluster);
+    }
+
+    @Override
+    protected Task getTask(String cluster, String resourceName, String targetPartition,
+                           int backupLimitMbs,
+                           long jobVersion, String job,
+                           String host, int port, CuratorFramework zkClient) {
+      return new DummyBackupTask(cluster, resourceName, targetPartition, backupLimitMbs, jobVersion,
+          job, host,
+          port,
+          zkClient);
+    }
+  }
+
+  private class DummyBackupTask extends BackupTask {
+
+    public DummyBackupTask(String cluster, String resourceName, String partitionName,
+                           int backupLimitMbs,
+                           long resourceVersion,
+                           String job, String host, int adminPort,
+                           CuratorFramework zkClient) {
+      super(cluster, resourceName, partitionName, backupLimitMbs, resourceVersion, job, host,
+          adminPort, zkClient);
+    }
+
+    @Override
+    public TaskResult run() {
+      allTasksReady.countDown();
+      try {
+        adminReady.await();
+      } catch (Exception e) {
+        return new TaskResult(TaskResult.Status.FATAL_FAILED, e.getMessage());
+      }
+
+      // store backup_limit_mbs, jobVersion into Task userStore to verify succesfully passed from
+      // BackupTaskfactory
+      try {
+        // use Java reflection to access supper class's private members, only for testing
+        long resVersion = readPrivateSuperClassLongField("resourceVersion");
+        int backupLimitMbs = readPrivateSuperClassIntField("backupLimitMbs");
+        putUserContent("resourceVersion", String.valueOf(resVersion), Scope.TASK);
+        putUserContent("backupLimitMbs", String.valueOf(backupLimitMbs), Scope.TASK);
+      } catch (Exception e) {
+        System.out.println(e.getCause());
+      }
+
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+
+    @Override
+    public void cancel() {
+
+    }
+
+    // helper function for testing
+    // java refection: http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
+
+    private long readPrivateSuperClassLongField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.getLong(this);
+    }
+
+    private int readPrivateSuperClassIntField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.getInt(this);
+    }
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestDedupTask.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestDedupTask.java
@@ -1,0 +1,303 @@
+package com.pinterest.rocksplicator.task;
+
+import com.pinterest.rocksplicator.TaskUtils;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.tools.ClusterSetup;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+@RunWith(PowerMockRunner.class)
+public class TestDedupTask extends TaskTestBase {
+
+  private static final String JOB_COMMAND = "DummyCommand";
+  private static final int NUM_TASK = 2;
+  private Map<String, String> _jobCommandMap;
+  private long mockedLatestResourceVersion = 123456789L;
+  private long resourceVersionIncr = 1L;
+
+  private final CountDownLatch allTasksReady = new CountDownLatch(NUM_TASK);
+  private final CountDownLatch adminReady = new CountDownLatch(1);
+
+
+  @Before
+  public void setUp() throws Exception {
+
+  }
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _participants = new MockParticipantManager[_numNodes];
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursively(namespace);
+    }
+
+    // Setup cluster and instances
+    ClusterSetup setupTool = new ClusterSetup(ZK_ADDR);
+    setupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < _numNodes; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    // start dummy participants
+    for (int i = 0; i < _numNodes; i++) {
+      final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+
+      // Set task callbacks
+      Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
+      taskFactoryReg.put("Dedup", new DummyDedupTaskFactory(instanceName.split("_")[0],
+          Integer.parseInt(instanceName.split("_")[1]),
+          ZK_ADDR, CLUSTER_NAME));
+
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      // Register a Task state model factory.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      stateMachine.registerStateModelFactory("Task",
+          new TaskStateModelFactory(_participants[i], taskFactoryReg));
+      _participants[i].syncStart();
+    }
+
+    // Start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    // Start an admin connection
+    _manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+
+    _jobCommandMap = new HashMap<>();
+  }
+
+  @Test
+  public void testDedupTasksInSameJobPossessUnifiedResourceVersion() throws Exception {
+
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 1 jobs with 2 Dedup Task
+    List<TaskConfig> taskConfigs = new ArrayList<>();
+    for (int i = 0; i < NUM_TASK; i++) {
+      Map<String, String> taskConfigMap = new HashMap<>();
+      taskConfigMap.put("TASK_TARGET_PARTITION", "test_segment_" + String.valueOf(i));
+      taskConfigs.add(new TaskConfig("Dedup", taskConfigMap));
+    }
+
+    String resource_cluster = "test_cluster";
+    String resource_segment = "test_segment";
+    _jobCommandMap.put("RESOURCE_CLUSTER", resource_cluster);
+    _jobCommandMap.put("RESOURCE", resource_segment);
+
+    JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+        .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+    String jobName = "JOB" + 0;
+    workflowBuilder.addJob(jobName, jobConfigBulider);
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    String job = "JOB" + 0;
+    String namespacedJobName = TaskUtil.getNamespacedJobName(workflowName, job);
+    Map<String, String> jobUserStore = _driver.getJobUserContentMap(workflowName, job);
+
+    Set<String> resVersionBeforeUnified = new HashSet<>();
+    Set<String> jobVersionBeforeUnified = new HashSet<>();
+    Set<String> resVersionAfterUnified = new HashSet<>();
+    Set<String> jobVersionAfterUnified = new HashSet<>();
+    for (int i = 0; i < NUM_TASK; i++) {
+      Map<String, String>
+          taskUserStore =
+          _driver.getTaskUserContentMap(workflowName, job, String.valueOf(i));
+
+      Assert.assertTrue(taskUserStore.containsKey("resourceVersion-beforeUnified"));
+      resVersionBeforeUnified.add(taskUserStore.get("resourceVersion-beforeUnified"));
+      Assert.assertTrue(taskUserStore.containsKey("jobVersion-beforeUnified"));
+      jobVersionBeforeUnified.add(taskUserStore.get("jobVersion-beforeUnified"));
+
+      Assert.assertTrue(taskUserStore.containsKey("resourceVersion-afterUnified"));
+      resVersionAfterUnified.add(taskUserStore.get("resourceVersion-afterUnified"));
+      Assert.assertTrue(taskUserStore.containsKey("jobVersion-afterUnified"));
+      jobVersionAfterUnified.add(taskUserStore.get("jobVersion-afterUnified"));
+    }
+
+    // assert resource version diff before task execution
+    Assert.assertTrue(jobUserStore.containsKey("resourceVersion"));
+    Assert.assertEquals(resVersionBeforeUnified.size(), 2);
+    Assert.assertEquals(resVersionAfterUnified.size(), 1);
+    Assert.assertTrue(resVersionAfterUnified.contains(jobUserStore.get("resourceVersion")));
+
+    // assert resource version unified after task execution
+    Assert.assertTrue(jobUserStore.containsKey("jobVersion"));
+    Assert.assertEquals(jobVersionBeforeUnified.size(), 1);
+    Assert.assertEquals(jobVersionAfterUnified.size(), 1);
+    Assert.assertTrue(jobVersionAfterUnified.contains(jobUserStore.get("jobVersion")));
+
+    _jobCommandMap.clear();
+  }
+
+  //*****************************************************
+  // dummy TaskFactory, Task to limit testing scope
+  //
+  // Varied behavior based on specific testing class:
+  // - return varied resource version for diff Tasks from same Job, testing resource version
+  // unifying during task execution
+  // - populate Task level userStore
+  //****************************************************/
+
+  protected class DummyDedupTaskFactory extends DedupTaskFactory {
+
+    public DummyDedupTaskFactory(String host, int adminPort, String zkConnectString,
+                                 String cluster) {
+      super(host, adminPort, zkConnectString, cluster);
+    }
+
+    @Override
+    protected Task getTask(String cluster, String resourceCluster, String resourceName,
+                           String targetPartition,
+                           long resourceVersion, long jobVersion, String job,
+                           String host, int port, CuratorFramework zkClient) {
+      return new DummyDedupTask(cluster, resourceCluster, resourceName, targetPartition,
+          resourceVersion,
+          jobVersion, job, host, port, zkClient);
+    }
+
+    @Override
+    protected long getLatestVersion(String cluster, String resource) {
+      // return different resource version to tasks, test unifying version among tasks
+      return mockedLatestResourceVersion + resourceVersionIncr++;
+    }
+  }
+
+  protected class DummyDedupTask extends DedupTask {
+
+    public DummyDedupTask(String taskCluster, String resourceCluster, String resourceName,
+                          String partitionName, long resourceVersion, long jobVersion,
+                          String job, String host, int adminPort,
+                          CuratorFramework zkClient) {
+      super(taskCluster, resourceCluster, resourceName, partitionName, resourceVersion, jobVersion,
+          job, host, adminPort, zkClient);
+    }
+
+    @Override
+    public TaskResult run() {
+      allTasksReady.countDown();
+      try {
+        adminReady.await();
+      } catch (Exception e) {
+        return new TaskResult(TaskResult.Status.FATAL_FAILED, e.getMessage());
+      }
+      try {
+        long resVersion = readPrivateSuperClassLongField("resourceVersion");
+        long jobVersion = readPrivateSuperClassLongField("jobVersion");
+        putUserContent("resourceVersion-beforeUnified", String.valueOf(resVersion), Scope.TASK);
+        putUserContent("jobVersion-beforeUnified", String.valueOf(jobVersion), Scope.TASK);
+      } catch (Exception e) {
+        System.out.println(
+            "Failed to read super class's private filed or fail to pur userStore" + e.getMessage());
+      }
+
+      super.run();
+
+      // store resourceVersion, jobVersion, resourceCluster into Task userStore to compare with
+      // Job level userStore populated by Dedup task execution
+      try {
+        // use Java reflection to access supper class's private members, only for testing
+        long resVersion = readPrivateSuperClassLongField("resourceVersion");
+        long jobVersion = readPrivateSuperClassLongField("jobVersion");
+        String resCluster = readPrivateSuperClassStringField("resourceCluster");
+        putUserContent("resourceVersion-afterUnified", String.valueOf(resVersion), Scope.TASK);
+        putUserContent("jobVersion-afterUnified", String.valueOf(jobVersion), Scope.TASK);
+        putUserContent("resourceCluster", resCluster, Scope.TASK);
+      } catch (Exception e) {
+        System.out.println(
+            "Failed to read super class's private filed or fail to pur userStore" + e.getMessage());
+      }
+
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+
+    @Override
+    protected TaskUtils.BackupStatus getBackupStatus(String cluster, String segment,
+                                                     long resVersion) throws RuntimeException {
+
+      return TaskUtils.BackupStatus.COMPLETED;
+    }
+
+    @Override
+    protected TaskUtils.ExportStatus getExportStatus(String taskCluster, String segment,
+                                                     long resourceVersion, long jobVersion)
+        throws RuntimeException {
+      return TaskUtils.ExportStatus.FAILED;
+    }
+
+    @Override
+    protected void executeDedup(String dbName, int adminPort, String src_hdfsPath,
+                                String dest_hdfsPath) throws RuntimeException {
+      System.out.println("mock execute dedup");
+    }
+
+    @Override
+    public void cancel() {
+
+    }
+
+    // helper function for testing
+    // java refection: http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
+    private String readPrivateSuperClassStringField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (String) field.get(this);
+    }
+
+    private long readPrivateSuperClassLongField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.getLong(this);
+    }
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestDedupTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestDedupTaskFactory.java
@@ -1,0 +1,308 @@
+package com.pinterest.rocksplicator.task;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.tools.ClusterSetup;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+@RunWith(PowerMockRunner.class)
+public class TestDedupTaskFactory extends TaskTestBase {
+
+  private static final String JOB_COMMAND = "DummyCommand";
+  private static final int NUM_TASK = 2;
+  private Map<String, String> _jobCommandMap;
+  private long mockedLatestResourceVersion = 123456789L;
+
+  private final CountDownLatch allTasksReady = new CountDownLatch(NUM_TASK);
+  private final CountDownLatch adminReady = new CountDownLatch(1);
+
+
+  @Before
+  public void setUp() throws Exception {
+
+  }
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _participants = new MockParticipantManager[_numNodes];
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursively(namespace);
+    }
+
+    // Setup cluster and instances
+    ClusterSetup setupTool = new ClusterSetup(ZK_ADDR);
+    setupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < _numNodes; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    // start dummy participants
+    for (int i = 0; i < _numNodes; i++) {
+      final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+
+      // Set task callbacks
+      Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
+      taskFactoryReg.put("Dedup", new DummyDedupTaskFactory(instanceName.split("_")[0],
+          Integer.parseInt(instanceName.split("_")[1]),
+          ZK_ADDR, CLUSTER_NAME));
+
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      // Register a Task state model factory.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      stateMachine.registerStateModelFactory("Task",
+          new TaskStateModelFactory(_participants[i], taskFactoryReg));
+      _participants[i].syncStart();
+    }
+
+    // Start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    // Start an admin connection
+    _manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+
+    _jobCommandMap = new HashMap<>();
+  }
+
+  @Test
+  public void testDedupTaskFactoryCreateNewTaskWithSpecifiedResVersion() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    String resource_cluster = "test_cluster";
+    String resource_segment = "test_segment";
+    String resource_version = String.valueOf(System.currentTimeMillis());
+    Set<String>
+        target_partitions =
+        new HashSet<>(Arrays.asList("test_segment_0", "test_segment_1"));
+
+    // Create 1 jobs with 2 Dedup Task each
+    List<TaskConfig> taskConfigs = new ArrayList<>();
+    for (int i = 0; i < NUM_TASK; i++) {
+      Map<String, String> taskConfigMap = new HashMap<>();
+      taskConfigMap.put("TASK_TARGET_PARTITION", resource_segment + "_" + String.valueOf(i));
+      taskConfigs.add(new TaskConfig("Dedup", taskConfigMap));
+    }
+
+    _jobCommandMap.put("RESOURCE_CLUSTER", resource_cluster);
+    _jobCommandMap.put("RESOURCE", resource_segment);
+    _jobCommandMap.put("RESOURCE_VERSION", resource_version);
+    JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+        .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+    String jobName = "JOB" + 0;
+    workflowBuilder.addJob(jobName, jobConfigBulider);
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    String job = "JOB" + 0;
+    String namespacedJobName = TaskUtil.getNamespacedJobName(workflowName, job);
+    // verify Task Command is passed in: Dedup
+    for (TaskConfig taskConfig : _driver.getJobConfig(namespacedJobName).getTaskConfigMap()
+        .values()) {
+      Assert.assertEquals(taskConfig.getCommand(), "Dedup");
+      Assert.assertTrue(target_partitions.contains(taskConfig.getTargetPartition()));
+    }
+
+    Set<String> jobVersions = new HashSet<>();
+
+    // assert each task hold same resource version as job configured
+    for (int i = 0; i < NUM_TASK; i++) {
+      Map<String, String>
+          taskContentMap =
+          _driver.getTaskUserContentMap(workflowName, job, String.valueOf(i));
+      Assert.assertEquals(taskContentMap.get("resourceCluster"), resource_cluster);
+      Assert.assertEquals(taskContentMap.get("resourceName"), resource_segment);
+      Assert.assertEquals(taskContentMap.get("resourceVersion"), resource_version);
+      jobVersions.add(taskContentMap.get("jobVersion"));
+    }
+    Assert.assertEquals(jobVersions.size(), 1);
+
+    _jobCommandMap.clear();
+  }
+
+
+  @Test
+  public void testDedupTaskFactoryCreateNewTaskWithoutSpecifiedResVersion() throws Exception {
+    String resource_cluster = "test_cluster";
+    String resource_segment = "test_segment";
+
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 1 jobs with 2 Dedup Task each
+    List<TaskConfig> taskConfigs = new ArrayList<>();
+    for (int i = 0; i < NUM_TASK; i++) {
+      Map<String, String> taskConfigMap = new HashMap<>();
+      taskConfigMap.put("TASK_TARGET_PARTITION", resource_segment + "_" + String.valueOf(i));
+      taskConfigs.add(new TaskConfig("Dedup", taskConfigMap));
+    }
+    _jobCommandMap.put("RESOURCE_CLUSTER", resource_cluster);
+    _jobCommandMap.put("RESOURCE", resource_segment);
+    JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+        .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+    String jobName = "JOB" + 0;
+    workflowBuilder.addJob(jobName, jobConfigBulider);
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    String job = "JOB" + 0;
+
+    // assert task can dynamically get resource version job is not configed with resource version
+    for (int i = 0; i < NUM_TASK; i++) {
+      Map<String, String>
+          taskContentMap =
+          _driver.getTaskUserContentMap(workflowName, job, String.valueOf(i));
+      Assert.assertEquals(taskContentMap.get("resourceCluster"), resource_cluster);
+      Assert.assertEquals(taskContentMap.get("resourceName"), resource_segment);
+      Assert.assertEquals(taskContentMap.get("resourceVersion"),
+          String.valueOf(mockedLatestResourceVersion));
+    }
+
+    _jobCommandMap.clear();
+  }
+
+  //*****************************************************
+  // dummy TaskFactory, Task to limit testing scope
+  //
+  // Varied behavior based on specific testing class:
+  // - return same resource version
+  // - populate Task level userStore to compared with Job Level userStore
+  //****************************************************/
+
+  protected class DummyDedupTaskFactory extends DedupTaskFactory {
+
+    public DummyDedupTaskFactory(String host, int adminPort, String zkConnectString,
+                                 String cluster) {
+      super(host, adminPort, zkConnectString, cluster);
+    }
+
+    @Override
+    protected Task getTask(String cluster, String resourceCluster, String resourceName,
+                           String targetPartition,
+                           long resourceVersion, long jobVersion, String job,
+                           String host, int port, CuratorFramework zkClient) {
+      return new DummyDedupTask(cluster, resourceCluster, resourceName, targetPartition,
+          resourceVersion,
+          jobVersion, job, host, port, zkClient);
+    }
+
+    @Override
+    protected long getLatestVersion(String cluster, String resource) {
+      return mockedLatestResourceVersion;
+    }
+  }
+
+  protected class DummyDedupTask extends DedupTask {
+
+    public DummyDedupTask(String taskCluster, String resourceCluster, String resourceName,
+                          String partitionName, long resourceVersion, long jobVersion,
+                          String job, String host, int adminPort,
+                          CuratorFramework zkClient) {
+      super(taskCluster, resourceCluster, resourceName, partitionName, resourceVersion, jobVersion,
+          job, host, adminPort, zkClient);
+    }
+
+    @Override
+    public TaskResult run() {
+      allTasksReady.countDown();
+      try {
+        adminReady.await();
+      } catch (Exception e) {
+        return new TaskResult(TaskResult.Status.FATAL_FAILED, e.getMessage());
+      }
+
+      // store Dedup_limit_mbs, jobVersion into Task userStore to verify succesfully passed from
+      // DedupTaskfactory
+      try {
+        // use Java reflection to access supper class's private members, only for testing
+        String resCluster = readPrivateSuperClassStringField("resourceCluster");
+        String resName = readPrivateSuperClassStringField("resourceName");
+        long resVersion = readPrivateSuperClassLongField("resourceVersion");
+        long jobVersion = readPrivateSuperClassLongField("jobVersion");
+        putUserContent("resourceCluster", resCluster, Scope.TASK);
+        putUserContent("resourceName", resName, Scope.TASK);
+        putUserContent("resourceVersion", String.valueOf(resVersion), Scope.TASK);
+        putUserContent("jobVersion", String.valueOf(jobVersion), Scope.TASK);
+      } catch (Exception e) {
+        System.out.println(e.getCause());
+      }
+
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    // helper function for testing
+    // java refection: http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
+    private String readPrivateSuperClassStringField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (String) field.get(this);
+    }
+
+    private long readPrivateSuperClassLongField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.getLong(this);
+    }
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestGenerator.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestGenerator.java
@@ -1,0 +1,310 @@
+package com.pinterest.rocksplicator.task;
+
+import com.pinterest.rocksplicator.Generator;
+import com.pinterest.rocksplicator.TaskUtils;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.integration.task.WorkflowGenerator;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.tools.ClusterSetup;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.WorkflowConfig;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+public class TestGenerator extends TaskTestBase {
+  private HelixAdmin admin;
+  private static final String JOB_COMMAND = "DummyCommand";
+  private static final int NUM_TASK = 2;
+  private Map<String, String> _jobCommandMap;
+  private long mockedLatestResourceVersion = 123456789L;
+
+  private final CountDownLatch allTasksReady = new CountDownLatch(NUM_TASK);
+  private final CountDownLatch adminReady = new CountDownLatch(1);
+
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _participants = new MockParticipantManager[_numNodes];
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursively(namespace);
+    }
+
+    // Setup cluster and instances
+    ClusterSetup setupTool = new ClusterSetup(ZK_ADDR);
+    setupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < _numNodes; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    // start dummy participants
+    for (int i = 0; i < _numNodes; i++) {
+      final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+
+      // Set task callbacks
+      Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
+      taskFactoryReg.put("Dedup", new DummyDedupTaskFactory(instanceName.split("_")[0],
+          Integer.parseInt(instanceName.split("_")[1]),
+          ZK_ADDR, CLUSTER_NAME));
+
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      // Register a Task state model factory.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      stateMachine.registerStateModelFactory("Task",
+          new TaskStateModelFactory(_participants[i], taskFactoryReg));
+      _participants[i].syncStart();
+    }
+
+    // Start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    // Start an admin connection
+    _manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+    admin = _manager.getClusterManagmentTool();
+
+    _jobCommandMap = new HashMap<>();
+  }
+
+  @BeforeTest
+  public void setup() throws Exception {
+
+  }
+
+  @Test
+  public void TestGetDbResourcesByExcludingWfAndJobs() throws Exception {
+    // add 1 res: TestDB with 20 partNum, and MasterSlave mode
+    super.setupDBs();
+
+    // add workflow
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 1 jobs with 2 Dedup Task
+    List<TaskConfig> taskConfigs = new ArrayList<>();
+    for (int i = 0; i < NUM_TASK; i++) {
+      Map<String, String> taskConfigMap = new HashMap<>();
+      taskConfigMap.put("TASK_TARGET_PARTITION", "test_segment_" + String.valueOf(i));
+      taskConfigs.add(new TaskConfig("Dedup", taskConfigMap));
+    }
+
+    String resource_cluster = "test_cluster";
+    String resource_segment = "test_segment";
+    _jobCommandMap.put("RESOURCE_CLUSTER", resource_cluster);
+    _jobCommandMap.put("RESOURCE", resource_segment);
+
+    JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+        .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+    String jobName = "JOB" + 0;
+    workflowBuilder.addJob(jobName, jobConfigBulider);
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    List<String> resources = admin.getResourcesInCluster(CLUSTER_NAME);
+    // before job completd, resources contain: TestDB, [wf], [job]
+    Assert.assertEquals(resources.size(), 3);
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    DummyGenerator dummyGenerator = new DummyGenerator(CLUSTER_NAME, _manager);
+    List<String> db_resources = dummyGenerator.filterOutWfAndJobs(resources);
+
+    Assert.assertEquals(db_resources.size(), 1);
+    Assert.assertTrue(db_resources.contains(WorkflowGenerator.DEFAULT_TGT_DB));
+
+    // force remove the workflow and its jobs' related zk nodes. prevent affect other tests
+    _driver.delete(workflowName, true);
+
+    _jobCommandMap.clear();
+  }
+
+  @Test
+  public void TestJobStateGeneration() throws Exception {
+    // add workflow
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 2 jobs with 1 Dedup Task
+    String resource_cluster = "test_cluster";
+    String resource_segment = "test_segment";
+    for (int i = 0; i < NUM_TASK; i++) {
+      List<TaskConfig> taskConfigs = new ArrayList<>();
+      Map<String, String> taskConfigMap = new HashMap<>();
+      taskConfigMap.put("TASK_TARGET_PARTITION", resource_segment + i + "_" + String.valueOf(i));
+      taskConfigs.add(new TaskConfig("Dedup", taskConfigMap));
+
+      String jobName = "JOB" + i;
+      Map<String, String> jobCmdMap = new HashMap<>();
+      jobCmdMap.put("RESOURCE_CLUSTER", resource_cluster + i);
+      jobCmdMap.put("RESOURCE", resource_segment + i);
+      JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+          .addTaskConfigs(taskConfigs).setJobCommandConfigMap(jobCmdMap);
+      workflowBuilder.addJob(jobName, jobConfigBulider);
+    }
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    DummyGenerator dummyGenerator = new DummyGenerator(CLUSTER_NAME, _manager);
+    String stateJson = dummyGenerator.getJobStateConfig();
+    Map<String, Map<String, Map<String, String>>> stateMap = TaskUtils.jobStateJsonToMap(stateJson);
+
+    // 2 segments are deduped
+    Assert.assertEquals(stateMap.keySet(),
+        new HashSet<String>(Arrays.asList("test_segment0", "test_segment1")));
+
+    // the deduped resource version is the assigned version
+    Assert.assertTrue(stateMap.get("test_segment0").keySet()
+        .contains(String.valueOf(mockedLatestResourceVersion)));
+    Assert.assertEquals(
+        stateMap.get("test_segment0").get(String.valueOf(mockedLatestResourceVersion)).values(),
+        new HashSet<String>(Arrays.asList("COMPLETED")));
+
+    // force remove the workflow and its jobs' related zk nodes. prevent affect other tests
+    _driver.delete(workflowName, true);
+  }
+
+
+  //*****************************************************
+   // dummy TaskFactory, Task to limit testing scope
+   //
+   // Varied behavior based on specific testing class:
+   // - return same resource version
+   // - no populate Task level userStore
+   //****************************************************/
+
+  protected class DummyDedupTaskFactory extends DedupTaskFactory {
+
+    public DummyDedupTaskFactory(String host, int adminPort, String zkConnectString,
+                                 String cluster) {
+      super(host, adminPort, zkConnectString, cluster);
+    }
+
+    @Override
+    protected Task getTask(String cluster, String resourceCluster, String resourceName,
+                           String targetPartition,
+                           long resourceVersion, long jobVersion, String job,
+                           String host, int port, CuratorFramework zkClient) {
+      return new DummyDedupTask(cluster, resourceCluster, resourceName, targetPartition,
+          resourceVersion,
+          jobVersion, job, host, port, zkClient);
+    }
+
+    @Override
+    protected long getLatestVersion(String cluster, String resource) {
+      // return different resource version to tasks, test unifying version among tasks
+      return mockedLatestResourceVersion;
+    }
+  }
+
+  protected class DummyDedupTask extends DedupTask {
+
+    public DummyDedupTask(String taskCluster, String resourceCluster, String resourceName,
+                          String partitionName, long resourceVersion, long jobVersion,
+                          String job, String host, int adminPort,
+                          CuratorFramework zkClient) {
+      super(taskCluster, resourceCluster, resourceName, partitionName, resourceVersion, jobVersion,
+          job, host, adminPort, zkClient);
+    }
+
+    @Override
+    public TaskResult run() {
+      allTasksReady.countDown();
+      try {
+        adminReady.await();
+      } catch (Exception e) {
+        return new TaskResult(TaskResult.Status.FATAL_FAILED, e.getMessage());
+      }
+
+      super.run();
+
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+
+    @Override
+    protected TaskUtils.BackupStatus getBackupStatus(String cluster, String segment,
+                                                     long resVersion) throws RuntimeException {
+
+      return TaskUtils.BackupStatus.COMPLETED;
+    }
+
+    @Override
+    protected TaskUtils.ExportStatus getExportStatus(String taskCluster, String segment,
+                                                     long resourceVersion, long jobVersion)
+        throws RuntimeException {
+      return TaskUtils.ExportStatus.FAILED;
+    }
+
+    @Override
+    protected void executeDedup(String dbName, int adminPort, String src_hdfsPath,
+                                String dest_hdfsPath) throws RuntimeException {
+      System.out.println("mock execute dedup");
+    }
+
+    @Override
+    public void cancel() {
+    }
+  }
+
+  // dummy Generator for testing public methods: @getJobStateConfig, @filterOutWfAndJobs
+  private class DummyGenerator extends Generator {
+
+    public DummyGenerator(String clusterName, HelixManager helixManager) {
+      super(clusterName, helixManager);
+      super.driver = _driver;
+    }
+
+    @Override
+    public void onCallback(NotificationContext notificationContext) {
+
+    }
+  }
+
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestServerContext.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestServerContext.java
@@ -1,0 +1,182 @@
+package com.pinterest.rocksplicator.task;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.MockTask;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.tools.ClusterSetup;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CuratorFrameworkFactory.class})
+public class TestServerContext extends TaskTestBase {
+
+  private static final String JOB_COMMAND = "DummyCommand";
+  private static final int NUM_JOB = 5;
+  private Map<String, String> _jobCommandMap;
+
+  private final CountDownLatch allTasksReady = new CountDownLatch(NUM_JOB);
+  private final CountDownLatch adminReady = new CountDownLatch(1);
+
+  private ExponentialBackoffRetry mockRetry;
+  private CuratorFramework mockZkClient;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    mockRetry = mock(ExponentialBackoffRetry.class);
+    PowerMockito.whenNew(ExponentialBackoffRetry.class).withAnyArguments().thenReturn(mockRetry);
+
+    mockZkClient = mock(CuratorFramework.class);
+    PowerMockito.spy(CuratorFrameworkFactory.class);
+    doReturn(mockZkClient).when(
+        CuratorFrameworkFactory.class, "newClient", anyString(), mockRetry);
+  }
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _participants = new MockParticipantManager[_numNodes];
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursively(namespace);
+    }
+
+    // Setup cluster and instances
+    ClusterSetup setupTool = new ClusterSetup(ZK_ADDR);
+    setupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < _numNodes; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    // start dummy participants
+    for (int i = 0; i < _numNodes; i++) {
+      final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+
+      Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
+      TaskFactory shortTaskFactory = new TaskFactory() {
+        @Override
+        public Task createNewTask(TaskCallbackContext context) {
+          return new WriteTask(context);
+        }
+      };
+      taskFactoryReg.put("WriteTask", shortTaskFactory);
+
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      // Register a Task state model factory.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      stateMachine.registerStateModelFactory("Task",
+          new TaskStateModelFactory(_participants[i], taskFactoryReg));
+      _participants[i].syncStart();
+    }
+
+    // Start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    // Start an admin connection
+    _manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+
+    _jobCommandMap = new HashMap<>();
+  }
+
+  @Test
+  public void testServerContextAccessZk() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 5 jobs with 1 write Task
+    for (int i = 0; i < NUM_JOB; i++) {
+      List<TaskConfig> taskConfigs = new ArrayList<>();
+      taskConfigs.add(new TaskConfig("WriteTask", new HashMap<String, String>()));
+      JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+          .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+      String jobName = "JOB" + i;
+      String taskPartitionId = "0";
+      workflowBuilder.addJob(jobName, jobConfigBulider);
+    }
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+
+    ServerContext serverContext = new ServerContext(ZK_ADDR);
+    TaskDriver taskDriver = serverContext.getTaskDriver(CLUSTER_NAME);
+    Map<String, WorkflowConfig> workflowConfigMap = taskDriver.getWorkflows();
+    Map<String, List<String>> dataMap = new HashMap<>();
+    dataMap.put("workflows", new ArrayList<>(workflowConfigMap.keySet()));
+    for (String wf : dataMap.get("workflows")) {
+      System.out.println("Inside spectator, task driver dump workflowContext: " +
+          taskDriver.getWorkflowContext(wf));
+    }
+
+    Assert.assertEquals(_driver.getJobConfig(workflowName + "_JOB0"), taskDriver.getJobConfig(workflowName + "_JOB0"));
+  }
+
+  private class WriteTask extends MockTask {
+
+    public WriteTask(TaskCallbackContext context) {
+      super(context);
+    }
+
+    @Override
+    public TaskResult run() {
+      allTasksReady.countDown();
+      try {
+        adminReady.await();
+      } catch (Exception e) {
+        return new TaskResult(TaskResult.Status.FATAL_FAILED, e.getMessage());
+      }
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+  }
+}
+

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestTaskUtils.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestTaskUtils.java
@@ -1,0 +1,26 @@
+package com.pinterest.rocksplicator.task;
+
+import com.pinterest.rocksplicator.TaskUtils;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@RunWith(PowerMockRunner.class)
+public class TestTaskUtils {
+
+  @Before
+  public void setUp() throws Exception {
+  }
+
+  @Test
+  public void testBuildStatePostUrl() throws Exception {
+    String configPostUrl = "http://prefix.com/clusterA?mode=overwrite";
+    String expectedStatePostUrl = "http://prefix.com/clusterA_state?mode=overwrite";
+    String statePostUrl = TaskUtils.buildStatePostUrl(configPostUrl);
+    Assert.assertEquals(statePostUrl, expectedStatePostUrl);
+  }
+}


### PR DESCRIPTION
Add helix task framework (1.0) support into rocksplicator

Previously, rocksplicator was only used to manage db resource with participant register to one of statemodels, e.g. MasterSlave, Bootstrap, etc. Here, we integrate Helix Task framework (1.0) into rocksplicator. After this, participant cluster will register to: ([0 or 1 of statemodels, ie. MasterSlave, Bootstrap, etc] + [Task]). 
**Unchanged:** 
cluster resource management, e.g. if participant cluster still register to 1 statemodel (MasterSlave, etc), state transitions will remain as before
**Added:**
we can perform operations with Task on top of resource. e.g. use Task to backup resources (i.e. db shards)  

How-to:
each participant cluster will register to Task along with selected statemodels (MasterSlave, Bootstrap, etc). To use our provided Tasks (e.g. BackupTask, RestoreTask, DedupTask), just set JobConfigProperty.JobType to be "Backup" or "Resource" or "Dedup" during job creation. 

changelists:
1. Add Participant to register to Task 
2. Register Backup, Restore, Dedup TaskFactory
3. (will provide sample script to add jobs throught helix UI)
