### PR TITLE
[cluster management] add backup taskFactory and task impl

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -281,6 +281,22 @@ public class Utils {
     }
   }
 
+  public static void backupDBWithLimit(String host, int adminPort, String dbName, String hdfsPath,
+                                       int limitMbs)
+      throws RuntimeException {
+    LOG.error("Backup " + dbName + " from " + host + " to " + hdfsPath);
+    try {
+      Admin.Client client = getAdminClient(host, adminPort);
+
+      BackupDBRequest req = new BackupDBRequest(dbName, hdfsPath);
+      req.setLimit_mbs(limitMbs);
+      client.backupDB(req);
+    } catch (TException e) {
+      LOG.error("Failed to backup DB: ", e.toString());
+      throw new RuntimeException(e);
+    }
+  }
+
   /**
    * Restore the local DB from HDFS
    * @param adminPort

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTask.java
@@ -1,0 +1,121 @@
+/// Copyright 2017 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author kangnanli (kangnanli@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.task;
+
+import com.pinterest.rocksplicator.Utils;
+
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.UserContentStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * backup a single local db shard to cloud
+ */
+public class BackupTask extends UserContentStore implements Task {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BackupTask.class);
+
+  private final String taskCluster;
+  private final String partitionName;
+  private final int backupLimitMbs;
+  private final String storePathPrefix;
+  private final long resourceVersion;
+  private final String job;
+  private final int adminPort;
+
+  public BackupTask(String taskCluster, String partitionName, int backupLimitMbs,
+                    String storePathPrefix, long resourceVersion, String job, int adminPort) {
+    this.taskCluster = taskCluster;
+    this.partitionName = partitionName;
+    this.backupLimitMbs = backupLimitMbs;
+    this.storePathPrefix = storePathPrefix;
+    this.resourceVersion = resourceVersion;
+    this.job = job;
+    this.adminPort = adminPort;
+  }
+
+  /**
+   * Execute the task.
+   * @return A {@link TaskResult} object indicating the status of the task and any additional
+   *         context information that can be interpreted by the specific {@link Task}
+   *         implementation.
+   */
+  @Override
+  public TaskResult run() {
+
+    String dbName = Utils.getDbName(partitionName);
+    if (storePathPrefix.isEmpty()) {
+      String errMsg =
+          "Cancel the task, storePathPrefix is not provided from job command config map";
+      LOG.error(errMsg);
+      return new TaskResult(TaskResult.Status.CANCELED, errMsg);
+    }
+
+    try {
+      String storePath =
+          String.format("%s/%s/%s", storePathPrefix, String.valueOf(resourceVersion), dbName);
+
+      LOG.error(
+          String.format(
+              "BackupTask run to backup partition: %s to storePath: %s. Other info {taskCluster: "
+                  + "%s, job: %s, version: %d}", partitionName, storePath, taskCluster, job,
+              resourceVersion));
+
+      executeBackup("127.0.0.1", adminPort, dbName, storePath, backupLimitMbs);
+
+      return new TaskResult(TaskResult.Status.COMPLETED, "BackupTask is completed!");
+    } catch (Exception e) {
+      LOG.error("Task backup failed", e);
+      return new TaskResult(TaskResult.Status.FAILED, "BackupTask failed");
+    }
+
+  }
+
+  protected void executeBackup(String host, int port, String dbName, String storePath,
+                               int backupLimitMbs) throws RuntimeException {
+    try {
+      Utils.backupDBWithLimit(host, port, dbName, storePath, backupLimitMbs);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Signals the task to stop execution. The task implementation should carry out any clean up
+   * actions that may be required and return from the {@link #run()} method.
+   *
+   * with default TaskStateModel, "cancel()" invoked by {@link org.apache.helix.task.TaskRunner
+   * #cancel()} during state transitions: running->stopped /task_aborted /dropped /init, and during
+   * {@link org.apache.helix.task.TaskStateModel #reset()}
+   */
+  @Override
+  public void cancel() {
+    // TODO: delete the db from cloud when cancel
+    // bakcup might be interrupted by host unreachable or termination or issued cancellation; after
+    // cancel, partial backup files remained on cloud by rocksdb backupEngine.
+    // Two options: 1. remove unfinished shard, so that new backup can start over; 2. leave
+    // untouched, if Task resume on same replica, then, wont re-upload those files, if Task
+    // resume on another replica, will ignore(?) leftovers since checksum of files are verified
+
+    // options2: leave leftovers untouched
+    LOG.error("BackupTask cancelled");
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
@@ -1,0 +1,117 @@
+/// Copyright 2017 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author kangnanli (kangnanli@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.task;
+
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * An implementation of {@link TaskFactory} that create Tasks upon backup-job launching.
+ *
+ * This class takes in {@param adminPort}, {@param cluster}, from
+ * {@link com.pinterest.rocksplicator.Participant} to create tasks to backup local db to cloud.
+ **
+ * Upon Task creation, configs inherited from job configs JobCommandConfigMap: STORE_PATH_PREFIX,
+ * the cloud path prefix to store the backup; RESOURCE_VERSION: the timestamp the backup job is
+ * submitted from scheduling service, if not provided, use the job creation time as the default
+ * resource version; "prefix/[version]/[dbName]" will be the full filesystem path to store db on
+ * cloud; (optional) BACKUP_LIMIT_MBS, specify backup limit by mbs;
+ */
+public class BackupTaskFactory implements TaskFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BackupTaskFactory.class);
+
+  private final String cluster;
+  private final int adminPort;
+
+  private static final int DEFAULT_BACKUP_LIMIT_MBS = 64;
+
+  public BackupTaskFactory(String cluster, int adminPort) {
+    this.cluster = cluster;
+    this.adminPort = adminPort;
+  }
+
+  /**
+   * Returns a {@link Task} instance.
+   * @param context Contextual information for the task, including task and job configurations
+   */
+  @Override
+  public Task createNewTask(TaskCallbackContext context) {
+
+    TaskConfig taskConfig = context.getTaskConfig();
+    JobConfig jobConfig = context.getJobConfig();
+    String job = jobConfig.getJobId();
+
+    LOG.error("Create task with TaskConfig: " + taskConfig.toString());
+
+    long jobCreationTime = jobConfig.getStat().getCreationTime();
+
+    String storePathPrefix = "";
+    long resourceVersion = jobCreationTime;
+    int backupLimitMbs = DEFAULT_BACKUP_LIMIT_MBS;
+
+    try {
+      Map<String, String> jobCmdMap = jobConfig.getJobCommandConfigMap();
+      if (jobCmdMap != null && !jobCmdMap.isEmpty()) {
+        if (jobCmdMap.containsKey("STORE_PATH_PREFIX")) {
+          storePathPrefix = jobCmdMap.get("STORE_PATH_PREFIX");
+        }
+        if (jobCmdMap.containsKey("RESOURCE_VERSION")) {
+          resourceVersion = Long.parseLong(jobCmdMap.get("RESOURCE_VERSION"));
+        }
+        if (jobCmdMap.containsKey("BACKUP_LIMIT_MBS")) {
+          backupLimitMbs = Integer.parseInt(jobCmdMap.get("BACKUP_LIMIT_MBS"));
+        }
+      }
+    } catch (NumberFormatException e) {
+      LOG.error(
+          String.format(
+              "Failed to parse configs from job command config map, use defaults backupLimitMbs: "
+                  + "%d, resourceVersion: %d", DEFAULT_BACKUP_LIMIT_MBS, resourceVersion), e);
+    }
+
+    String targetPartition = taskConfig.getTargetPartition();
+
+    LOG.error(
+        String.format(
+            "Create Task for cluster: %s, targetPartition: %s from job: %s to execute at "
+                + "localhost, port: %d. {resourceVersion: %d, helixJobCreationTime: %d, "
+                + "taskCreationTime: %d}",
+            cluster, targetPartition, job, adminPort, resourceVersion, jobCreationTime,
+            System.currentTimeMillis()));
+
+    return getTask(cluster, targetPartition, backupLimitMbs, storePathPrefix, resourceVersion, job,
+        adminPort);
+  }
+
+  protected Task getTask(String cluster, String targetPartition, int backupLimitMbs,
+                         String storePathPrefix, long resourceVersion, String job, int port) {
+    return new BackupTask(cluster, targetPartition, backupLimitMbs, storePathPrefix,
+        resourceVersion, job, port);
+  }
+
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTaskFactory.java
@@ -1,0 +1,291 @@
+package com.pinterest.rocksplicator.task;
+
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.tools.ClusterSetup;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.Assert;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+
+public class TestBackupTaskFactory extends TaskTestBase {
+
+  private static final String JOB_COMMAND = "DummyCommand";
+  private static final int NUM_JOB = 2;
+  private static final int NUM_TASK_PER_JOB = 2;
+  private static final int NUM_TASK = NUM_JOB * NUM_TASK_PER_JOB;
+  private Map<String, String> _jobCommandMap;
+
+  private static final long fakeResourceVersion = 1234L;
+
+  private final CountDownLatch allTasksReady = new CountDownLatch(NUM_TASK);
+  private final CountDownLatch adminReady = new CountDownLatch(1);
+
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _participants = new MockParticipantManager[_numNodes];
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursively(namespace);
+    }
+
+    // Setup cluster and instances
+    ClusterSetup setupTool = new ClusterSetup(ZK_ADDR);
+    setupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < _numNodes; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    // start dummy participants
+    for (int i = 0; i < _numNodes; i++) {
+      final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+
+      // Set task callbacks
+      Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
+      taskFactoryReg.put("Backup", new DummyBackupTaskFactory(CLUSTER_NAME,
+          Integer.parseInt(instanceName.split("_")[1])));
+
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      // Register a Task state model factory.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      stateMachine.registerStateModelFactory("Task",
+          new TaskStateModelFactory(_participants[i], taskFactoryReg));
+      _participants[i].syncStart();
+    }
+
+    // Start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    // Start an admin connection
+    _manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+
+    _jobCommandMap = new HashMap<>();
+  }
+
+  @BeforeMethod
+  public void setUp(Method m) throws Exception {
+    String workflowName = m.getName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 2 jobs with 2 Backup Tasks each
+    for (int i = 0; i < NUM_JOB; i++) {
+      String jobName = "JOB" + i;
+
+      _jobCommandMap.put("STORE_PATH_PREFIX", "/test_cloud");
+      _jobCommandMap.put("BACKUP_LIMIT_MBS", String.valueOf(10));
+      _jobCommandMap.put("RESOURCE_VERSION", String.valueOf(fakeResourceVersion + i));
+
+      List<TaskConfig> taskConfigs = new ArrayList<>();
+      for (int j = 0; j < NUM_TASK_PER_JOB; ++j) {
+        Map<String, String> taskConfigMap = new HashMap<>();
+        taskConfigMap.put("TASK_TARGET_PARTITION", "test_seg_" + j);
+        taskConfigs.add(new TaskConfig("Backup", taskConfigMap));
+      }
+
+      JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+          .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+      workflowBuilder.addJob(jobName, jobConfigBulider);
+    }
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+  }
+
+  @AfterMethod
+  public void cleanUp(Method m) throws Exception {
+    _jobCommandMap.clear();
+  }
+
+  @Test
+  public void testBackupTaskFactoryCreateNewTaskWithPassedConfigs() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+
+    Assert.assertEquals(_driver.getWorkflowConfig(workflowName).getWorkflowId(), workflowName);
+
+    for (int i = 0; i < NUM_JOB; i++) {
+      String jobName = "JOB" + i;
+      String namespacedJobName = TaskUtil.getNamespacedJobName(workflowName, jobName);
+      JobConfig jobConfig = _driver.getJobConfig(namespacedJobName);
+
+      Assert.assertEquals(jobConfig.getCommand(), JOB_COMMAND);
+
+      Set<String> taskTargetParts = new HashSet<>();
+      for (TaskConfig taskConfig : _driver.getJobConfig(namespacedJobName).getTaskConfigMap()
+          .values()) {
+        Assert.assertEquals(taskConfig.getCommand(), "Backup");
+        taskTargetParts.add(taskConfig.getTargetPartition());
+
+        Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("STORE_PATH_PREFIX"),
+            _driver.getTaskUserContentMap(workflowName, jobName, "0").get("storePathPrefix"));
+
+        Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("BACKUP_LIMIT_MBS"),
+            _driver.getTaskUserContentMap(workflowName, jobName, "0").get("backupLimitMbs"));
+
+        Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("RESOURCE_VERSION"),
+            _driver.getTaskUserContentMap(workflowName, jobName, "0").get("resourceVersion"));
+      }
+
+      Assert
+          .assertEquals(taskTargetParts, new HashSet<>(Arrays.asList("test_seg_0", "test_seg_1")));
+    }
+  }
+
+  @Test
+  public void testResVersionDifferAmongTasksFromDiffJobs() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+
+    Set<String> resVersions = new HashSet<>();
+    for (int i = 0; i < NUM_JOB; i++) {
+      String job = "JOB" + i;
+      String jobResVersion = _driver.getJobUserContentMap(workflowName, job).get("resourceVersion");
+
+      Assert.assertTrue(resVersions.add(jobResVersion));
+    }
+    Assert.assertEquals(resVersions.size(), 2);
+  }
+
+  @Test
+  public void testResourceVersionSameAmongTasksFromSameJob() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+
+    for (int i = 0; i < NUM_JOB; ++i) {
+      String jobName = "JOB" + 0;
+      Set<String> resourceVersions = new HashSet<>();
+      for (int j = 0; j < NUM_TASK_PER_JOB; j++) {
+        resourceVersions.add(_driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(j))
+            .get("resourceVersion"));
+      }
+      Assert.assertEquals(resourceVersions.size(), 1);
+    }
+  }
+
+  //*****************************************************
+  // dummy TaskFactory, Task to limit testing scope
+  //
+  // Varied behavior based on specific testing class:
+  // - populate Task level userStore
+  //****************************************************/
+
+  private class DummyBackupTaskFactory extends BackupTaskFactory {
+
+    public DummyBackupTaskFactory(String cluster, int adminPort) {
+      super(cluster, adminPort);
+    }
+
+    @Override
+    protected Task getTask(String cluster, String targetPartition, int backupLimitMbs,
+                           String storePathPrefix, long resourceVersion, String job, int port) {
+      return new DummyBackupTask(cluster, targetPartition, backupLimitMbs, storePathPrefix,
+          resourceVersion, job, port);
+    }
+  }
+
+  private class DummyBackupTask extends BackupTask {
+
+    public DummyBackupTask(String taskCluster, String partitionName, int backupLimitMbs,
+                           String storePathPrefix, long resourceVersion, String job,
+                           int adminPort) {
+      super(taskCluster, partitionName, backupLimitMbs, storePathPrefix, resourceVersion, job,
+          adminPort);
+    }
+
+    @Override
+    public TaskResult run() {
+      allTasksReady.countDown();
+      try {
+        adminReady.await();
+      } catch (Exception e) {
+        return new TaskResult(TaskResult.Status.FATAL_FAILED, e.getMessage());
+      }
+
+      // store task info into Task level userStore to compare with BackupTaskfactory
+      try {
+        long resVersion = readPrivateSuperClassLongField("resourceVersion");
+        int backupLimitMbs = readPrivateSuperClassIntField("backupLimitMbs");
+        String storePathPrefix = readPrivateSuperClassStringField("storePathPrefix");
+        putUserContent("resourceVersion", String.valueOf(resVersion), Scope.JOB);
+        putUserContent("resourceVersion", String.valueOf(resVersion), Scope.TASK);
+        putUserContent("backupLimitMbs", String.valueOf(backupLimitMbs), Scope.TASK);
+        putUserContent("storePathPrefix", storePathPrefix, Scope.TASK);
+      } catch (Exception e) {
+        System.out.println(
+            "Failed to read super class's private filed or fail to pur userStore" + e.getMessage());
+      }
+
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    // helper function for testing
+    // java refection: http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
+
+    private long readPrivateSuperClassLongField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.getLong(this);
+    }
+
+    private int readPrivateSuperClassIntField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.getInt(this);
+    }
+
+    private String readPrivateSuperClassStringField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (String) field.get(this);
+    }
+  }
+}


### PR DESCRIPTION
Add backup support. This will enable schedule ad-hoc or recurrent backup of segments. With backup, the cluster is more resilient to cluster failure; and provide source data for downstream offline data analysis. 

Details: after backup job is configured and submit to helix task framework (ie. through helix rest); helix will pick up the job and create backup tasks, and each Task is responsible to call backupDB from rocksdb_admin to upload db from local to cloud. 