### PR TITLE
[rocksplicator][kafka config]: Add method to read in kafka java client properties file

### DIFF
--- a/common/kafka/kafka_config.cpp
+++ b/common/kafka/kafka_config.cpp
@@ -1,0 +1,54 @@
+//
+// Created by Gopal Rajpurohit on 5/8/20.
+//
+
+#include <fstream>
+
+#include "glog/logging.h"
+#include "common/kafka/kafka_config.h"
+
+namespace kafka {
+
+/**
+ * @brief Read (Java client) configuration file
+ */
+bool read_conf_file(
+  const std::string &conf_file,
+  const std::shared_ptr<ConfigMap> configMap,
+  bool compatibility_flag) {
+  std::ifstream inf(conf_file.c_str());
+
+  if (!inf) {
+    LOG(ERROR) << ": " << conf_file << ": could not open file" << std::endl;
+    return false;
+  }
+
+  LOG(INFO) << ": " << conf_file << ": read config file" << std::endl;
+
+  std::string line;
+  int linenr = 0;
+
+  while (std::getline(inf, line)) {
+    linenr++;
+
+    // Ignore comments and empty lines
+    if (line[0] == '#' || line.length() == 0)
+      continue;
+
+    // Match on key=value..
+    size_t d = line.find("=");
+    if (d == 0 || d == std::string::npos) {
+      LOG(INFO) << ": " << conf_file << ":" << linenr << ": " << line
+                << ": invalid line (expect key=value): " << ::std::endl;
+      return false;
+    }
+
+    std::string key = line.substr(0, d);
+    std::string val = line.substr(d + 1);
+
+    configMap->insert(make_pair(key, make_pair(val, compatibility_flag)));
+  }
+  inf.close();
+  return true;
+}
+} // namespace kafka

--- a/common/kafka/kafka_config.cpp
+++ b/common/kafka/kafka_config.cpp
@@ -13,6 +13,7 @@
 /// limitations under the License.
 
 #include <fstream>
+#include <folly/ScopeGuard.h>
 
 #include "glog/logging.h"
 #include "common/kafka/kafka_config.h"
@@ -37,6 +38,10 @@ bool KafkaConfig::read_conf_file(
   std::string line;
   int linenr = 0;
 
+  SCOPE_EXIT {
+    inf.close();
+  };
+
   while (std::getline(inf, line)) {
     linenr++;
 
@@ -57,7 +62,6 @@ bool KafkaConfig::read_conf_file(
 
     (*configMap)[key] = std::move(val);
   }
-  inf.close();
   return true;
 }
 } // namespace kafka

--- a/common/kafka/kafka_config.cpp
+++ b/common/kafka/kafka_config.cpp
@@ -14,8 +14,8 @@
 
 #include <fstream>
 #include <folly/ScopeGuard.h>
+#include <glog/logging.h>
 
