### PR TITLE
[cluster-management] register dedup task factory into participant

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -19,6 +19,7 @@
 package com.pinterest.rocksplicator;
 
 import com.pinterest.rocksplicator.task.BackupTaskFactory;
+import com.pinterest.rocksplicator.task.DedupTaskFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -220,10 +221,7 @@ public class Participant {
       // taskFactoryRegistry.put("Restore", new RestoreTaskFactory());
 
     } else if (stateModelType.equals("Task")) {
-
-      // TODO: register dedup factories
-      // taskFactoryRegistry.put("Dedup", new DedupTaskFactory());
-
+      taskFactoryRegistry.put("Dedup", new DedupTaskFactory(clusterName, port));
     } else {
       LOG.error("Unknown state model: " + stateModelType);
     }


### PR DESCRIPTION
register dedup task factory into task state model into participant. 

Since our production backup rocksdb dbs still contain duplicated keys in different levels (same key at top level (ie. close to level0) are fresh key-value, while same key at bottom (ie. level 3 or 4) are lazily expired key-value), we can't directly dump the sst through MapReduce jobs since it will contain duplicate keys. 
With dedup task factory, we can download un-compacted sst files from cloud, and do full compaction locally, then, upload the compacted (ie. deduped) sst files back to cloud. This is provide us sst files with duplicate keys to sst dump.

Note: in our case, full compaction will remove obsolete key-value values, and merge those lazy-merge key-values. 