### PR TITLE
add dedup task and taskfactory

### DIFF
--- a/cluster_management/pom.xml
+++ b/cluster_management/pom.xml
@@ -103,6 +103,18 @@
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.25</version>
     </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>6.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.helix</groupId>
+      <artifactId>helix-core</artifactId>
+      <version>0.8.4</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -33,6 +33,7 @@ import com.pinterest.rocksdb_admin.thrift.GetSequenceNumberRequest;
 import com.pinterest.rocksdb_admin.thrift.GetSequenceNumberResponse;
 import com.pinterest.rocksdb_admin.thrift.RestoreDBRequest;
 import com.pinterest.rocksdb_admin.thrift.RestoreDBFromS3Request;
+import com.pinterest.rocksdb_admin.thrift.CompactDBRequest;
 
 import org.apache.helix.model.Message;
 import org.apache.thrift.TException;
@@ -350,6 +351,18 @@ public class Utils {
         throw new RuntimeException(e);
       }
     }
+
+  public static void compactDB(int adminPort, String dbName) throws RuntimeException {
+    LOG.error(String.format("Compact partition: %s", dbName));
+    try {
+      Admin.Client client = getLocalAdminClient(adminPort);
+      CompactDBRequest req = new CompactDBRequest(dbName);
+      client.compactDB(req);
+    } catch (TException e) {
+      LOG.error("Failed to dedup DB: ", e.toString());
+      throw new RuntimeException(e);
+    }
+  }
 
   /**
    * Check if the DB on host:adminPort is Master. If the CheckDBRequest request fails, return false.

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTask.java
@@ -1,0 +1,113 @@
+package com.pinterest.rocksplicator.task;
+
+import com.pinterest.rocksplicator.Utils;
+
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.UserContentStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DedupTask extends UserContentStore implements Task {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DedupTask.class);
+
+  private final String srcStorePathPrefix;
+  private final long resourceVersion;
+  private final String partitionName;
+  private final String taskCluster;
+  private final String job;
+  private final int adminPort;
+  private final String destStorePathPrefix;
+
+  public DedupTask(String srcStorePathPrefix, long resourceVersion, String partitionName,
+                   String taskCluster, String job, int adminPort,
+                   String destStorePathPrefix) {
+    this.srcStorePathPrefix = srcStorePathPrefix;
+    this.resourceVersion = resourceVersion;
+    this.partitionName = partitionName;
+    this.taskCluster = taskCluster;
+    this.job = job;
+    this.adminPort = adminPort;
+    this.destStorePathPrefix = destStorePathPrefix;
+  }
+
+  /**
+   * Execute the task.
+   * @return A {@link TaskResult} object indicating the status of the task and any additional
+   *         context information that can be interpreted by the specific {@link Task}
+   *         implementation.
+   */
+  @Override
+  public TaskResult run() {
+
+    if (srcStorePathPrefix.isEmpty() || resourceVersion == -1 || destStorePathPrefix.isEmpty()) {
+      String errMsg =
+          "Cancel the task, due to job command config map failed to provide all three of "
+              + "srcStorePathPrefix, resourceVersion, and destStorePathPrefix";
+      LOG.error(errMsg);
+      return new TaskResult(TaskResult.Status.CANCELED, errMsg);
+    }
+
+    // check task created with resource name and match prefix of target partition
+    String dbName = Utils.getDbName(partitionName);
+
+    try {
+
+      String srcStorePath =
+          String.format("%s/%s/%s", srcStorePathPrefix, String.valueOf(resourceVersion), dbName);
+
+      String destStorePath =
+          String.format("%s/%s/%s", destStorePathPrefix, String.valueOf(resourceVersion), dbName);
+
+      LOG.error(
+          String.format(
+              "DedupTask run to dedup partition: %s from source path: %s, to dest path: %s "
+                  + "Other info {cluster: %s, job: %s, resourceVersion: %d}", dbName,
+              srcStorePath, destStorePath, taskCluster, job, resourceVersion));
+
+      executeDedup(dbName, adminPort, srcStorePath, destStorePath);
+
+      LOG.error("DedupTask completed, with: success");
+      return new TaskResult(TaskResult.Status.COMPLETED, "DedupTask is completed!");
+    } catch (Exception e) {
+      LOG.error("Task dedup failed", e);
+      return new TaskResult(TaskResult.Status.FAILED, "DedupTask failed");
+    }
+
+  }
+
+  protected void executeDedup(String dbName, int adminPort, String srcStorePath,
+                              String destStorePath) throws RuntimeException {
+    try {
+      Utils.addDB(dbName, adminPort);
+      Utils.closeDB(dbName, adminPort);
+      Utils.restoreLocalDB(adminPort, dbName, srcStorePath, "127.0.0.1", adminPort);
+      LOG.error("restoreDB is done, begin compactDB");
+
+      Utils.compactDB(adminPort, dbName);
+      LOG.error("compactDB is done");
+
+      Utils.backupDB("127.0.0.1", adminPort, dbName, destStorePath);
+      Utils.clearDB(dbName, adminPort);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Signals the task to stop execution. The task implementation should carry out any clean up
+   * actions that may be required and return from the {@link #run()} method.
+   *
+   * with default TaskStateModel, "cancel()" invoked by {@link org.apache.helix.task.TaskRunner
+   * #cancel()} during state transitions: running->stopped /task_aborted /dropped /init, and during
+   * {@link org.apache.helix.task.TaskStateModel #reset()}
+   */
+  @Override
+  public void cancel() {
+    // upon cancel, clear db from local
+    String dbName = Utils.getDbName(partitionName);
+    Utils.clearDB(dbName, adminPort);
+    LOG.error("DedupTask cancelled");
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
@@ -1,0 +1,89 @@
+package com.pinterest.rocksplicator.task;
+
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * an implementation of {@link TaskFactory} that creates Tasks to dedup rocksdb instances
+ *
+ * This class takes in {@param cluster}, {@param adminPort}, from
+ * {@link com.pinterest.rocksplicator.Participant} used to identify job (tasks) belonging.
+ *
+ * Upon Task creation, take in params from JobConfig which could be passed at job creation.
+ * JobCommandConfigMap: SRC_STORE_PATH_PREFIX, RESOURCE_VERSION, DEST_STORE_PATH_PREFIX
+ * Upon Task execution, download db from "src_prefix/version/dbName", dedup, upload to
+ * "dest_prefix/version/dbName"
+ */
+
+public class DedupTaskFactory implements TaskFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DedupTaskFactory.class);
+
+  private final String cluster;
+  private final int adminPort;
+
+  public DedupTaskFactory(String cluster, int adminPort) {
+    this.cluster = cluster;
+    this.adminPort = adminPort;
+  }
+
+  /**
+   * @param context Contextual information for the task, including task and job configurations
+   * @return A {@link Task} instance.
+   */
+  @Override
+  public Task createNewTask(TaskCallbackContext context) {
+
+    TaskConfig taskConfig = context.getTaskConfig();
+    JobConfig jobConfig = context.getJobConfig();
+    String job = jobConfig.getJobId();
+
+    LOG.error("Create task with TaskConfig: " + taskConfig.toString());
+
+    String srcStorePathPrefix = "";
+    long resourceVersion = -1;
+    String destStorePathPrefix = "";
+
+    try {
+      Map<String, String> jobCmdMap = jobConfig.getJobCommandConfigMap();
+      if (jobCmdMap != null && !jobCmdMap.isEmpty()) {
+        if (jobCmdMap.containsKey("SRC_STORE_PATH_PREFIX")) {
+          srcStorePathPrefix = jobCmdMap.get("SRC_STORE_PATH_PREFIX");
+        }
+        if (jobCmdMap.containsKey("RESOURCE_VERSION")) {
+          resourceVersion = Long.parseLong(jobCmdMap.get("RESOURCE_VERSION"));
+        }
+        if (jobCmdMap.containsKey("DEST_STORE_PATH_PREFIX")) {
+          destStorePathPrefix = jobCmdMap.get("DEST_STORE_PATH_PREFIX");
+        }
+      }
+    } catch (NumberFormatException e) {
+      LOG.error("Failed to parse resource_version from job command config map", e);
+    }
+
+    String targetPartition = taskConfig.getTargetPartition();
+
+    LOG.error(String.format(
+        "Create Task for cluster: %s, targetPartition: %s from job: %s to execute at localhost, port:"
+            + " %d. {resourceVersion: %d, helixJobCreationTime: %d, taskCreationTime: %d}", cluster,
+        targetPartition, job, adminPort, resourceVersion, jobConfig.getStat().getCreationTime(),
+        System.currentTimeMillis()));
+
+    return getTask(srcStorePathPrefix, resourceVersion, targetPartition, cluster, job, adminPort,
+        destStorePathPrefix);
+  }
+
+  protected DedupTask getTask(String srcStorePathPrefix, long resourceVersion, String partitionName,
+                              String cluster, String job, int port, String destStorePathPrefix) {
+    return new DedupTask(srcStorePathPrefix, resourceVersion, partitionName, cluster, job, port,
+        destStorePathPrefix);
+  }
+
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestDedupTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestDedupTaskFactory.java
@@ -1,0 +1,246 @@
+package com.pinterest.rocksplicator.task;
+
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.ClusterControllerManager;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.apache.helix.tools.ClusterSetup;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+public class TestDedupTaskFactory extends TaskTestBase {
+
+  private static final String JOB_COMMAND = "DummyCommand";
+  private static final int NUM_JOB = 2;
+  private static final int NUM_TASK_PER_JOB = 2;
+  private static final int NUM_TASK = NUM_JOB * NUM_TASK_PER_JOB;
+  private Map<String, String> _jobCommandMap;
+
+  private final String fakeSrcStorePathPrefix = "/source/store";
+  private final long fakeResourceVersion = 123456789L;
+  private final String fakeDestStorePathPrefix = "/dest/store";
+
+  private final CountDownLatch allTasksReady = new CountDownLatch(NUM_TASK);
+  private final CountDownLatch adminReady = new CountDownLatch(1);
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    _participants = new MockParticipantManager[_numNodes];
+    String namespace = "/" + CLUSTER_NAME;
+    if (_gZkClient.exists(namespace)) {
+      _gZkClient.deleteRecursively(namespace);
+    }
+
+    // Setup cluster and instances
+    ClusterSetup setupTool = new ClusterSetup(ZK_ADDR);
+    setupTool.addCluster(CLUSTER_NAME, true);
+    for (int i = 0; i < _numNodes; i++) {
+      String storageNodeName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+      setupTool.addInstanceToCluster(CLUSTER_NAME, storageNodeName);
+    }
+
+    // start dummy participants
+    for (int i = 0; i < _numNodes; i++) {
+      final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+
+      // Set task callbacks
+      Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
+      taskFactoryReg.put("Dedup",
+          new DummyDedupTaskFactory(CLUSTER_NAME, Integer.parseInt(instanceName.split("_")[1])));
+
+      _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
+
+      // Register a Task state model factory.
+      StateMachineEngine stateMachine = _participants[i].getStateMachineEngine();
+      stateMachine.registerStateModelFactory("Task",
+          new TaskStateModelFactory(_participants[i], taskFactoryReg));
+      _participants[i].syncStart();
+    }
+
+    // Start controller
+    String controllerName = CONTROLLER_PREFIX + "_0";
+    _controller = new ClusterControllerManager(ZK_ADDR, CLUSTER_NAME, controllerName);
+    _controller.syncStart();
+
+    // Start an admin connection
+    _manager = HelixManagerFactory.getZKHelixManager(CLUSTER_NAME, "Admin",
+        InstanceType.ADMINISTRATOR, ZK_ADDR);
+    _manager.connect();
+    _driver = new TaskDriver(_manager);
+
+    _jobCommandMap = new HashMap<>();
+  }
+
+  @BeforeMethod
+  public void setUp(Method m) throws Exception {
+    String workflowName = m.getName();
+
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 2 jobs with 2 Dedup Tasks each
+    for (int i = 0; i < NUM_JOB; i++) {
+      String jobName = "JOB" + i;
+
+      _jobCommandMap.put("SRC_STORE_PATH_PREFIX", fakeSrcStorePathPrefix);
+      _jobCommandMap.put("RESOURCE_VERSION", String.valueOf(fakeResourceVersion + i));
+      _jobCommandMap.put("DEST_STORE_PATH_PREFIX", fakeDestStorePathPrefix);
+
+      List<TaskConfig> taskConfigs = new ArrayList<>();
+      for (int j = 0; j < NUM_TASK_PER_JOB; ++j) {
+        Map<String, String> taskConfigMap = new HashMap<>();
+        taskConfigMap.put("TASK_TARGET_PARTITION", "test_seg_" + j);
+        taskConfigs.add(new TaskConfig("Dedup", taskConfigMap));
+      }
+
+      JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+          .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+      workflowBuilder.addJob(jobName, jobConfigBulider);
+    }
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+  }
+
+  @AfterMethod
+  public void cleanUp(Method m) throws Exception {
+    _jobCommandMap.clear();
+  }
+
+  @Test
+  public void testDedupTaskFactoryCreateNewTaskWithSpecifiedConfigs() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+
+    System.out.println(workflowName);
+    // verify Task Command is passed in: Dedup
+    for (int i = 0; i < NUM_JOB; i++) {
+      String jobName = "JOB" + i;
+      String namespacedJobName = TaskUtil.getNamespacedJobName(workflowName, jobName);
+      JobConfig jobConfig = _driver.getJobConfig(namespacedJobName);
+
+      Set<String> taskTargetParts = new HashSet<>();
+      for (TaskConfig taskConfig : _driver.getJobConfig(namespacedJobName).getTaskConfigMap()
+          .values()) {
+        Assert.assertEquals(taskConfig.getCommand(), "Dedup");
+        taskTargetParts.add(taskConfig.getTargetPartition());
+
+        Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("SRC_STORE_PATH_PREFIX"),
+            _driver.getTaskUserContentMap(workflowName, jobName, "0").get("srcStorePathPrefix"));
+
+        Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("RESOURCE_VERSION"),
+            _driver.getTaskUserContentMap(workflowName, jobName, "0").get("resourceVersion"));
+
+        Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("DEST_STORE_PATH_PREFIX"),
+            _driver.getTaskUserContentMap(workflowName, jobName, "0").get("destStorePathPrefix"));
+      }
+
+      Assert
+          .assertEquals(taskTargetParts, new HashSet<>(Arrays.asList("test_seg_0", "test_seg_1")));
+    }
+
+    _jobCommandMap.clear();
+  }
+
+
+  protected class DummyDedupTaskFactory extends DedupTaskFactory {
+
+    public DummyDedupTaskFactory(String cluster, int adminPort) {
+      super(cluster, adminPort);
+    }
+
+    @Override
+    protected DedupTask getTask(String srcStorePathPrefix, long resourceVersion,
+                                String partitionName, String cluster, String job, int port,
+                                String destStorePathPrefix) {
+      return new DummyDedupTask(srcStorePathPrefix, resourceVersion, partitionName, cluster, job,
+          port, destStorePathPrefix);
+    }
+  }
+
+  protected class DummyDedupTask extends DedupTask {
+
+    public DummyDedupTask(String srcStorePathPrefix, long resourceVersion,
+                          String partitionName, String taskCluster, String job, int adminPort,
+                          String destStorePathPrefix) {
+      super(srcStorePathPrefix, resourceVersion, partitionName, taskCluster, job, adminPort,
+          destStorePathPrefix);
+    }
+
+    @Override
+    public TaskResult run() {
+      allTasksReady.countDown();
+      try {
+        adminReady.await();
+      } catch (Exception e) {
+        return new TaskResult(TaskResult.Status.FATAL_FAILED, e.getMessage());
+      }
+
+      try {
+        String srcStorePathPrefix = readPrivateSuperClassStringField("srcStorePathPrefix");
+        long resVersion = readPrivateSuperClassLongField("resourceVersion");
+        String destStorePathPrefix = readPrivateSuperClassStringField("destStorePathPrefix");
+        putUserContent("srcStorePathPrefix", srcStorePathPrefix, Scope.TASK);
+        putUserContent("resourceVersion", String.valueOf(resVersion), Scope.TASK);
+        putUserContent("destStorePathPrefix", destStorePathPrefix, Scope.TASK);
+      } catch (Exception e) {
+        System.out.println(e.getCause());
+      }
+
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    // helper function for testing
+    // java refection: http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
+    private String readPrivateSuperClassStringField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (String) field.get(this);
+    }
+
+    private long readPrivateSuperClassLongField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.getLong(this);
+    }
+  }
+}


### PR DESCRIPTION
dedup task will download db from given source path, and run full compaction locally based on rocksdb options from the downloaded db, and upload the compacted db back to cloud. 

This full compaction can dedup any lazy-merging keys in rocksdb sst files, and prepare for sst dump into other formats, e.g. SequenceFile,  for offline consumption. 