-#include "glog/logging.h"
 #include "common/kafka/kafka_config.h"
 
 namespace kafka {

--- a/common/kafka/kafka_config.cpp
+++ b/common/kafka/kafka_config.cpp
@@ -23,7 +23,8 @@ namespace kafka {
  * Read Java kafka client configuration file
  */
 bool KafkaConfig::read_conf_file(
-  const std::string &conf_file, ConfigMap &configMap) {
+  const std::string &conf_file,
+  ConfigMap *configMap) {
   std::ifstream inf(conf_file.c_str());
 
   if (!inf) {
@@ -54,7 +55,7 @@ bool KafkaConfig::read_conf_file(
     std::string key = line.substr(0, d);
     std::string val = line.substr(d + 1);
 
-    configMap[key] = std::move(val);
+    (*configMap)[key] = std::move(val);
   }
   inf.close();
   return true;

--- a/common/kafka/kafka_config.cpp
+++ b/common/kafka/kafka_config.cpp
@@ -1,6 +1,16 @@
-//
-// Created by Gopal Rajpurohit on 5/8/20.
-//
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #include <fstream>
 
@@ -10,9 +20,9 @@
 namespace kafka {
 
 /**
- * @brief Read (Java client) configuration file
+ * Read Java kafka client configuration file
  */
-bool read_conf_file(
+bool KafkaConfig::read_conf_file(
   const std::string &conf_file,
   const std::shared_ptr<ConfigMap> configMap,
   bool compatibility_flag) {
@@ -46,7 +56,7 @@ bool read_conf_file(
     std::string key = line.substr(0, d);
     std::string val = line.substr(d + 1);
 
-    configMap->insert(make_pair(key, make_pair(val, compatibility_flag)));
+    (*configMap)[key] = make_pair(val, compatibility_flag);
   }
   inf.close();
   return true;

--- a/common/kafka/kafka_config.cpp
+++ b/common/kafka/kafka_config.cpp
@@ -28,7 +28,7 @@ bool KafkaConfig::read_conf_file(
   ConfigMap *configMap) {
   std::ifstream inf(conf_file.c_str());
 
-  if (!inf) {
+  if (!inf || !inf.is_open()) {
     LOG(ERROR) << ": " << conf_file << ": could not open file" << std::endl;
     return false;
   }

--- a/common/kafka/kafka_config.cpp
+++ b/common/kafka/kafka_config.cpp
@@ -26,9 +26,9 @@ namespace kafka {
 bool KafkaConfig::read_conf_file(
   const std::string &conf_file,
   ConfigMap *configMap) {
-  std::ifstream inf(conf_file.c_str());
+  std::ifstream input_stream(conf_file.c_str());
 
-  if (!inf || !inf.is_open()) {
+  if (!input_stream || !input_stream.is_open()) {
     LOG(ERROR) << ": " << conf_file << ": could not open file" << std::endl;
     return false;
   }
@@ -39,10 +39,10 @@ bool KafkaConfig::read_conf_file(
   int linenr = 0;
 
   SCOPE_EXIT {
-    inf.close();
+    input_stream.close();
   };
 
-  while (std::getline(inf, line)) {
+  while (std::getline(input_stream, line)) {
     linenr++;
 
     // Ignore comments and empty lines

--- a/common/kafka/kafka_config.cpp
+++ b/common/kafka/kafka_config.cpp
@@ -23,9 +23,7 @@ namespace kafka {
  * Read Java kafka client configuration file
  */
 bool KafkaConfig::read_conf_file(
-  const std::string &conf_file,
-  const std::shared_ptr<ConfigMap> configMap,
-  bool compatibility_flag) {
+  const std::string &conf_file, ConfigMap &configMap) {
   std::ifstream inf(conf_file.c_str());
 
   if (!inf) {
@@ -42,7 +40,7 @@ bool KafkaConfig::read_conf_file(
     linenr++;
 
     // Ignore comments and empty lines
-    if (line[0] == '#' || line.length() == 0)
+    if (line.length() == 0 || line[0] == '#')
       continue;
 
     // Match on key=value..
@@ -56,7 +54,7 @@ bool KafkaConfig::read_conf_file(
     std::string key = line.substr(0, d);
     std::string val = line.substr(d + 1);
 
-    (*configMap)[key] = make_pair(val, compatibility_flag);
+    configMap[key] = std::move(val);
   }
   inf.close();
   return true;

--- a/common/kafka/kafka_config.h
+++ b/common/kafka/kafka_config.h
@@ -1,0 +1,18 @@
+//
+// Created by Gopal Rajpurohit on 5/8/20.
+//
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <memory>
+
+namespace kafka {
+typedef std::map<std::string, std::pair<std::string, bool>> ConfigMap;
+
+bool read_conf_file(
+  const std::string &conf_file,
+  const std::shared_ptr<ConfigMap> configMap,
+  bool compatibility_flag);
+} // namespace kafka

--- a/common/kafka/kafka_config.h
+++ b/common/kafka/kafka_config.h
@@ -1,18 +1,32 @@
-//
-// Created by Gopal Rajpurohit on 5/8/20.
-//
+/// Copyright 2019 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
 
 #pragma once
 
 #include <map>
-#include <string>
 #include <memory>
+#include <string>
 
 namespace kafka {
+
 typedef std::map<std::string, std::pair<std::string, bool>> ConfigMap;
 
-bool read_conf_file(
-  const std::string &conf_file,
-  const std::shared_ptr<ConfigMap> configMap,
-  bool compatibility_flag);
+class KafkaConfig {
+public:
+  static bool read_conf_file(
+    const std::string &conf_file,
+    const std::shared_ptr<ConfigMap> configMap,
+    bool compatibility_flag);
+};
 } // namespace kafka

--- a/common/kafka/kafka_config.h
+++ b/common/kafka/kafka_config.h
@@ -20,13 +20,21 @@
 
 namespace kafka {
 
-typedef std::map<std::string, std::pair<std::string, bool>> ConfigMap;
+typedef std::map<std::string, std::string> ConfigMap;
 
 class KafkaConfig {
 public:
+  // This method reads in properties/configuration in key=value pair format
+  // into configMap.
+  // The format of properties file is similar to java properties file
+  // except it doesn't dereference any escape characters or special characters.
+  // Empty lines must not contain any whitespace.
+  // parameters:
+  // conf_file: path of configuration file to read.
+  // configMap: Output-only parameter, map containing all key-value pairs read
+  //            from the provided config file.
   static bool read_conf_file(
     const std::string &conf_file,
-    const std::shared_ptr<ConfigMap> configMap,
-    bool compatibility_flag);
+    ConfigMap &configMap);
 };
 } // namespace kafka

--- a/common/kafka/kafka_config.h
+++ b/common/kafka/kafka_config.h
@@ -35,6 +35,6 @@ public:
   //            from the provided config file.
   static bool read_conf_file(
     const std::string &conf_file,
-    ConfigMap &configMap);
+    ConfigMap *configMap);
 };
 } // namespace kafka

--- a/common/kafka/tests/CMakeLists.txt
+++ b/common/kafka/tests/CMakeLists.txt
@@ -14,5 +14,6 @@ foreach(testsourcefile ${TEST_SOURCES})
   add_executable(${testname} ${testsourcefile})
   target_link_libraries(${testname} common gtest kafka_consumer mock_kafka_consumer rdkafka++)
   add_test(NAME ${testname} COMMAND ${testname})
+  set_tests_properties(${testname} PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach(testsourcefile ${TEST_SOURCES})
 

--- a/common/kafka/tests/client_config.properties
+++ b/common/kafka/tests/client_config.properties
@@ -1,0 +1,7 @@
+# Comment Java kafka client config file.
+# Following is empty line without any white space.
+
+enable.sparse.connections=true
+
+
+# end of config file

--- a/common/kafka/tests/client_config.properties
+++ b/common/kafka/tests/client_config.properties
@@ -3,5 +3,8 @@
 
 enable.sparse.connections=true
 
+timeout_millis=1200
+socket_timeout_ms=300
+
 
 # end of config file

--- a/common/kafka/tests/client_config.properties
+++ b/common/kafka/tests/client_config.properties
@@ -6,5 +6,6 @@ enable.sparse.connections=true
 timeout_millis=1200
 socket_timeout_ms=300
 
+#comment.not.visible=300
 
 # end of config file

--- a/common/kafka/tests/kafka_config_test.cpp
+++ b/common/kafka/tests/kafka_config_test.cpp
@@ -1,0 +1,25 @@
+//
+// Test for read_conf_file
+//
+
+#include "common/kafka/kafka_config.h"
+#include "gtest/gtest.h"
+
+namespace kafka {
+
+TEST(KafkaConfigTest, TestConfigFile) {
+  std::shared_ptr<ConfigMap> configMap = std::shared_ptr<ConfigMap>(new ConfigMap);
+
+  std::string configFile = std::string("common/client_config.properties");
+  EXPECT_TRUE(read_conf_file(configFile, configMap, true));
+  EXPECT_TRUE(configMap->find("enable.sparse.connections") != configMap->end());
+  EXPECT_TRUE(configMap->find("enable.sparse.connections")->second.first == "true");
+  EXPECT_TRUE(configMap->find("enable.sparse.connections")->second.second);
+  EXPECT_TRUE(configMap->find("not_enabled_config_file") == configMap->end());
+}
+} // namespace kafka
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/common/kafka/tests/kafka_config_test.cpp
+++ b/common/kafka/tests/kafka_config_test.cpp
@@ -2,21 +2,59 @@
 // Test for read_conf_file
 //
 
-#include "common/kafka/kafka_config.h"
+#include <string>
+
+#include <stdio.h>  /* defines FILENAME_MAX */
+#include <unistd.h>
+#define GetCurrentDir getcwd
+#include<iostream>
+
 #include "gtest/gtest.h"
+#include "common/kafka/kafka_config.h"
 
 namespace kafka {
 
-TEST(KafkaConfigTest, TestConfigFile) {
+std::string GetCurrentWorkingDir() {
+  char buff[FILENAME_MAX];
+  GetCurrentDir( buff, FILENAME_MAX );
+  std::string current_working_dir(buff);
+  return current_working_dir;
+}
+
+class KafkaConfigTest : public ::testing::Test {};
+
+TEST_F(KafkaConfigTest, BasicTest) {
+  EXPECT_TRUE(true);
+}
+
+TEST_F(KafkaConfigTest, SecondBasicTest) {
+  EXPECT_TRUE(true);
+}
+
+TEST_F(KafkaConfigTest, ConfigFileTest) {
+
+  std::cout << GetCurrentWorkingDir() << std::endl;
+  std::cout.flush();
+
   std::shared_ptr<ConfigMap> configMap = std::shared_ptr<ConfigMap>(new ConfigMap);
 
-  std::string configFile = std::string("common/client_config.properties");
-  EXPECT_TRUE(read_conf_file(configFile, configMap, true));
+  std::string configFile = std::string("client_config.properties");
+  EXPECT_TRUE(KafkaConfig::read_conf_file(configFile, configMap, true));
+  /*
   EXPECT_TRUE(configMap->find("enable.sparse.connections") != configMap->end());
   EXPECT_TRUE(configMap->find("enable.sparse.connections")->second.first == "true");
   EXPECT_TRUE(configMap->find("enable.sparse.connections")->second.second);
+  EXPECT_TRUE(configMap->find("timeout_millis") != configMap->end());
+  EXPECT_TRUE(configMap->find("timeout_millis")->second.first == "1200");
+  EXPECT_TRUE(configMap->find("timeout_millis")->second.second);
+  EXPECT_TRUE(configMap->find("socket_timeout_ms") != configMap->end());
+  EXPECT_TRUE(configMap->find("socket_timeout_ms")->first == "socket_timeout_ms");
+  EXPECT_TRUE(configMap->find("socket_timeout_ms")->second.first == "300");
+  EXPECT_TRUE(configMap->find("socket_timeout_ms")->second.second);
   EXPECT_TRUE(configMap->find("not_enabled_config_file") == configMap->end());
+   */
 }
+
 } // namespace kafka
 
 int main(int argc, char** argv) {

--- a/common/kafka/tests/kafka_config_test.cpp
+++ b/common/kafka/tests/kafka_config_test.cpp
@@ -21,17 +21,7 @@ std::string GetCurrentWorkingDir() {
   return current_working_dir;
 }
 
-class KafkaConfigTest : public ::testing::Test {};
-
-TEST_F(KafkaConfigTest, BasicTest) {
-  EXPECT_TRUE(true);
-}
-
-TEST_F(KafkaConfigTest, SecondBasicTest) {
-  EXPECT_TRUE(true);
-}
-
-TEST_F(KafkaConfigTest, ConfigFileTest) {
+TEST(KafkaConfigTest, ConfigFileTest) {
 
   std::cout << GetCurrentWorkingDir() << std::endl;
   std::cout.flush();
@@ -40,7 +30,6 @@ TEST_F(KafkaConfigTest, ConfigFileTest) {
 
   std::string configFile = std::string("client_config.properties");
   EXPECT_TRUE(KafkaConfig::read_conf_file(configFile, configMap, true));
-  /*
   EXPECT_TRUE(configMap->find("enable.sparse.connections") != configMap->end());
   EXPECT_TRUE(configMap->find("enable.sparse.connections")->second.first == "true");
   EXPECT_TRUE(configMap->find("enable.sparse.connections")->second.second);
@@ -52,7 +41,6 @@ TEST_F(KafkaConfigTest, ConfigFileTest) {
   EXPECT_TRUE(configMap->find("socket_timeout_ms")->second.first == "300");
   EXPECT_TRUE(configMap->find("socket_timeout_ms")->second.second);
   EXPECT_TRUE(configMap->find("not_enabled_config_file") == configMap->end());
-   */
 }
 
 } // namespace kafka

--- a/common/kafka/tests/kafka_config_test.cpp
+++ b/common/kafka/tests/kafka_config_test.cpp
@@ -26,21 +26,19 @@ TEST(KafkaConfigTest, ConfigFileTest) {
   std::cout << GetCurrentWorkingDir() << std::endl;
   std::cout.flush();
 
-  std::shared_ptr<ConfigMap> configMap = std::shared_ptr<ConfigMap>(new ConfigMap);
+  ConfigMap configMap;
 
   std::string configFile = std::string("client_config.properties");
-  EXPECT_TRUE(KafkaConfig::read_conf_file(configFile, configMap, true));
-  EXPECT_TRUE(configMap->find("enable.sparse.connections") != configMap->end());
-  EXPECT_TRUE(configMap->find("enable.sparse.connections")->second.first == "true");
-  EXPECT_TRUE(configMap->find("enable.sparse.connections")->second.second);
-  EXPECT_TRUE(configMap->find("timeout_millis") != configMap->end());
-  EXPECT_TRUE(configMap->find("timeout_millis")->second.first == "1200");
-  EXPECT_TRUE(configMap->find("timeout_millis")->second.second);
-  EXPECT_TRUE(configMap->find("socket_timeout_ms") != configMap->end());
-  EXPECT_TRUE(configMap->find("socket_timeout_ms")->first == "socket_timeout_ms");
-  EXPECT_TRUE(configMap->find("socket_timeout_ms")->second.first == "300");
-  EXPECT_TRUE(configMap->find("socket_timeout_ms")->second.second);
-  EXPECT_TRUE(configMap->find("not_enabled_config_file") == configMap->end());
+  EXPECT_TRUE(KafkaConfig::read_conf_file(configFile, configMap));
+  EXPECT_TRUE(configMap.find("enable.sparse.connections") != configMap.end());
+  EXPECT_TRUE(configMap.find("enable.sparse.connections")->second == "true");
+  EXPECT_TRUE(configMap.find("timeout_millis") != configMap.end());
+  EXPECT_TRUE(configMap.find("timeout_millis")->second == "1200");
+  EXPECT_TRUE(configMap.find("socket_timeout_ms") != configMap.end());
+  EXPECT_TRUE(configMap.find("socket_timeout_ms")->first == "socket_timeout_ms");
+  EXPECT_TRUE(configMap.find("socket_timeout_ms")->second == "300");
+  EXPECT_TRUE(configMap.find("not_enabled_config_file") == configMap.end());
+  EXPECT_FALSE(configMap.find("comment.not.visible") == configMap.end());
 }
 
 } // namespace kafka

--- a/common/kafka/tests/kafka_config_test.cpp
+++ b/common/kafka/tests/kafka_config_test.cpp
@@ -29,7 +29,7 @@ TEST(KafkaConfigTest, ConfigFileTest) {
   ConfigMap configMap;
 
   std::string configFile = std::string("client_config.properties");
-  EXPECT_TRUE(KafkaConfig::read_conf_file(configFile, configMap));
+  EXPECT_TRUE(KafkaConfig::read_conf_file(configFile, &configMap));
   EXPECT_TRUE(configMap.find("enable.sparse.connections") != configMap.end());
   EXPECT_TRUE(configMap.find("enable.sparse.connections")->second == "true");
   EXPECT_TRUE(configMap.find("timeout_millis") != configMap.end());

--- a/common/kafka/tests/kafka_config_test.cpp
+++ b/common/kafka/tests/kafka_config_test.cpp
@@ -4,28 +4,12 @@
 
 #include <string>
 
-#include <stdio.h>  /* defines FILENAME_MAX */
-#include <unistd.h>
-#define GetCurrentDir getcwd
-#include<iostream>
-
 #include "gtest/gtest.h"
 #include "common/kafka/kafka_config.h"
 
 namespace kafka {
 
-std::string GetCurrentWorkingDir() {
-  char buff[FILENAME_MAX];
-  GetCurrentDir( buff, FILENAME_MAX );
-  std::string current_working_dir(buff);
-  return current_working_dir;
-}
-
 TEST(KafkaConfigTest, ConfigFileTest) {
-
-  std::cout << GetCurrentWorkingDir() << std::endl;
-  std::cout.flush();
-
   ConfigMap configMap;
 
   std::string configFile = std::string("client_config.properties");

--- a/common/kafka/tests/kafka_config_test.cpp
+++ b/common/kafka/tests/kafka_config_test.cpp
@@ -38,7 +38,7 @@ TEST(KafkaConfigTest, ConfigFileTest) {
   EXPECT_TRUE(configMap.find("socket_timeout_ms")->first == "socket_timeout_ms");
   EXPECT_TRUE(configMap.find("socket_timeout_ms")->second == "300");
   EXPECT_TRUE(configMap.find("not_enabled_config_file") == configMap.end());
-  EXPECT_FALSE(configMap.find("comment.not.visible") == configMap.end());
+  EXPECT_TRUE(configMap.find("comment.not.visible") == configMap.end());
 }
 
 } // namespace kafka

--- a/common/kafka/tests/mock_kafka_consumer.h
+++ b/common/kafka/tests/mock_kafka_consumer.h
@@ -94,6 +94,18 @@ public:
     return nullptr;
   }
 
+  Status status() const override {
+    return MSG_STATUS_PERSISTED;
+  }
+
+  Headers *headers() override {
+    return nullptr;
+  }
+
+  Headers *headers(RdKafka::ErrorCode *err) override {
+    return nullptr;
+  }
+
 private:
   const std::string topic_name_;
   const int32_t partition_id_;
@@ -335,6 +347,40 @@ private:
   struct rd_kafka_s* c_ptr() override {
     return NotImplNullptr<struct rd_kafka_s>();
   }
+
+public:
+  ~MockKafkaConsumer() override {
+
+  }
+
+  int32_t controllerid(int timeout_ms) override {
+    return 0;
+  }
+
+  ErrorCode fatal_error(std::string &errstr) override {
+    return ERR_UNKNOWN_TOPIC_OR_PART;
+  }
+
+  ErrorCode
+  oauthbearer_set_token(
+    const std::string &token_value,
+    int64_t md_lifetime_ms,
+    const std::string &md_principal_name,
+    const std::list<std::string> &extensions,
+    std::string &errstr) override {
+    return ERR_UNKNOWN_TOPIC_OR_PART;
+  }
+
+  ErrorCode oauthbearer_set_token_failure(const std::string &errstr) override {
+    return ERR_UNKNOWN_TOPIC_OR_PART;
+  }
+
+  ConsumerGroupMetadata *groupMetadata() override {
+    return nullptr;
+  }
+
+private:
+
 
   ////////////////////////////////////////////////////////////////
   // Other private methods

--- a/common/kafka/tests/mock_kafka_consumer.h
+++ b/common/kafka/tests/mock_kafka_consumer.h
@@ -94,18 +94,6 @@ public:
     return nullptr;
   }
 
-  Status status() const override {
-    return MSG_STATUS_PERSISTED;
-  }
-
-  Headers *headers() override {
-    return nullptr;
-  }
-
-  Headers *headers(RdKafka::ErrorCode *err) override {
-    return nullptr;
-  }
-
 private:
   const std::string topic_name_;
   const int32_t partition_id_;
@@ -347,40 +335,6 @@ private:
   struct rd_kafka_s* c_ptr() override {
     return NotImplNullptr<struct rd_kafka_s>();
   }
-
-public:
-  ~MockKafkaConsumer() override {
-
-  }
-
-  int32_t controllerid(int timeout_ms) override {
-    return 0;
-  }
-
-  ErrorCode fatal_error(std::string &errstr) override {
-    return ERR_UNKNOWN_TOPIC_OR_PART;
-  }
-
-  ErrorCode
-  oauthbearer_set_token(
-    const std::string &token_value,
-    int64_t md_lifetime_ms,
-    const std::string &md_principal_name,
-    const std::list<std::string> &extensions,
-    std::string &errstr) override {
-    return ERR_UNKNOWN_TOPIC_OR_PART;
-  }
-
-  ErrorCode oauthbearer_set_token_failure(const std::string &errstr) override {
-    return ERR_UNKNOWN_TOPIC_OR_PART;
-  }
-
-  ConsumerGroupMetadata *groupMetadata() override {
-    return nullptr;
-  }
-
-private:
-
 
   ////////////////////////////////////////////////////////////////
   // Other private methods


### PR DESCRIPTION
Simple configuration/properties file providing k=v in simple format can be read in for allowing application to set kafka parameters ...

# comment
# empty line is ok as below

key=value
key1=value1

# empty line with white spaces is not accepted.