### PR TITLE
Upgrade java to version java 8

### DIFF
--- a/cluster_management/pom.xml
+++ b/cluster_management/pom.xml
@@ -73,8 +73,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
We are already using helix-0.9.1 version, the library version that is using java 8. Hence we can't compile cluster_management with java 7 anyway.