### PR TITLE
add listAllObjects into s3_util

### DIFF
--- a/common/rocksdb_env_s3.cpp
+++ b/common/rocksdb_env_s3.cpp
@@ -300,7 +300,7 @@ Status S3Env::GetChildren(const std::string& path,
                           std::vector<std::string>* result) {
   auto formated_path = ensure_ends_with_pathsep(path);
   // fetch all files using the given path as the key prefix in S3
-  auto resp = s3_util_->listObjects(formated_path);
+  auto resp = s3_util_->listAllObjects(formated_path);
   if (!resp.Error().empty()) {
     LOG(ERROR) << "Error happened when fetching files from S3: "
                << resp.Error() << " under path: " << formated_path;
@@ -308,7 +308,7 @@ Status S3Env::GetChildren(const std::string& path,
   }
 
   // trim the file name
-  for (auto& v : resp.Body()) {
+  for (auto& v : resp.Body().objects) {
     // the path should be a prefix of the fetched value
     if (v.find(formated_path) == 0) {
       result->push_back(v.substr(formated_path.size()));

--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -256,6 +256,25 @@ ListObjectsResponseV2 S3Util::listObjectsV2(const string& prefix,
           ListObjectsResponseV2Body(objects, next_marker), error_message);
 }
 
+ListObjectsResponseV2 S3Util::listAllObjects(const string& prefix, const string& delimiter) {
+  vector<string> output;
+  vector<string> objects;
+  string error_message;
+  string marker;
+  string next_marker;
+  do {
+    listObjectsHelper(prefix, delimiter, marker, &objects, &next_marker, &error_message);
+    if (!error_message.empty()) {
+      break;
+    }
+    output.insert(output.end(), objects.begin(), objects.end());
+    objects.clear();
+    marker = next_marker;
+    next_marker.clear();
+  } while (!marker.empty());
+  return ListObjectsResponseV2(ListObjectsResponseV2Body(output, next_marker), error_message);
+}
+
 GetObjectsResponse S3Util::getObjects(
     const string& prefix, const string& local_directory,
     const string& delimiter, const bool direct_io) {

--- a/common/s3util.h
+++ b/common/s3util.h
@@ -188,7 +188,7 @@ class S3Util {
   // Return a list of objects under the prefix.
   // If delimiter is not empty, it will return all keys between Prefix
   // and the next occurrence of the string specified by delimiter.
-  // NOTE: this API doesn't provide continuation support.
+  // NOTE: this API doesn't provide continuation support; default 1000 as up-limit for objects count
   ListObjectsResponse listObjects(const string& prefix,
                                   const string& delimiter = "");
 
@@ -200,6 +200,9 @@ class S3Util {
   ListObjectsResponseV2 listObjectsV2(const string& prefix,
                                       const string& delimiter = "",
                                       const string& marker = "");
+
+  // Return a list of all objects under the prefix. It will have no up-limit for objects count
+  ListObjectsResponseV2 listAllObjects(const string& prefix, const string& delimiter = "");
 
   // Download all objects under a prefix. We only assume
   // For each object downloading,


### PR DESCRIPTION
add listAllObjects to get all objects with same prefix. Currently, both listObjects and listObjectsV2 has 1000 as default up-limit to objects, add listAllObjects to get all. 