### PR TITLE
Use rocksdb checkpoint for backup

### DIFF
--- a/rocksdb_admin/tests/s3_backup_integration_test.cpp
+++ b/rocksdb_admin/tests/s3_backup_integration_test.cpp
@@ -21,11 +21,14 @@
 #include "common/rocksdb_env_s3.h"
 #include "common/rocksdb_glogger/rocksdb_glogger.h"
 #include "common/s3util.h"
+#include "common/timeutil.h"
 #include "boost/filesystem.hpp"
 #include "gtest/gtest.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
+#include "rocksdb/options.h"
 #include "rocksdb/utilities/backupable_db.h"
+#include "rocksdb/utilities/checkpoint.h"
 
 using rocksdb::BackupableDBOptions;
 using rocksdb::BackupEngine;
@@ -54,6 +57,9 @@ DEFINE_string(original_db_path, "/tmp/test_s3_backup_original",
 
 DEFINE_string(restored_db_path, "/tmp/test_s3_backup_copy",
               "The dir for the restored racksdb instance");
+DEFINE_string(s3_backup_dir_checkpoint, "tmp/backup_test/backup/checkpoint", "The s3 key prefix for backup checkpoint");
+
+DEFINE_string(local_backup_dir_checkpoint, "/tmp/backup_test/backup/checkpoint", "");
 
 // helper function to open a rocksdb instance
 unique_ptr<DB> OpenDB(const string& path, bool error_if_exists = false) {
@@ -139,6 +145,83 @@ TEST(S3BackupRestoreTest, Basics) {
     status = restored_db->Get(ReadOptions(), "key" + to_string(i), &value);
     EXPECT_TRUE(status.ok());
     EXPECT_EQ(value, "value" + to_string(i));  
+  }
+}
+
+TEST(S3BackupRestoreCheckpointTest, Basics) {
+  boost::system::error_code remove_err;
+  boost::system::error_code create_err;
+  boost::filesystem::remove_all(FLAGS_local_backup_dir_checkpoint, remove_err);
+  boost::filesystem::create_directories(FLAGS_local_backup_dir_checkpoint, create_err);
+  boost::filesystem::remove_all(FLAGS_restored_db_path, remove_err);
+  boost::filesystem::create_directories(FLAGS_restored_db_path, create_err);
+  EXPECT_FALSE(remove_err || create_err);
+  SCOPE_EXIT {
+      boost::filesystem::remove_all(FLAGS_local_backup_dir_checkpoint, remove_err);
+      boost::filesystem::remove_all(FLAGS_restored_db_path, remove_err);
+  };
+  EXPECT_FALSE(remove_err || create_err);
+
+  int expected_seq_no = 10;
+
+  // create a new db
+  auto original_db = CleanAndOpenDB(FLAGS_original_db_path);
+  for (int i = 0; i < expected_seq_no; ++i) {
+    EXPECT_EQ(original_db->GetLatestSequenceNumber(), i);
+    auto status = original_db->Put(rocksdb::WriteOptions(),
+                                   "key" + to_string(i), "value" + to_string(i));
+    EXPECT_TRUE(status.ok());
+  }
+
+  // back up db. backup can be found in the s3 by using the following command
+  // aws s3 ls s3://FLAGS_s3_bucket/FLAGS_s3_backup_dir_checkpoint
+  auto local_s3_util = common::S3Util::BuildS3Util(50, FLAGS_s3_bucket);
+  rocksdb::Checkpoint* checkpoint;
+  auto status = rocksdb::Checkpoint::Create(original_db.get(), &checkpoint);
+  EXPECT_TRUE(status.ok());
+
+  auto ts = common::timeutil::GetCurrentTimestamp();
+  std::string formatted_local_dir_path = folly::stringPrintf("%s/test%d", FLAGS_local_backup_dir_checkpoint.c_str(), ts);
+  std::string formatted_s3_dir_path = folly::stringPrintf("%s/test%d/", FLAGS_s3_backup_dir_checkpoint.c_str(), ts);
+  status = checkpoint->CreateCheckpoint(formatted_local_dir_path);
+  EXPECT_TRUE(status.ok());
+  std::unique_ptr<rocksdb::Checkpoint> checkpoint_holder(checkpoint);
+
+  std::vector<std::string> checkpoint_files;
+  status = rocksdb::Env::Default()->GetChildren(formatted_local_dir_path, &checkpoint_files);
+  EXPECT_TRUE(status.ok());
+
+  // Upload checkpoint to s3
+  for (const auto& file : checkpoint_files) {
+    if (file == "." || file == "..") {
+      continue;
+    }
+    auto copy_resp = local_s3_util->putObject(formatted_s3_dir_path + file, formatted_local_dir_path + "/" + file);
+    EXPECT_TRUE(copy_resp.Error().empty());
+  }
+
+  // restore db
+  auto resp = local_s3_util->listAllObjects(formatted_s3_dir_path);
+  EXPECT_TRUE(resp.Error().empty());
+  std::string formatted_local_path = FLAGS_restored_db_path + "/";
+
+  for (auto& v : resp.Body().objects) {
+    // If there is error in one file downloading, then we fail the whole restore process
+    auto get_resp = local_s3_util->getObject(v, formatted_local_path + v.substr(formatted_s3_dir_path.size()), false);
+    EXPECT_TRUE(get_resp.Error().empty());
+  }
+
+  rocksdb::DB* restored_db;
+  status = rocksdb::DB::Open(rocksdb::Options(), formatted_local_path, &restored_db);
+  EXPECT_TRUE(status.ok());
+
+  // compare the original db with the restored db
+  EXPECT_EQ(restored_db->GetLatestSequenceNumber(), expected_seq_no);
+  for (int i = 0; i < expected_seq_no; ++i) {
+    string value;
+    status = restored_db->Get(ReadOptions(), "key" + to_string(i), &value);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(value, "value" + to_string(i));
   }
 }
 


### PR DESCRIPTION
Checkpoint is a feature in RocksDB which provides the ability to take a snapshot
of a running RocksDB database in a separate directory. And unlike the previous
s3 backup solution, while we need to create a backup to local indirectly(copy sst files and
wal logs) and then upload to s3, due to s3 is not a pure file system as hdfs.
For the checkpoint solutin, it only create the hard links in local and then
upload to s3, which will save us an unnessary copy. We also implemented parallel
upload/download in this approach.