### PR TITLE
Update shard map before notifying followers of new leader.

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
@@ -153,10 +153,11 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
       try (Locker locker = new Locker(partitionMutex)) {
         HelixAdmin admin = context.getManager().getClusterManagmentTool();
         Map<String, String> stateMap = null;
+        ExternalView view = null;
 
         // sanity check no existing Leader for up to 59 seconds
         for (int i = 0; i < 60; ++i) {
-          ExternalView view = admin.getResourceExternalView(cluster, resourceName);
+          view = admin.getResourceExternalView(cluster, resourceName);
           stateMap = view.getStateMap(partitionName);
 
           if (!stateMap.containsValue("LEADER")) {
@@ -225,6 +226,9 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
         Utils.changeDBRoleAndUpStream("localhost", adminPort, dbName, "LEADER",
         "", adminPort);
 
+        // Get the latest external view and state map
+        view = admin.getResourceExternalView(cluster, resourceName);
+        stateMap = view.getStateMap(partitionName);
         // changeDBRoleAndUpStream(all_other_followers_or_offlines, "Follower", "my_ip_port")
         for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
           String hostName = instanceNameAndRole.getKey().split("_")[0];

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
@@ -153,10 +153,11 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
       try (Locker locker = new Locker(partitionMutex)) {
         HelixAdmin admin = context.getManager().getClusterManagmentTool();
         Map<String, String> stateMap = null;
+        ExternalView view = null;
 
         // sanity check no existing Master for up to 59 seconds
         for (int i = 0; i < 60; ++i) {
-          ExternalView view = admin.getResourceExternalView(cluster, resourceName);
+          view = admin.getResourceExternalView(cluster, resourceName);
           stateMap = view.getStateMap(partitionName);
 
           if (!stateMap.containsValue("MASTER")) {
@@ -225,6 +226,9 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
         Utils.changeDBRoleAndUpStream("localhost", adminPort, dbName, "MASTER",
         "", adminPort);
 
+        // Get the latest external view and state map
+        view = admin.getResourceExternalView(cluster, resourceName);
+        stateMap = view.getStateMap(partitionName);
         // changeDBRoleAndUpStream(all_other_slaves_or_offlines, "Slave", "my_ip_port")
         for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
           String hostName = instanceNameAndRole.getKey().split("_")[0];


### PR DESCRIPTION
We have seen issues where a follower has its upstream set to a previous
leader. This causes the follower to not receive any updates from the
current leader, leading to inconsistent data being read by clients.

One of the causes for the above could be that the shard map is
potentially not updated for 10 minutes before notifying the followers.
Although there is a distributed lock for each partition and it is
unlikely that a new follower might have come up while a follower->leader
transition is taking place, with zookeeper involved it could be possible.
This is an easy fix to mitigate the issue to a certain extent.

I was unable to reproduce the issue on a test cluster. So will need to
test it once I land it.