### PR TITLE
[s3_env] optimize s3 env backup process

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -739,11 +739,11 @@ void AdminHandler::async_tm_backupDBToS3(
     return;
   }
 
+  common::Timer timer(kS3BackupMs);
   auto local_s3_util = createLocalS3Util(request->limit_mbs, request->s3_bucket);
   std::string formatted_s3_dir_path = rtrim(request->s3_backup_dir, '/');
   rocksdb::Env* s3_env = new rocksdb::S3Env(formatted_s3_dir_path, local_path, std::move(local_s3_util));
 
-  common::Timer timer(kS3BackupMs);
   LOG(INFO) << "S3 Backup " << request->db_name << " to " << formatted_s3_dir_path;
   if (!backupDBHelper(request->db_name,
                       formatted_s3_dir_path,
@@ -806,12 +806,12 @@ void AdminHandler::async_tm_restoreDBFromS3(
     return;
   }
 
+  common::Timer timer(kS3RestoreMs);
   auto local_s3_util = createLocalS3Util(request->limit_mbs, request->s3_bucket);
   std::string formatted_s3_dir_path = rtrim(request->s3_backup_dir, '/');
   rocksdb::Env* s3_env = new rocksdb::S3Env(
   formatted_s3_dir_path, std::move(local_path), std::move(local_s3_util));
 
-  common::Timer timer(kS3RestoreMs);
   LOG(INFO) << "S3 Restore " << request->db_name << " from " << formatted_s3_dir_path;
   if (!restoreDBHelper(request->db_name,
                        formatted_s3_dir_path,


### PR DESCRIPTION
S3 does not support renaming natively, so previously we need to upload these
tmp files into S3, copy them to target name, and then delete these tmp files, so
there are 3 file operations(2 copy + 1 delete). In the new logic, we do the
renaming locally and then upload them to s3, and only 1 copy is needed(local
linux rename is a mv, the overhead could be omitted).