### PR TITLE
remove the slash prefix for hdfs_backup_dir to be consistent with s3 …

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
@@ -379,7 +379,7 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
         // before we call backupDB() below. In that case, we will throw and let Helix mark the
         // local partition as error.
         if (!useS3Backup) {
-          String hdfsPath = "/rocksplicator/" + cluster + "/" + dbName + "/" + snapshotHost + "_"
+          String hdfsPath = "rocksplicator/" + cluster + "/" + dbName + "/" + snapshotHost + "_"
             + String.valueOf(snapshotPort) + "/" + String.valueOf(System.currentTimeMillis());
 
           // backup a snapshot from the upstream host, and restore it locally

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -629,7 +629,7 @@ void AdminHandler::async_tm_backupDB(
     std::unique_ptr<apache::thrift::HandlerCallback<std::unique_ptr<
       BackupDBResponse>>> callback,
     std::unique_ptr<BackupDBRequest> request) {
-  auto full_path = FLAGS_hdfs_name_node + request->hdfs_backup_dir;
+  auto full_path = FLAGS_hdfs_name_node + ensure_start_with_pathsep(request->hdfs_backup_dir, '/');
   rocksdb::Env* hdfs_env;
   auto status = rocksdb::NewHdfsEnv(&hdfs_env, full_path);
   if (!OKOrSetException(status,
@@ -671,7 +671,7 @@ void AdminHandler::async_tm_restoreDB(
     return;
   }
 
-  auto full_path = FLAGS_hdfs_name_node + request->hdfs_backup_dir;
+  auto full_path = FLAGS_hdfs_name_node + ensure_start_with_pathsep(request->hdfs_backup_dir, '/');
   rocksdb::Env* hdfs_env;
   auto status = rocksdb::NewHdfsEnv(&hdfs_env, full_path);
   if (!OKOrSetException(status,

--- a/rocksdb_admin/utils.h
+++ b/rocksdb_admin/utils.h
@@ -34,4 +34,11 @@ std::string DbNameToSegment(const std::string& db_name);
  */
 int ExtractShardId(const std::string& db_name);
 
+inline std::string ensure_start_with_pathsep(const std::string& s, char pathsep) {
+  if (!s.empty() && s.front() != pathsep) {
+    return pathsep + s;
+  }
+  return s;
+}
+
 }  // namespace admin


### PR DESCRIPTION
Remove the the slash prefix from hdfs_backup_dir, so it could be consistent with s3_path conversion. 
During backup/dedup, client provide storePathPrefix which has no visibility of which cloud was used (hdfs or s3). Thus, rocksplicator code should be consistent about how to concat namenode/bucket with storePathPrefix. Therefore, in admin_handler, we need to concat hdfs_namenode + "/" + hdfs_backup_dir, which is consistent with s3, which will eventually use path: s3_bucket + "/" + s3_backup_dir. 