### PR TITLE
[rocksplicator] throws exception when addDb or closeDB failed to tasks

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/BootstrapStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/BootstrapStateModelFactory.java
@@ -124,7 +124,11 @@ public class BootstrapStateModelFactory extends StateModelFactory<StateModel> {
       Utils.checkSanity("OFFLINE", "BOOTSTRAP", message, resourceName, partitionName);
       Utils.logTransitionMessage(message);
 
-      Utils.addDB(Utils.getDbName(partitionName), adminPort, "NOOP");
+      try{
+        Utils.addDB(Utils.getDbName(partitionName), adminPort, "NOOP");
+      } catch (Exception e) {
+        LOG.error("addDB with dbRole: NOOP failed with exception during offline->bootstrap");
+      }
 
       try {
         zkClient.sync().forPath(Utils.getMetaLocation(cluster, resourceName));

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -108,10 +108,15 @@ public class Utils {
    * @param adminPort
    */
   public static void closeDB(String dbName, int adminPort) {
-    closeRemoteOrLocalDB("localhost", adminPort, dbName);
+    try {
+      closeRemoteOrLocalDB("localhost", adminPort, dbName);
+    } catch (RuntimeException e) {
+      LOG.error("closeDB failed with exception", e);
+    }
   }
 
-  public static void closeRemoteOrLocalDB(String host, int adminPort, String dbName) {
+  public static void closeRemoteOrLocalDB(String host, int adminPort, String dbName)
+      throws RuntimeException {
     try {
       LOG.error("Close DB: " + dbName + " on host: " + host);
       Admin.Client client = getAdminClient(host, adminPort);
@@ -119,10 +124,13 @@ public class Utils {
       client.closeDB(req);
     } catch (AdminException e) {
       LOG.error(dbName + " doesn't exist", e);
+      throw new RuntimeException(e);
     } catch (TTransportException e) {
       LOG.error("Failed to connect to Admin port", e);
+      throw new RuntimeException(e);
     } catch (TException e) {
       LOG.error("CloseDB() request failed", e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -160,8 +168,10 @@ public class Utils {
       }
     } catch (TTransportException e) {
       LOG.error("Failed to connect to local Admin port", e);
+      throw new RuntimeException(e);
     } catch (TException e) {
       LOG.error("AddDB() request failed", e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -171,7 +181,11 @@ public class Utils {
    * @param adminPort
    */
   public static void addDB(String dbName, int adminPort) {
-    addDB(dbName, adminPort, "SLAVE");
+    try {
+      addDB(dbName, adminPort, "SLAVE");
+    } catch (RuntimeException e) {
+      LOG.error("addDB failed with exception", e);
+    }
   }
 
   /**

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTask.java
@@ -92,8 +92,8 @@ public class DedupTask extends UserContentStore implements Task {
                               int backupLimitMbs, boolean shareFilesWithChecksum)
       throws RuntimeException {
     try {
-      Utils.addDB(dbName, adminPort);
-      Utils.closeDB(dbName, adminPort);
+      Utils.addDB(dbName, adminPort, "SLAVE");
+      Utils.closeRemoteOrLocalDB("localhost", adminPort, dbName);
       if (useS3Store) {
         Utils.restoreLocalDBFromS3(adminPort, dbName, s3Bucket, srcStorePath, "127.0.0.1",
             adminPort);


### PR DESCRIPTION
AddDB and closeDB did not re-throw exception, but only log the errors. While, for helix backup/dedup, we do want to catch these errors to fail the Task quickly if exception happen. 
Impl:
- Keep the original addDB, closeDB no-throw by wrapping the RPC call to add/close DB, and catching exception in the function and log the error. 
- let helix Task use the un-wrapped add/close DB so that it could throw exception when failed. 
