### PR TITLE
[common] Catch TApplicationException from recv_func

### DIFF
--- a/common/safe_future_client.h
+++ b/common/safe_future_client.h
@@ -186,7 +186,7 @@ class SafeFutureClient {
 
     auto ex = folly::try_and_catch<std::exception,
                                    apache::thrift::TApplicationException,
-                                   typename RequestTraits<T>::exception_type>([&p, &recvState]() {
+                                   typename RequestTraits<T>::exception_type>([p, recvState]() {
        typename RequestTraits<T>::response_type response;
        RequestTraits<T>::recv_func(response, *recvState);
        p->setValue(std::move(response));

--- a/common/safe_future_client.h
+++ b/common/safe_future_client.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <thrift/lib/cpp2/async/HeaderClientChannel.h>
-#include <thrift/lib/cpp2/ServiceIncludes.h>
 #include <thrift/lib/cpp/TApplicationException.h>
 
 #include <string>

--- a/common/safe_future_client.h
+++ b/common/safe_future_client.h
@@ -19,6 +19,8 @@
 #pragma once
 
 #include <thrift/lib/cpp2/async/HeaderClientChannel.h>
+#include <thrift/lib/cpp2/ServiceIncludes.h>
+#include <thrift/lib/cpp/TApplicationException.h>
 
 #include <string>
 
@@ -183,16 +185,16 @@ class SafeFutureClient {
       return;
     }
 
-    try {
-      typename RequestTraits<T>::response_type response;
-      RequestTraits<T>::recv_func(response, *recvState);
-      p->setValue(std::move(response));
-    } catch (typename RequestTraits<T>::exception_type& e) {
-      p->setException(
-        folly::make_exception_wrapper<
-          typename RequestTraits<T>::exception_type>(std::move(e)));
-    } catch (std::exception& e) {
-      p->setException(folly::exception_wrapper(std::move(e)));
+    auto ex = folly::try_and_catch<std::exception,
+                                   apache::thrift::TApplicationException,
+                                   typename RequestTraits<T>::exception_type>([&p, &recvState]() {
+       typename RequestTraits<T>::response_type response;
+       RequestTraits<T>::recv_func(response, *recvState);
+       p->setValue(std::move(response));
+    });
+
+    if (ex) {
+      p->setException(std::move(ex));
     }
   }
 


### PR DESCRIPTION
I found sometimes in our application logs i saw std::exception and it turns out to be TApplicationException thrown by recv_func.

Change safe_future_client to catch TApplicationException to provide us more visibility