### PR TITLE
add restore task to Participant

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -20,6 +20,7 @@ package com.pinterest.rocksplicator;
 
 import com.pinterest.rocksplicator.task.BackupTaskFactory;
 import com.pinterest.rocksplicator.task.DedupTaskFactory;
+import com.pinterest.rocksplicator.task.RestoreTaskFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -218,10 +219,10 @@ public class Participant {
       stateModelFactory = new MasterSlaveStateModelFactory(instanceName.split("_")[0],
           port, zkConnectString, clusterName, useS3Backup, s3BucketName);
 
-      // TODO: register restore factories
       taskFactoryRegistry
           .put("Backup", new BackupTaskFactory(clusterName, port, useS3Backup, s3BucketName));
-      // taskFactoryRegistry.put("Restore", new RestoreTaskFactory());
+      taskFactoryRegistry
+          .put("Restore", new RestoreTaskFactory(clusterName, port, useS3Backup, s3BucketName));
 
     } else if (stateModelType.equals("Task")) {
       taskFactoryRegistry

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -108,15 +108,19 @@ public class Utils {
    * @param adminPort
    */
   public static void closeDB(String dbName, int adminPort) {
+    closeRemoteOrLocalDB("localhost", adminPort, dbName);
+  }
+
+  public static void closeRemoteOrLocalDB(String host, int adminPort, String dbName) {
     try {
-      LOG.error("Close local DB: " + dbName);
-      Admin.Client client = getLocalAdminClient(adminPort);
+      LOG.error("Close DB: " + dbName + " on host: " + host);
+      Admin.Client client = getAdminClient(host, adminPort);
       CloseDBRequest req = new CloseDBRequest(dbName);
       client.closeDB(req);
     } catch (AdminException e) {
       LOG.error(dbName + " doesn't exist", e);
     } catch (TTransportException e) {
-      LOG.error("Failed to connect to local Admin port", e);
+      LOG.error("Failed to connect to Admin port", e);
     } catch (TException e) {
       LOG.error("CloseDB() request failed", e);
     }
@@ -316,9 +320,15 @@ public class Utils {
   public static void restoreLocalDB(int adminPort, String dbName, String hdfsPath,
                                     String upsreamHost, int upstreamPort)
       throws RuntimeException {
+    restoreRemoteOrLocalDB("localhost", adminPort, dbName, hdfsPath, upsreamHost, upstreamPort);
+  }
+
+  public static void restoreRemoteOrLocalDB(String host, int adminPort, String dbName,
+                                            String hdfsPath, String upsreamHost, int upstreamPort)
+      throws RuntimeException {
     LOG.error("(HDFS)Restore " + dbName + " from " + hdfsPath + " with upstream " + upsreamHost);
     try {
-      Admin.Client client = getLocalAdminClient(adminPort);
+      Admin.Client client = getAdminClient(host, adminPort);
 
       RestoreDBRequest req =
           new RestoreDBRequest(dbName, hdfsPath, upsreamHost, (short) upstreamPort);
@@ -380,9 +390,17 @@ public class Utils {
   public static void restoreLocalDBFromS3(int adminPort, String dbName, String s3Bucket,
                                           String s3Path, String upsreamHost, int upstreamPort)
       throws RuntimeException {
+    restoreRemoteOrLocalDBFromS3("localhost", adminPort, dbName, s3Bucket, s3Path, upsreamHost,
+        upstreamPort);
+  }
+
+  public static void restoreRemoteOrLocalDBFromS3(String host, int adminPort, String dbName,
+                                                  String s3Bucket, String s3Path,
+                                                  String upsreamHost, int upstreamPort)
+      throws RuntimeException {
     LOG.error("(S3)Restore " + dbName + " from " + s3Path + " with upstream " + upsreamHost);
     try {
-      Admin.Client client = getLocalAdminClient(adminPort);
+      Admin.Client client = getAdminClient(host, adminPort);
 
       RestoreDBFromS3Request req =
           new RestoreDBFromS3Request(dbName, s3Bucket, s3Path, upsreamHost, (short) upstreamPort);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
@@ -72,7 +72,7 @@ public class BackupTaskFactory implements TaskFactory {
 
     LOG.error("Create task with TaskConfig: " + taskConfig.toString());
 
-    long jobCreationTime = jobConfig.getStat().getCreationTime();
+    long jobCreationTime = jobConfig.getStat().getCreationTime() / 1000; // milli to seconds
 
     String storePathPrefix = "";
     long resourceVersion = jobCreationTime;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTaskFactory.java
@@ -72,12 +72,11 @@ import java.util.Map;
  * and restore task will be configured (ie. set "TargetPartitionStates": "Master" in {@link JobConfig})
  * to target 1 and only 1 replica in Master state (compared to {@link BackupTask} which target
  * 1 and only 1 replica either in Master or Slave with "TargetPartitionStates": "Master, Slave").
- * If replica factor (RF) > 1, then {@link RestoreTask} is also responsible to sync data from
- * Master replica to all Slave replicas. Due to the resource must be newly created, replicas in
- * other states, such as Offline, Error should always have no data which will later go through
- * helix state transition to get the latest restored data from Master or Slave.
- * TODO: we can extend to support restore to replica in either Master or Slave, and replicate to
- * all replicas, not limited to only restore to Master.
+ * If replica factor (RF) > 1, then {@link RestoreTask} is also responsible to initiate restore
+ * to all other replicas in state model: Slave/Offline/Error.
+ *
+ * TODO: we can extend to support restoreTask to target replica in either Master or Slave in case
+ * transient missing Master replica.
  *
  * Upon Task creation, configs inherited from job configs JobCommandConfigMap: STORE_PATH_PREFIX,
  * the cloud path prefix stored the backup; RESOURCE_VERSION: the timestamp the available backup

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTaskFactory.java
@@ -34,11 +34,11 @@ import java.util.Map;
  * cloud to local.
  *
  * There are 2 use cases: 1. if periodical backup is setup for the resource, then, RestoreTask
- * provide rollback to a previous backup version, especially during disaster recovery.
- * note: it can only be used to restore to newly created segment, which require the resource to
- * be manually removed, then re-created by service operator; 2. if there is available backup
- * (either from periodical or ad-hoc backup), then, restore the resource to a new cluster which
- * provide the ability of data migration (note: client need request to the new cluster after migration).
+ * provide rollback to a previous backup version, especially during disaster recovery. 2. if there
+ * is available backup (either from periodical or ad-hoc backup), then, restore the resource to a
+ * new cluster which provide the ability of data migration (note: client need request to the new
+ * cluster after migration). note: during restore, the DB will be closed which will stall the
+ * realtime writes.
  *
  * TODO (Kangnan) rescue writes loss due to: 1. writes since the backup; 2. writes during restore
  * due to DB close.

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTaskFactory.java
@@ -1,0 +1,142 @@
+/// Copyright 2017 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author kangnanli (kangnanli@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.task;
+
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * An implementation of {@link TaskFactory} that create Tasks to restore backed up data from
+ * cloud to local.
+ *
+ * There are 2 use cases: 1. if periodical backup is setup for the resource, then, RestoreTask
+ * provide rollback to a previous backup version, especially during disaster recovery. The
+ * rollback will discard the local data and restore to a previous snapshot; 2. if there is
+ * available backup (either from periodical or ad-hoc backup), then, restore the resource to a
+ * new cluster which provide the ability of data migration (note: client need request to the new
+ * cluster after migration).
+ * TODO (Kangnan) rescue writes loss due to: 1. writes since the backup; 2. writes during restore
+ * due to DB close.
+ *
+ * use case 1:
+ *            - - - - - - - - - - - - - -  - - - - - - - - - - - - - -
+ *           |   s3   (backupVersion v1)   (backupVersion v2)   ...   |
+ *            - - - - - - - - - - - - - -  - - - - - - - - - - - - - -
+ *                 ^                                 |
+ *                 | (periodical backup)             |  (restore from v2)
+ *                 |                                 v
+ *           - - - - - - - - - - - - - -  - - - - - - - - - - - - - -
+ *          | source/dest cluster: [shard1->v2], [shard2->v2],   ...  |
+ *           - - - - - - - - - - - - - -  - - - - - - - - - - - - - -
+ *
+ * use case 2:
+ *            - - - - - - - - - - - - - -  - - - - - - - - - - - - - -
+ *           |   s3   (backupVersion v1)   (backupVersion v2)   ...   |
+ *            - - - - - - - - - - - - - -  - - - - - - - - - - - - - -
+ *            ^                                         |
+ *            | (ad-hoc or periodical backup)           |  (restore from v2)
+ *            |                                         v
+ *      - - - - - - - - -       - - - -  - - - - - - - - - - - - - - - - - - -
+ *     | source cluster  |     | dest cluster: [shard1:v2], [shard2:v2],   ... |
+ *      - - - - - - - - -       - - - -  - - - - - - - - - - - - - - - - - - -
+ *
+ * The Task will be running as targeted job similar to backupTask, which means the db resource
+ * must exist first before the restoreTask to pinpoint the targetPartition and restore it.
+ *
+ * Upon Task creation, configs inherited from job configs JobCommandConfigMap: STORE_PATH_PREFIX,
+ * the cloud path prefix stored the backup; RESOURCE_VERSION: the timestamp the available backup
+ * to restore from; "prefix/[version]/[dbName]" will be the full filesystem path to get db from
+ * cloud; (optional) SRC_CLUSTER, default same as dest(task) cluster.
+ */
+public class RestoreTaskFactory implements TaskFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RestoreTaskFactory.class);
+
+  private final String cluster;
+  private final int adminPort;
+  private final boolean useS3Store;
+  private final String s3Bucket;
+
+  public RestoreTaskFactory(String cluster, int adminPort, boolean useS3Store, String s3Bucket) {
+    this.cluster = cluster;
+    this.adminPort = adminPort;
+    this.useS3Store = useS3Store;
+    this.s3Bucket = s3Bucket;
+  }
+
+  @Override
+  public Task createNewTask(TaskCallbackContext context) {
+
+    TaskConfig taskConfig = context.getTaskConfig();
+    JobConfig jobConfig = context.getJobConfig();
+    String job = jobConfig.getJobId();
+
+    String storePathPrefix = "";
+    // in use case 2: sync latest data from src_cluster to dest_cluster
+    String src_cluster = cluster;
+    long resourceVersion = 0L;
+
+    try {
+      Map<String, String> jobCmdMap = jobConfig.getJobCommandConfigMap();
+      if (jobCmdMap != null && !jobCmdMap.isEmpty()) {
+        if (jobCmdMap.containsKey("STORE_PATH_PREFIX")) {
+          storePathPrefix = jobCmdMap.get("STORE_PATH_PREFIX");
+        }
+        if (jobCmdMap.containsKey("SRC_CLUSTER")) {
+          src_cluster = jobCmdMap.get("SRC_CLUSTER");
+        }
+        if (jobCmdMap.containsKey("RESOURCE_VERSION")) {
+          resourceVersion = Long.parseLong(jobCmdMap.get("RESOURCE_VERSION"));
+        }
+      }
+    } catch (NumberFormatException e) {
+      LOG.error(
+          String.format(
+              "Failed to parse configs from job command config map, resourceVersion: %d",
+              resourceVersion), e);
+    }
+
+    String targetPartition = taskConfig.getTargetPartition();
+
+    LOG.error(
+        String.format(
+            "Create Task for cluster: %s, targetPartition: %s from job: %s to execute at "
+                + "localhost, port: %d. {src_cluster: %s, resourceVersion: %d, "
+                + "taskCreationTime: %d}",
+            cluster, targetPartition, job, adminPort, src_cluster, resourceVersion,
+            System.currentTimeMillis()));
+
+    return getTask(cluster, targetPartition, storePathPrefix, src_cluster, resourceVersion, job,
+        adminPort, useS3Store, s3Bucket);
+  }
+
+  protected Task getTask(String cluster, String targetPartition, String storePathPrefix,
+                         String src_cluster, long resourceVersion, String job, int port,
+                         boolean useS3Store, String s3Bucket) {
+    return new RestoreTask(cluster, targetPartition, storePathPrefix, src_cluster,
+        resourceVersion, job, port, useS3Store, s3Bucket);
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestRestoreTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestRestoreTaskFactory.java
@@ -1,0 +1,268 @@
+package com.pinterest.rocksplicator.task;
+
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+public class TestRestoreTaskFactory extends TaskTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestRestoreTaskFactory.class);
+
+  private static final String JOB_COMMAND = "DummyCommand";
+  private static final int NUM_JOB = 2;
+  private static final int NUM_TASK_PER_JOB = 2;
+  private static final int NUM_TASK = NUM_JOB * NUM_TASK_PER_JOB;
+  private Map<String, String> _jobCommandMap;
+
+  private static final long fakeResourceVersion = 1234L;
+  private static final String fakeS3Bucket = "pinterest-fake-bucket";
+
+  private final CountDownLatch allTasksReady = new CountDownLatch(NUM_TASK);
+  private final CountDownLatch adminReady = new CountDownLatch(1);
+
+
+  @Override
+  protected void startParticipant(String zkAddr, int i) {
+    final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+    Map<String, TaskFactory> taskFactoryReg = new HashMap();
+    taskFactoryReg.put("Restore", new TestRestoreTaskFactory.DummyRestoreTaskFactory(CLUSTER_NAME,
+        Integer.parseInt(instanceName.split("_")[1]), true, fakeS3Bucket));
+    this._participants[i] = new MockParticipantManager(zkAddr, this.CLUSTER_NAME, instanceName);
+    StateMachineEngine stateMachine = this._participants[i].getStateMachineEngine();
+    stateMachine.registerStateModelFactory("Task",
+        new TaskStateModelFactory(this._participants[i], taskFactoryReg));
+    this._participants[i].syncStart();
+  }
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    super.beforeClass();
+    _jobCommandMap = new HashMap<>();
+  }
+
+  @BeforeMethod
+  public void setUp(Method m) throws Exception {
+    String workflowName = m.getName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 2 jobs with 2 Backup Tasks each
+    for (int i = 0; i < NUM_JOB; i++) {
+      String jobName = "JOB" + i;
+
+      _jobCommandMap.put("STORE_PATH_PREFIX", "/test_cloud");
+      _jobCommandMap.put("SRC_CLUSTER", CLUSTER_NAME);
+      _jobCommandMap.put("RESOURCE_VERSION", String.valueOf(fakeResourceVersion + i));
+
+      List<TaskConfig> taskConfigs = new ArrayList<>();
+      for (int j = 0; j < NUM_TASK_PER_JOB; ++j) {
+        Map<String, String> taskConfigMap = new HashMap<>();
+        taskConfigMap.put("TASK_TARGET_PARTITION", "test_seg_" + j);
+        taskConfigs.add(new TaskConfig("Restore", taskConfigMap));
+      }
+
+      JobConfig.Builder jobConfigBulider = new JobConfig.Builder().setCommand(JOB_COMMAND)
+          .addTaskConfigs(taskConfigs).setJobCommandConfigMap(_jobCommandMap);
+      workflowBuilder.addJob(jobName, jobConfigBulider);
+    }
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+  }
+
+  @AfterMethod
+  public void cleanUp(Method m) throws Exception {
+    _jobCommandMap.clear();
+  }
+
+  @Test
+  public void testBackupTaskFactoryCreateNewTaskWithPassedConfigs() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+
+    Assert.assertEquals(_driver.getWorkflowConfig(workflowName).getWorkflowId(), workflowName);
+
+    for (int i = 0; i < NUM_JOB; i++) {
+      String jobName = "JOB" + i;
+      String namespacedJobName = TaskUtil.getNamespacedJobName(workflowName, jobName);
+      JobConfig jobConfig = _driver.getJobConfig(namespacedJobName);
+
+      Assert.assertEquals(jobConfig.getCommand(), JOB_COMMAND);
+
+      Set<String> taskTargetParts = new HashSet<>();
+      int taskPartitionId = 0;
+      for (TaskConfig taskConfig : _driver.getJobConfig(namespacedJobName).getTaskConfigMap()
+          .values()) {
+        Assert.assertEquals(taskConfig.getCommand(), "Restore");
+        taskTargetParts.add(taskConfig.getTargetPartition());
+
+        Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("STORE_PATH_PREFIX"),
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("storePathPrefix"));
+
+        Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("SRC_CLUSTER"),
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("srcCluster"));
+
+        Assert.assertEquals(jobConfig.getJobCommandConfigMap().get("RESOURCE_VERSION"),
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("resourceVersion"));
+
+        Assert.assertEquals(
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("useS3Store"), "true");
+
+        Assert.assertEquals(
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("s3Bucket"),
+            fakeS3Bucket);
+
+        taskPartitionId++;
+      }
+
+      Assert
+          .assertEquals(taskTargetParts, new HashSet<>(Arrays.asList("test_seg_0", "test_seg_1")));
+    }
+  }
+
+  //*****************************************************
+  // dummy TaskFactory, Task to limit testing scope
+  //
+  // Varied behavior based on specific testing class:
+  // - populate Task level userStore
+  //****************************************************/
+
+  private class DummyRestoreTaskFactory extends RestoreTaskFactory {
+
+    public DummyRestoreTaskFactory(String cluster, int adminPort, boolean useS3Store,
+                                   String s3Bucket) {
+      super(cluster, adminPort, useS3Store, s3Bucket);
+    }
+
+    @Override
+    protected Task getTask(String cluster, String targetPartition, String storePathPrefix,
+                           String src_cluster, long resourceVersion, String job, int port,
+                           boolean useS3Store, String s3Bucket) {
+      return new TestRestoreTaskFactory.DummyRestoreTask(cluster, targetPartition,
+          storePathPrefix, src_cluster, resourceVersion, job, port, useS3Store, s3Bucket);
+    }
+
+  }
+
+  private class DummyRestoreTask extends RestoreTask {
+
+    public DummyRestoreTask(String taskCluster, String partitionName, String storePathPrefix,
+                            String src_cluster, long resourceVersion, String job, int adminPort,
+                            boolean useS3Store, String s3Bucket) {
+      super(taskCluster, partitionName, storePathPrefix, src_cluster, resourceVersion, job,
+          adminPort, useS3Store, s3Bucket);
+    }
+
+    @Override
+    public TaskResult run() {
+      allTasksReady.countDown();
+      try {
+        adminReady.await();
+      } catch (Exception e) {
+        return new TaskResult(TaskResult.Status.FATAL_FAILED, e.getMessage());
+      }
+
+      try {
+        long resVersion = readPrivateSuperClassLongField("resourceVersion");
+        String storePathPrefix = readPrivateSuperClassStringField("storePathPrefix");
+        String srcCluster = readPrivateSuperClassStringField("srcCluster");
+        putUserContent("resourceVersion", String.valueOf(resVersion), Scope.JOB);
+        putUserContent("resourceVersion", String.valueOf(resVersion), Scope.TASK);
+        putUserContent("storePathPrefix", storePathPrefix, Scope.TASK);
+        putUserContent("srcCluster", srcCluster, Scope.TASK);
+      } catch (Exception e) {
+        LOG.error(
+            "Failed to read super class's private filed or fail to pur userStore" + e.getMessage());
+      }
+
+      try {
+        super.run();
+      } catch (Exception e) {
+        LOG.error("Failed to execute BackupTask run" + e.getMessage());
+      }
+
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+
+    @Override
+    protected void executeRestore(String host, int port, String dbName, String storePath,
+                                  boolean useS3Store, String s3Bucket) throws RuntimeException {
+      try {
+        boolean useS3 = readPrivateSuperClassBooleanField("useS3Store");
+        String bucket = readPrivateSuperClassStringField("s3Bucket");
+        putUserContent("useS3Store", String.valueOf(useS3), Scope.TASK);
+        putUserContent("s3Bucket", bucket, Scope.TASK);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    // helper function for testing
+    // java refection: http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
+
+    private long readPrivateSuperClassLongField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.getLong(this);
+    }
+
+    private String readPrivateSuperClassStringField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (String) field.get(this);
+    }
+
+    private boolean readPrivateSuperClassBooleanField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (Boolean) field.get(this);
+    }
+  }
+}
+

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestRestoreTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestRestoreTaskFactory.java
@@ -1,5 +1,6 @@
 package com.pinterest.rocksplicator.task;
 
+import org.apache.helix.HelixAdmin;
 import org.apache.helix.TestHelper;
 import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.integration.task.TaskTestBase;
@@ -88,7 +89,7 @@ public class TestRestoreTaskFactory extends TaskTestBase {
       List<TaskConfig> taskConfigs = new ArrayList<>();
       for (int j = 0; j < NUM_TASK_PER_JOB; ++j) {
         Map<String, String> taskConfigMap = new HashMap<>();
-        taskConfigMap.put("TASK_TARGET_PARTITION", "test_seg_" + j);
+        taskConfigMap.put("TASK_TARGET_PARTITION", "TestDB_" + j);
         taskConfigs.add(new TaskConfig("Restore", taskConfigMap));
       }
 
@@ -155,7 +156,7 @@ public class TestRestoreTaskFactory extends TaskTestBase {
       }
 
       Assert
-          .assertEquals(taskTargetParts, new HashSet<>(Arrays.asList("test_seg_0", "test_seg_1")));
+          .assertEquals(taskTargetParts, new HashSet<>(Arrays.asList("TestDB_0", "TestDB_1")));
     }
   }
 
@@ -174,21 +175,20 @@ public class TestRestoreTaskFactory extends TaskTestBase {
     }
 
     @Override
-    protected Task getTask(String cluster, String targetPartition, String storePathPrefix,
-                           String src_cluster, long resourceVersion, String job, int port,
-                           boolean useS3Store, String s3Bucket) {
-      return new TestRestoreTaskFactory.DummyRestoreTask(cluster, targetPartition,
+    protected Task getTask(HelixAdmin admin, String cluster, String targetPartition,
+                           String storePathPrefix, String src_cluster, long resourceVersion,
+                           String job, int port, boolean useS3Store, String s3Bucket) {
+      return new TestRestoreTaskFactory.DummyRestoreTask(admin, cluster, targetPartition,
           storePathPrefix, src_cluster, resourceVersion, job, port, useS3Store, s3Bucket);
     }
-
   }
 
   private class DummyRestoreTask extends RestoreTask {
 
-    public DummyRestoreTask(String taskCluster, String partitionName, String storePathPrefix,
-                            String src_cluster, long resourceVersion, String job, int adminPort,
-                            boolean useS3Store, String s3Bucket) {
-      super(taskCluster, partitionName, storePathPrefix, src_cluster, resourceVersion, job,
+    public DummyRestoreTask(HelixAdmin admin, String taskCluster, String partitionName,
+                            String storePathPrefix, String src_cluster, long resourceVersion,
+                            String job, int adminPort, boolean useS3Store, String s3Bucket) {
+      super(admin, taskCluster, partitionName, storePathPrefix, src_cluster, resourceVersion, job,
           adminPort, useS3Store, s3Bucket);
     }
 


### PR DESCRIPTION
add Restore task into participant, which will enable participant cluster to restore from a static backup from cloud.
Usage: this will use to restore/rollback a segment to a previous version (which need be backup ahead of time); or, it could be used to bootstrap a copy of the segment into another cluster.  
Limitation: during restore, it will close the DB first, which means real time write to the DB during the Restore will be loss. 