### PR TITLE
[rocksplicator] delete db in async way

### DIFF
--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <unordered_set>
 
 #include "common/object_lock.h"
@@ -50,7 +51,7 @@ class AdminHandler : virtual public AdminSvIf {
     std::unique_ptr<ApplicationDBManager> db_manager,
     RocksDBOptionsGeneratorType rocksdb_options);
 
-  virtual ~AdminHandler() {}
+  virtual ~AdminHandler();
 
   void async_tm_ping(
       std::unique_ptr<apache::thrift::HandlerCallback<void>> callback) override;
@@ -196,6 +197,9 @@ class AdminHandler : virtual public AdminSvIf {
 
   std::shared_ptr<common::S3Util> createLocalS3Util(const uint32_t read_ratelimit_mb = 50,
                                                     const std::string& bucket = "");
+
+  std::unique_ptr<std::thread> db_deletion_thread_;
+  std::atomic<bool> stop_db_deletion_thread_;
 };
 
 }  // namespace admin


### PR DESCRIPTION
If the db/segment's size is huge, there will be latency spikes caused by high
disk IO usage when delete a helix resource which will close and delete all the
dbs in the host at the same time. In order to mitigate these spikes, we provide
an async way to handle the dbs deletion: 1. mv the dbs to db_tmp/ in
async_tm_clearDB which has cheap disk operation overhead. 2. delete the dbs
under db_tmp/ periodically.

Tested it in test & stage cluster, the spikes were gone.