### PR TITLE
switch dedup task to use backup with limitMbs

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
@@ -31,6 +31,8 @@ public class DedupTaskFactory implements TaskFactory {
   private final boolean useS3Store;
   private final String s3Bucket;
 
+  private static final int DEFAULT_BACKUP_LIMIT_MBS = 64;
+
   public DedupTaskFactory(String cluster, int adminPort, boolean useS3Store, String s3Bucket) {
     this.cluster = cluster;
     this.adminPort = adminPort;
@@ -54,6 +56,8 @@ public class DedupTaskFactory implements TaskFactory {
     String srcStorePathPrefix = "";
     long resourceVersion = -1;
     String destStorePathPrefix = "";
+    int backupLimitMbs = DEFAULT_BACKUP_LIMIT_MBS;
+    boolean shareFilesWithChecksum = true;
 
     try {
       Map<String, String> jobCmdMap = jobConfig.getJobCommandConfigMap();
@@ -66,6 +70,13 @@ public class DedupTaskFactory implements TaskFactory {
         }
         if (jobCmdMap.containsKey("DEST_STORE_PATH_PREFIX")) {
           destStorePathPrefix = jobCmdMap.get("DEST_STORE_PATH_PREFIX");
+        }
+        if (jobCmdMap.containsKey("BACKUP_LIMIT_MBS")) {
+          backupLimitMbs = Integer.parseInt(jobCmdMap.get("BACKUP_LIMIT_MBS"));
+        }
+        if (jobCmdMap.containsKey("ROCKSDB_SHARE_FILES_WITH_CHECKSUM")) {
+          shareFilesWithChecksum =
+              Boolean.parseBoolean(jobCmdMap.get("ROCKSDB_SHARE_FILES_WITH_CHECKSUM"));
         }
       }
     } catch (NumberFormatException e) {
@@ -82,14 +93,15 @@ public class DedupTaskFactory implements TaskFactory {
         System.currentTimeMillis()));
 
     return getTask(srcStorePathPrefix, resourceVersion, targetPartition, cluster, job, adminPort,
-        destStorePathPrefix, useS3Store, s3Bucket);
+        destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum);
   }
 
   protected DedupTask getTask(String srcStorePathPrefix, long resourceVersion, String partitionName,
                               String cluster, String job, int port, String destStorePathPrefix,
-                              boolean useS3Store, String s3Bucket) {
+                              boolean useS3Store, String s3Bucket, int backupLimitMbs,
+                              boolean shareFilesWithChecksum) {
     return new DedupTask(srcStorePathPrefix, resourceVersion, partitionName, cluster, job, port,
-        destStorePathPrefix, useS3Store, s3Bucket);
+        destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum);
   }
 
 }

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestDedupTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestDedupTaskFactory.java
@@ -159,20 +159,22 @@ public class TestDedupTaskFactory extends TaskTestBase {
     @Override
     protected DedupTask getTask(String srcStorePathPrefix, long resourceVersion,
                                 String partitionName, String cluster, String job, int port,
-                                String destStorePathPrefix, boolean useS3Store, String s3Bucket) {
-      return new DummyDedupTask(srcStorePathPrefix, resourceVersion, partitionName, cluster, job,
-          port,
-          destStorePathPrefix, useS3Store, s3Bucket);
+                                String destStorePathPrefix, boolean useS3Store, String s3Bucket,
+                                int backupLimitMbs, boolean shareFilesWithChecksum) {
+      return new DummyDedupTask(srcStorePathPrefix, resourceVersion, partitionName, cluster, job, port,
+          destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum);
     }
+
   }
 
   protected class DummyDedupTask extends DedupTask {
 
     public DummyDedupTask(String srcStorePathPrefix, long resourceVersion,
                           String partitionName, String taskCluster, String job, int adminPort,
-                          String destStorePathPrefix, boolean useS3Store, String s3Bucket) {
+                          String destStorePathPrefix, boolean useS3Store, String s3Bucket,
+                          int backupLimitMbs, boolean shareFilesWithChecksum) {
       super(srcStorePathPrefix, resourceVersion, partitionName, taskCluster, job, adminPort,
-          destStorePathPrefix, useS3Store, s3Bucket);
+          destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum);
     }
 
     @Override


### PR DESCRIPTION
Switch dedupTask's data upload API from ```backupDB```, ```backupDBToS3``` to ```backupDBWithLimit```, ```backupDBToS3WithLimit```, so we can control the data upload limit. And also enable ```shareFilesWithChecksum``` (similar to ```backupTask```) for data upload to prevent conflict when multiple rocksdb instances upload to the same directory. 