### PR TITLE
Rocksplicator/use s3 as cloud store

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -23,6 +23,7 @@ import com.pinterest.rocksplicator.task.DedupTaskFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.GnuParser;
@@ -55,6 +56,7 @@ import org.slf4j.LoggerFactory;
 
 
 public class Participant {
+
   private static final Logger LOG = LoggerFactory.getLogger(Participant.class);
   private static final String zkServer = "zkSvr";
   private static final String cluster = "cluster";
@@ -217,11 +219,13 @@ public class Participant {
           port, zkConnectString, clusterName, useS3Backup, s3BucketName);
 
       // TODO: register restore factories
-       taskFactoryRegistry.put("Backup", new BackupTaskFactory(clusterName, port));
+      taskFactoryRegistry
+          .put("Backup", new BackupTaskFactory(clusterName, port, useS3Backup, s3BucketName));
       // taskFactoryRegistry.put("Restore", new RestoreTaskFactory());
 
     } else if (stateModelType.equals("Task")) {
-      taskFactoryRegistry.put("Dedup", new DedupTaskFactory(clusterName, port));
+      taskFactoryRegistry
+          .put("Dedup", new DedupTaskFactory(clusterName, port, useS3Backup, s3BucketName));
     } else {
       LOG.error("Unknown state model: " + stateModelType);
     }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -344,6 +344,22 @@ public class Utils {
       }
     }
 
