### PR TITLE
enable share_files_with_checksum during rocksdb instance backup

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -291,7 +291,7 @@ public class Utils {
   }
 
   public static void backupDBWithLimit(String host, int adminPort, String dbName, String hdfsPath,
-                                       int limitMbs)
+                                       int limitMbs, boolean shareFilesWithChecksum)
       throws RuntimeException {
     LOG.error("Backup " + dbName + " from " + host + " to " + hdfsPath);
     try {
@@ -299,6 +299,7 @@ public class Utils {
 
       BackupDBRequest req = new BackupDBRequest(dbName, hdfsPath);
       req.setLimit_mbs(limitMbs);
+      req.setShare_files_with_checksum(shareFilesWithChecksum);
       client.backupDB(req);
     } catch (TException e) {
       LOG.error("Failed to backup DB: ", e.toString());

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTask.java
@@ -42,10 +42,11 @@ public class BackupTask extends UserContentStore implements Task {
   private final int adminPort;
   private final boolean useS3Store;
   private final String s3Bucket;
+  private final boolean shareFilesWithChecksum;
 
   public BackupTask(String taskCluster, String partitionName, int backupLimitMbs,
                     String storePathPrefix, long resourceVersion, String job, int adminPort,
-                    boolean useS3Store, String s3Bucket) {
+                    boolean useS3Store, String s3Bucket, boolean shareFilesWithChecksum) {
     this.taskCluster = taskCluster;
     this.partitionName = partitionName;
     this.backupLimitMbs = backupLimitMbs;
@@ -55,6 +56,7 @@ public class BackupTask extends UserContentStore implements Task {
     this.adminPort = adminPort;
     this.useS3Store = useS3Store;
     this.s3Bucket = s3Bucket;
+    this.shareFilesWithChecksum = shareFilesWithChecksum;
   }
 
   /**
@@ -85,7 +87,7 @@ public class BackupTask extends UserContentStore implements Task {
               resourceVersion));
 
       executeBackup("127.0.0.1", adminPort, dbName, storePath, backupLimitMbs, useS3Store,
-          s3Bucket);
+          s3Bucket, shareFilesWithChecksum);
 
       return new TaskResult(TaskResult.Status.COMPLETED, "BackupTask is completed!");
     } catch (Exception e) {
@@ -96,13 +98,15 @@ public class BackupTask extends UserContentStore implements Task {
   }
 
   protected void executeBackup(String host, int port, String dbName, String storePath,
-                               int backupLimitMbs, boolean useS3Store, String s3Bucket)
+                               int backupLimitMbs, boolean useS3Store, String s3Bucket,
+                               boolean shareFilesWithChecksum)
       throws RuntimeException {
     try {
       if (useS3Store) {
         Utils.backupDBToS3WithLimit(host, port, dbName, backupLimitMbs, s3Bucket, storePath);
       } else {
-        Utils.backupDBWithLimit(host, port, dbName, storePath, backupLimitMbs);
+        Utils.backupDBWithLimit(host, port, dbName, storePath, backupLimitMbs,
+            shareFilesWithChecksum);
       }
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
@@ -77,6 +77,7 @@ public class BackupTaskFactory implements TaskFactory {
     String storePathPrefix = "";
     long resourceVersion = jobCreationTime;
     int backupLimitMbs = DEFAULT_BACKUP_LIMIT_MBS;
+    boolean shareFilesWithChecksum = true;
 
     try {
       Map<String, String> jobCmdMap = jobConfig.getJobCommandConfigMap();
@@ -89,6 +90,10 @@ public class BackupTaskFactory implements TaskFactory {
         }
         if (jobCmdMap.containsKey("BACKUP_LIMIT_MBS")) {
           backupLimitMbs = Integer.parseInt(jobCmdMap.get("BACKUP_LIMIT_MBS"));
+        }
+        if (jobCmdMap.containsKey("ROCKSDB_SHARE_FILES_WITH_CHECKSUM")) {
+          shareFilesWithChecksum =
+              Boolean.parseBoolean(jobCmdMap.get("ROCKSDB_SHARE_FILES_WITH_CHECKSUM"));
         }
       }
     } catch (NumberFormatException e) {
@@ -109,14 +114,14 @@ public class BackupTaskFactory implements TaskFactory {
             System.currentTimeMillis()));
 
     return getTask(cluster, targetPartition, backupLimitMbs, storePathPrefix, resourceVersion, job,
-        adminPort, useS3Store, s3Bucket);
+        adminPort, useS3Store, s3Bucket, shareFilesWithChecksum);
   }
 
   protected Task getTask(String cluster, String targetPartition, int backupLimitMbs,
                          String storePathPrefix, long resourceVersion, String job, int port,
-                         boolean useS3Store, String s3Bucket) {
+                         boolean useS3Store, String s3Bucket, boolean shareFilesWithChecksum) {
     return new BackupTask(cluster, targetPartition, backupLimitMbs, storePathPrefix,
-        resourceVersion, job, port, useS3Store, s3Bucket);
+        resourceVersion, job, port, useS3Store, s3Bucket, shareFilesWithChecksum);
   }
 
 }

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTaskFactory.java
@@ -207,9 +207,9 @@ public class TestBackupTaskFactory extends TaskTestBase {
     @Override
     protected Task getTask(String cluster, String targetPartition, int backupLimitMbs,
                            String storePathPrefix, long resourceVersion, String job, int port,
-                           boolean useS3Store, String s3Bucket) {
+                           boolean useS3Store, String s3Bucket, boolean shareFilesWithChecksum) {
       return new DummyBackupTask(cluster, targetPartition, backupLimitMbs, storePathPrefix,
-          resourceVersion, job, port, useS3Store, s3Bucket);
+          resourceVersion, job, port, useS3Store, s3Bucket, shareFilesWithChecksum);
     }
 
   }
@@ -218,9 +218,9 @@ public class TestBackupTaskFactory extends TaskTestBase {
 
     public DummyBackupTask(String taskCluster, String partitionName, int backupLimitMbs,
                            String storePathPrefix, long resourceVersion, String job, int adminPort,
-                           boolean useS3Store, String s3Bucket) {
+                           boolean useS3Store, String s3Bucket, boolean shareFilesWithChecksum) {
       super(taskCluster, partitionName, backupLimitMbs, storePathPrefix, resourceVersion, job,
-          adminPort, useS3Store, s3Bucket);
+          adminPort, useS3Store, s3Bucket, shareFilesWithChecksum);
     }
 
     @Override
@@ -257,7 +257,8 @@ public class TestBackupTaskFactory extends TaskTestBase {
 
     @Override
     protected void executeBackup(String host, int port, String dbName, String storePath,
-                                 int backupLimitMbs, boolean useS3Store, String s3Bucket)
+                                 int backupLimitMbs, boolean useS3Store, String s3Bucket,
+                                 boolean shareFilesWithChecksum)
         throws RuntimeException {
       try {
         boolean useS3 = readPrivateSuperClassBooleanField("useS3Store");

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -925,7 +925,7 @@ void AdminHandler::async_tm_backupDBToS3(
                         std::unique_ptr<rocksdb::Env>(s3_env),
                         request->__isset.limit_mbs,
                         request->limit_mbs,
-                        false,
+                        false, // disable checksum support for s3 till checkpoint backup to s3 also support it
                         &e)) {
       callback.release()->exceptionInThread(std::move(e));
       common::Stats::get()->Incr(kS3BackupFailure);

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -183,6 +183,7 @@ class AdminHandler : virtual public AdminSvIf {
                       std::unique_ptr<rocksdb::Env> env_holder,
                       const bool enable_backup_rate_limit,
                       const uint32_t backup_rate_limit,
+                      const bool share_files_with_checksum,
                       AdminException* e);
 
   bool restoreDBHelper(const std::string& db_name,

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -62,6 +62,8 @@ struct BackupDBRequest {
   2: required string hdfs_backup_dir,
   # rate limit in MB/S, a non positive value means no limit
   3: optional i32 limit_mbs = 0,
+  # enable appending checksum to sst file name during backup
+  4: optional bool share_files_with_checksum = false,
 }
 
 struct BackupDBResponse {


### PR DESCRIPTION
Rocksdb backupEngine support backup with adding "timestamp" and "checksum" to sst filename by setting flag: ```share_files_with_checksum``` in BackupOptions, so that multiple rocksdb instance could backup to the same directory without introducing conflicts. 
- We add this as an optional field in the BackupRequest so that whoever request the backup, could control whether enable the flag. 
- We did not introduce another global Gflag to control this due to our existing statemodels use the default BackupOptions which has this flag disabled, by passing from BackupRequest, we could keep existing statemodels still use old options with flag disabled; while our new backup transitions with this flag enabled. 
- this is only enabled when hdfs is used as cloud storage, since it will conflict with current implementation of checkpoint backup with S3Env. 