+  public static void backupDBToS3WithLimit(String host, int adminPort, String dbName, int limitMbs,
+                                           String s3Bucket, String s3Path)
+      throws RuntimeException {
+    LOG.error("(S3)Backup " + dbName + " from " + host + " to " + s3Path);
+    try {
+      Admin.Client client = getAdminClient(host, adminPort);
+
+      BackupDBToS3Request req = new BackupDBToS3Request(dbName, s3Bucket, s3Path);
+      req.setLimit_mbs(limitMbs);
+      client.backupDBToS3(req);
+    } catch (TException e) {
+      LOG.error("Failed to backup DB: ", e.toString());
+      throw new RuntimeException(e);
+    }
+  }
+
     /**
      * Restore the local DB from s3
      * @param adminPort

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
@@ -47,12 +47,16 @@ public class BackupTaskFactory implements TaskFactory {
 
   private final String cluster;
   private final int adminPort;
+  private final boolean useS3Store;
+  private final String s3Bucket;
 
   private static final int DEFAULT_BACKUP_LIMIT_MBS = 64;
 
-  public BackupTaskFactory(String cluster, int adminPort) {
+  public BackupTaskFactory(String cluster, int adminPort, boolean useS3Store, String s3Bucket) {
     this.cluster = cluster;
     this.adminPort = adminPort;
+    this.useS3Store = useS3Store;
+    this.s3Bucket = s3Bucket;
   }
 
   /**
@@ -105,13 +109,14 @@ public class BackupTaskFactory implements TaskFactory {
             System.currentTimeMillis()));
 
     return getTask(cluster, targetPartition, backupLimitMbs, storePathPrefix, resourceVersion, job,
-        adminPort);
+        adminPort, useS3Store, s3Bucket);
   }
 
   protected Task getTask(String cluster, String targetPartition, int backupLimitMbs,
-                         String storePathPrefix, long resourceVersion, String job, int port) {
+                         String storePathPrefix, long resourceVersion, String job, int port,
+                         boolean useS3Store, String s3Bucket) {
     return new BackupTask(cluster, targetPartition, backupLimitMbs, storePathPrefix,
-        resourceVersion, job, port);
+        resourceVersion, job, port, useS3Store, s3Bucket);
   }
 
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTask.java
@@ -19,10 +19,12 @@ public class DedupTask extends UserContentStore implements Task {
   private final String job;
   private final int adminPort;
   private final String destStorePathPrefix;
+  private final boolean useS3Store;
+  private final String s3Bucket;
 
   public DedupTask(String srcStorePathPrefix, long resourceVersion, String partitionName,
                    String taskCluster, String job, int adminPort,
-                   String destStorePathPrefix) {
+                   String destStorePathPrefix, boolean useS3Store, String s3Bucket) {
     this.srcStorePathPrefix = srcStorePathPrefix;
     this.resourceVersion = resourceVersion;
     this.partitionName = partitionName;
@@ -30,6 +32,8 @@ public class DedupTask extends UserContentStore implements Task {
     this.job = job;
     this.adminPort = adminPort;
     this.destStorePathPrefix = destStorePathPrefix;
+    this.useS3Store = useS3Store;
+    this.s3Bucket = s3Bucket;
   }
 
   /**
@@ -66,7 +70,7 @@ public class DedupTask extends UserContentStore implements Task {
                   + "Other info {cluster: %s, job: %s, resourceVersion: %d}", dbName,
               srcStorePath, destStorePath, taskCluster, job, resourceVersion));
 
-      executeDedup(dbName, adminPort, srcStorePath, destStorePath);
+      executeDedup(dbName, adminPort, srcStorePath, destStorePath, useS3Store, s3Bucket);
 
       LOG.error("DedupTask completed, with: success");
       return new TaskResult(TaskResult.Status.COMPLETED, "DedupTask is completed!");
@@ -78,17 +82,25 @@ public class DedupTask extends UserContentStore implements Task {
   }
 
   protected void executeDedup(String dbName, int adminPort, String srcStorePath,
-                              String destStorePath) throws RuntimeException {
+                              String destStorePath, boolean useS3Store, String s3Bucket)
+      throws RuntimeException {
     try {
       Utils.addDB(dbName, adminPort);
       Utils.closeDB(dbName, adminPort);
-      Utils.restoreLocalDB(adminPort, dbName, srcStorePath, "127.0.0.1", adminPort);
+      if (useS3Store) {
+        Utils.restoreLocalDBFromS3(adminPort, dbName, s3Bucket, srcStorePath, "127.0.0.1", adminPort);
+      } else {
+        Utils.restoreLocalDB(adminPort, dbName, srcStorePath, "127.0.0.1", adminPort);
+      }
       LOG.error("restoreDB is done, begin compactDB");
 
       Utils.compactDB(adminPort, dbName);
       LOG.error("compactDB is done");
-
-      Utils.backupDB("127.0.0.1", adminPort, dbName, destStorePath);
+      if (useS3Store) {
+        Utils.backupDBToS3("127.0.0.1", adminPort, dbName, s3Bucket, destStorePath);
+      } else {
+        Utils.backupDB("127.0.0.1", adminPort, dbName, destStorePath);
+      }
       Utils.clearDB(dbName, adminPort);
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
@@ -28,10 +28,14 @@ public class DedupTaskFactory implements TaskFactory {
 
   private final String cluster;
   private final int adminPort;
+  private final boolean useS3Store;
+  private final String s3Bucket;
 
-  public DedupTaskFactory(String cluster, int adminPort) {
+  public DedupTaskFactory(String cluster, int adminPort, boolean useS3Store, String s3Bucket) {
     this.cluster = cluster;
     this.adminPort = adminPort;
+    this.useS3Store = useS3Store;
+    this.s3Bucket = s3Bucket;
   }
 
   /**
@@ -71,19 +75,21 @@ public class DedupTaskFactory implements TaskFactory {
     String targetPartition = taskConfig.getTargetPartition();
 
     LOG.error(String.format(
-        "Create Task for cluster: %s, targetPartition: %s from job: %s to execute at localhost, port:"
+        "Create Task for cluster: %s, targetPartition: %s from job: %s to execute at localhost, "
+            + "port:"
             + " %d. {resourceVersion: %d, helixJobCreationTime: %d, taskCreationTime: %d}", cluster,
         targetPartition, job, adminPort, resourceVersion, jobConfig.getStat().getCreationTime(),
         System.currentTimeMillis()));
 
     return getTask(srcStorePathPrefix, resourceVersion, targetPartition, cluster, job, adminPort,
-        destStorePathPrefix);
+        destStorePathPrefix, useS3Store, s3Bucket);
   }
 
   protected DedupTask getTask(String srcStorePathPrefix, long resourceVersion, String partitionName,
-                              String cluster, String job, int port, String destStorePathPrefix) {
+                              String cluster, String job, int port, String destStorePathPrefix,
+                              boolean useS3Store, String s3Bucket) {
     return new DedupTask(srcStorePathPrefix, resourceVersion, partitionName, cluster, job, port,
-        destStorePathPrefix);
+        destStorePathPrefix, useS3Store, s3Bucket);
   }
 
 }

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTaskFactory.java
@@ -20,6 +20,8 @@ import org.apache.helix.task.Workflow;
 import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.tools.ClusterSetup;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -40,6 +42,8 @@ import java.util.concurrent.CountDownLatch;
 
 public class TestBackupTaskFactory extends TaskTestBase {
 
+  private static final Logger LOG = LoggerFactory.getLogger(TestBackupTaskFactory.class);
+
   private static final String JOB_COMMAND = "DummyCommand";
   private static final int NUM_JOB = 2;
   private static final int NUM_TASK_PER_JOB = 2;
@@ -47,6 +51,7 @@ public class TestBackupTaskFactory extends TaskTestBase {
   private Map<String, String> _jobCommandMap;
 
   private static final long fakeResourceVersion = 1234L;
+  private static final String fakeS3Bucket = "pinterest-fake-bucket";
 
   private final CountDownLatch allTasksReady = new CountDownLatch(NUM_TASK);
   private final CountDownLatch adminReady = new CountDownLatch(1);
@@ -75,7 +80,7 @@ public class TestBackupTaskFactory extends TaskTestBase {
       // Set task callbacks
       Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
       taskFactoryReg.put("Backup", new DummyBackupTaskFactory(CLUSTER_NAME,
-          Integer.parseInt(instanceName.split("_")[1])));
+          Integer.parseInt(instanceName.split("_")[1]), true, fakeS3Bucket));
 
       _participants[i] = new MockParticipantManager(ZK_ADDR, CLUSTER_NAME, instanceName);
 
@@ -155,19 +160,34 @@ public class TestBackupTaskFactory extends TaskTestBase {
       Assert.assertEquals(jobConfig.getCommand(), JOB_COMMAND);
 
       Set<String> taskTargetParts = new HashSet<>();
+      int taskPartitionId = 0;
       for (TaskConfig taskConfig : _driver.getJobConfig(namespacedJobName).getTaskConfigMap()
           .values()) {
         Assert.assertEquals(taskConfig.getCommand(), "Backup");
         taskTargetParts.add(taskConfig.getTargetPartition());
 
         Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("STORE_PATH_PREFIX"),
-            _driver.getTaskUserContentMap(workflowName, jobName, "0").get("storePathPrefix"));
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("storePathPrefix"));
 
         Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("BACKUP_LIMIT_MBS"),
-            _driver.getTaskUserContentMap(workflowName, jobName, "0").get("backupLimitMbs"));
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("backupLimitMbs"));
 
         Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("RESOURCE_VERSION"),
-            _driver.getTaskUserContentMap(workflowName, jobName, "0").get("resourceVersion"));
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("resourceVersion"));
+
+        Assert.assertEquals(
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("useS3Store"), "true");
+
+        Assert.assertEquals(
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("s3Bucket"),
+            fakeS3Bucket);
+
+        taskPartitionId++;
       }
 
       Assert
@@ -213,25 +233,28 @@ public class TestBackupTaskFactory extends TaskTestBase {
 
   private class DummyBackupTaskFactory extends BackupTaskFactory {
 
-    public DummyBackupTaskFactory(String cluster, int adminPort) {
-      super(cluster, adminPort);
+    public DummyBackupTaskFactory(String cluster, int adminPort, boolean useS3Store,
+                                  String s3Bucket) {
+      super(cluster, adminPort, useS3Store, s3Bucket);
     }
 
     @Override
     protected Task getTask(String cluster, String targetPartition, int backupLimitMbs,
-                           String storePathPrefix, long resourceVersion, String job, int port) {
+                           String storePathPrefix, long resourceVersion, String job, int port,
+                           boolean useS3Store, String s3Bucket) {
       return new DummyBackupTask(cluster, targetPartition, backupLimitMbs, storePathPrefix,
-          resourceVersion, job, port);
+          resourceVersion, job, port, useS3Store, s3Bucket);
     }
+
   }
 
   private class DummyBackupTask extends BackupTask {
 
     public DummyBackupTask(String taskCluster, String partitionName, int backupLimitMbs,
-                           String storePathPrefix, long resourceVersion, String job,
-                           int adminPort) {
+                           String storePathPrefix, long resourceVersion, String job, int adminPort,
+                           boolean useS3Store, String s3Bucket) {
       super(taskCluster, partitionName, backupLimitMbs, storePathPrefix, resourceVersion, job,
-          adminPort);
+          adminPort, useS3Store, s3Bucket);
     }
 
     @Override
@@ -253,11 +276,31 @@ public class TestBackupTaskFactory extends TaskTestBase {
         putUserContent("backupLimitMbs", String.valueOf(backupLimitMbs), Scope.TASK);
         putUserContent("storePathPrefix", storePathPrefix, Scope.TASK);
       } catch (Exception e) {
-        System.out.println(
+        LOG.error(
             "Failed to read super class's private filed or fail to pur userStore" + e.getMessage());
       }
 
+      try {
+        super.run();
+      } catch (Exception e) {
+        LOG.error("Failed to execute BackupTask run" + e.getMessage());
+      }
+
       return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+
+    @Override
+    protected void executeBackup(String host, int port, String dbName, String storePath,
+                                 int backupLimitMbs, boolean useS3Store, String s3Bucket)
+        throws RuntimeException {
+      try {
+        boolean useS3 = readPrivateSuperClassBooleanField("useS3Store");
+        String bucket = readPrivateSuperClassStringField("s3Bucket");
+        putUserContent("useS3Store", String.valueOf(useS3), Scope.TASK);
+        putUserContent("s3Bucket", bucket, Scope.TASK);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
     }
 
     @Override
@@ -286,6 +329,13 @@ public class TestBackupTaskFactory extends TaskTestBase {
       Field field = clazz.getDeclaredField(fieldName);
       field.setAccessible(true);
       return (String) field.get(this);
+    }
+
+    private boolean readPrivateSuperClassBooleanField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (Boolean) field.get(this);
     }
   }
 }


### PR DESCRIPTION
Previously, we use HDFS as cloud storage to store backed up dbs, and deduped files. Now, we add support use s3 as the storage when flag: s3Bucket is provided. 