### PR TITLE
[Profiling Leader Handoff]: Implement Config / FileWatcher through polling

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/Decoder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/Decoder.java
@@ -1,0 +1,5 @@
+package com.pinterest.rocksplicator.codecs;
+
+public interface Decoder<T, S> {
+  S decode(final T data) throws CodecException;
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/Decoder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/Decoder.java
@@ -1,3 +1,21 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
 package com.pinterest.rocksplicator.codecs;
 
 public interface Decoder<T, S> {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/Encoder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/Encoder.java
@@ -1,0 +1,5 @@
+package com.pinterest.rocksplicator.codecs;
+
+public interface Encoder<S, T> {
+  T encode(final S obj) throws CodecException;
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/JSONArrayStringSetDecoder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/JSONArrayStringSetDecoder.java
@@ -1,0 +1,47 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.codecs;
+
+import com.google.common.collect.ImmutableSet;
+import org.json.simple.JSONArray;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Set;
+
+/**
+ * Decodes byte[] content as a JSONArray
+ * ["first", "second", "third"]
+ */
+public class JSONArrayStringSetDecoder implements Decoder<byte[], Set<String>> {
+
+  @Override
+  public Set<String> decode(byte[] data) throws CodecException {
+    JSONParser parser = new JSONParser();
+    try {
+      JSONArray array = (JSONArray) parser.parse(new String(data, "UTF-8"));
+      return ImmutableSet.copyOf(array);
+    } catch (ParseException e) {
+      throw new CodecException(e);
+    } catch (UnsupportedEncodingException e) {
+      throw new CodecException(e);
+    }
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/LineTerminatedStringSetDecoder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/LineTerminatedStringSetDecoder.java
@@ -1,3 +1,21 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
 package com.pinterest.rocksplicator.codecs;
 
 import com.google.common.collect.ImmutableSet;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/LineTerminatedStringSetDecoder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/LineTerminatedStringSetDecoder.java
@@ -1,0 +1,44 @@
+package com.pinterest.rocksplicator.codecs;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Set;
+
+public class LineTerminatedStringSetDecoder implements Decoder<byte[], Set<String>> {
+
+  @Override
+  public Set<String> decode(byte[] data) throws CodecException {
+    if (data == null) {
+      return ImmutableSet.of();
+    }
+
+    InputStream inputStream = new ByteArrayInputStream(data);
+    InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+    BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+
+    ImmutableSet.Builder<String> setBuilder = ImmutableSet.builder();
+
+    while (true) {
+      try {
+        String line = null;
+        if ((line = bufferedReader.readLine()) == null) {
+          break;
+        }
+        line = line.trim();
+        if (line.isEmpty() || line.startsWith("#")) {
+          // Comment, move on to next line.
+          continue;
+        }
+        setBuilder.add(line);
+      } catch (IOException e) {
+        throw new CodecException(e);
+      }
+    }
+    return setBuilder.build();
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/ConfigCodecEnum.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/ConfigCodecEnum.java
@@ -16,8 +16,9 @@
 // @author Gopal Rajpurohit (grajpurohit@pinterest.com)
 //
 
-package com.pinterest.rocksplicator.codecs;
+package com.pinterest.rocksplicator.config;
 
-public interface Encoder<S, T> {
-  T encode(final S obj) throws CodecException;
+public enum ConfigCodecEnum {
+  LINE_TERMINATED,
+  JSON_ARRAY
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/ConfigCodecs.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/ConfigCodecs.java
@@ -1,0 +1,52 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.config;
+
+import com.pinterest.rocksplicator.codecs.Decoder;
+import com.pinterest.rocksplicator.codecs.JSONArrayStringSetDecoder;
+import com.pinterest.rocksplicator.codecs.LineTerminatedStringSetDecoder;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Set;
+
+public class ConfigCodecs {
+
+  public static Decoder<byte[], Set<String>> getDecoder(String decoder_enum)
+      throws UnsupportedEncodingException {
+    if ("line_terminated".equalsIgnoreCase(decoder_enum)) {
+      return getDecoder(ConfigCodecEnum.LINE_TERMINATED);
+    } else if ("json_array".equalsIgnoreCase(decoder_enum)) {
+      return getDecoder(ConfigCodecEnum.JSON_ARRAY);
+    } else {
+      throw new UnsupportedEncodingException("Encoding not supported");
+    }
+  }
+
+  public static Decoder<byte[], Set<String>> getDecoder(ConfigCodecEnum cce)
+      throws UnsupportedEncodingException {
+    switch (cce) {
+      case LINE_TERMINATED:
+        return new LineTerminatedStringSetDecoder();
+      case JSON_ARRAY:
+        return new JSONArrayStringSetDecoder();
+      default:
+        throw new UnsupportedEncodingException("Encoding not supported");
+    }
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/ConfigStore.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/ConfigStore.java
@@ -1,0 +1,57 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.config;
+
+import com.pinterest.rocksplicator.codecs.CodecException;
+import com.pinterest.rocksplicator.codecs.Decoder;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ConfigStore<R> {
+
+  private Decoder<byte[], R> decoder;
+  private AtomicReference<R> ref;
+
+  public ConfigStore(Decoder<byte[], R> decoder, String filePath) throws IOException {
+    this(decoder, filePath, FileWatchers.getPollingFileWatcher());
+  }
+
+  @VisibleForTesting
+  ConfigStore(Decoder<byte[], R> decoder, String filePath, FileWatcher<byte[]> fileWatcher)
+      throws IOException {
+    this.decoder = decoder;
+    this.ref = new AtomicReference<>();
+    fileWatcher.addWatch(filePath, bytes -> {
+      try {
+        R newInstance = ConfigStore.this.decoder.decode(bytes);
+        ref.set(newInstance);
+      } catch (CodecException e) {
+        e.printStackTrace();
+      }
+      return null;
+    });
+  }
+
+  public R get() {
+    return ref.get();
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/FileWatcher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/FileWatcher.java
@@ -16,7 +16,13 @@
 // @author Gopal Rajpurohit (grajpurohit@pinterest.com)
 //
 
-package com.pinterest.rocksplicator.codecs;
+package com.pinterest.rocksplicator.config;
 
-public interface Codec<S, T> extends Encoder<S, T>, Decoder <T, S> {
+import java.io.IOException;
+import java.util.function.Function;
+
+public interface FileWatcher<R> {
+
+  void addWatch(String filePath, Function<R, Void> onUpdate) throws IOException;
 }
+

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/FileWatchers.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/FileWatchers.java
@@ -16,7 +16,10 @@
 // @author Gopal Rajpurohit (grajpurohit@pinterest.com)
 //
 
-package com.pinterest.rocksplicator.codecs;
+package com.pinterest.rocksplicator.config;
 
-public interface Codec<S, T> extends Encoder<S, T>, Decoder <T, S> {
+public class FileWatchers {
+  public static FileWatcher<byte[]> getPollingFileWatcher() {
+    return PollingFileWatcher.defaultInstance();
+  }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/PollingFileWatcher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/PollingFileWatcher.java
@@ -1,0 +1,229 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.config;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+/**
+ * Class to monitor config files on local disk. Typical usage is to use the default instance
+ * and have it monitor as many config files as needed.
+ *
+ * The class allows users to specify a watch on a file path and pass in a callback that
+ * will be invoked whenever an update to the file is detected. Update detection currently
+ * works by periodic polling; if the last modified time on the file is updated and the
+ * content hash has changed, all watchers on that file are notified. Note that last modified
+ * time is just used as a hint to determine whether to check the content and not for versioning.
+ *
+ * Objects of this class are thread safe.
+ *
+ */
+public class PollingFileWatcher implements FileWatcher<byte[]> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PollingFileWatcher.class);
+  private static final HashFunction HASH_FUNCTION = Hashing.md5();
+  public static final int DEFAULT_POLL_PERIOD_MILLIS = 10000;
+  private static volatile PollingFileWatcher DEFAULT_INSTANCE = null;
+
+  // Thread safety note: only addWatch() can add new entries to this map, and that method
+  // is synchronized. The reason for using a concurrent map is only to allow the watcher
+  // thread to concurrently iterate over it.
+  private final ConcurrentMap<String, ConfigFileInfo> watchedFileMap = Maps.newConcurrentMap();
+  private final WatcherTask watcherTask;
+
+  /**
+   * Creates the default ConfigFileWatcher instance on demand.
+   */
+  public static PollingFileWatcher defaultInstance() {
+    if (DEFAULT_INSTANCE == null) {
+      synchronized (PollingFileWatcher.class) {
+        if (DEFAULT_INSTANCE == null) {
+          DEFAULT_INSTANCE = new PollingFileWatcher(DEFAULT_POLL_PERIOD_MILLIS);
+        }
+      }
+    }
+
+    return DEFAULT_INSTANCE;
+  }
+
+  @VisibleForTesting
+  PollingFileWatcher(int pollPeriodMillis) {
+    ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor(
+        new ThreadFactoryBuilder().setDaemon(true).setNameFormat("PollingFileWatcher-%d").build());
+    this.watcherTask = new WatcherTask();
+    service.scheduleWithFixedDelay(
+        watcherTask, pollPeriodMillis, pollPeriodMillis, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Adds a watch on the specified file. The file must exist, otherwise a FileNotFoundException
+   * is returned. If the file is deleted after a watch is established, the watcher will log errors
+   * but continue to monitor it, and resume watching if it is recreated.
+   *
+   * @param filePath path to the file to watch.
+   * @param onUpdate function to call when a change is detected to the file. The entire contents
+   *                 of the file will be passed in to the function. Note that onUpdate will be
+   *                 called once before this call completes, which facilities initial load of data.
+   *                 This callback is executed synchronously on the watcher thread - it is
+   *                 important that the function be non-blocking.
+   */
+  @Override
+  public synchronized void addWatch(String filePath, Function<byte[], Void> onUpdate)
+      throws IOException {
+    Preconditions.checkNotNull(filePath);
+    Preconditions.checkArgument(!filePath.isEmpty());
+    Preconditions.checkNotNull(onUpdate);
+
+    // Read the file and make the initial onUpdate call.
+    File file = new File(filePath);
+    byte[] contents = read(file);
+    onUpdate.apply(contents);
+
+    // Add the file to our map if it isn't already there, and register the new change watcher.
+    ConfigFileInfo configFileInfo = watchedFileMap.get(filePath);
+    if (configFileInfo == null) {
+      configFileInfo = new ConfigFileInfo(
+          file.lastModified(), HASH_FUNCTION.newHasher().putBytes(contents).hash());
+      watchedFileMap.put(filePath, configFileInfo);
+    }
+    configFileInfo.changeWatchers.add(onUpdate);
+  }
+
+  @VisibleForTesting
+  public void runWatcherTaskNow() {
+    watcherTask.run();
+  }
+
+  /**
+   * Scheduled task that periodically checks each watched file for updates, and if found to have
+   * been changed, triggers notifications on all its watchers.
+   *
+   * Thread safety note: this task must be run in a single threaded executor; i.e. only one run
+   * of the task can be active at any time.
+   */
+  private class WatcherTask implements Runnable {
+
+    @Override
+    public void run() {
+      for (Map.Entry<String, ConfigFileInfo> entry : watchedFileMap.entrySet()) {
+        String filePath = entry.getKey();
+        ConfigFileInfo configFileInfo = entry.getValue();
+        try {
+          File file = new File(filePath);
+          long lastModified = file.lastModified();
+          Preconditions.checkArgument(lastModified > 0L);
+          if (lastModified != configFileInfo.lastModifiedTimestampMillis) {
+            configFileInfo.lastModifiedTimestampMillis = lastModified;
+            byte[] newContents = read(file);
+            HashCode newContentHash = HASH_FUNCTION.newHasher().putBytes(newContents).hash();
+            if (!newContentHash.equals(configFileInfo.contentHash)) {
+              configFileInfo.contentHash = newContentHash;
+              LOG.info("File {} was modified at {}, notifying watchers.", filePath, lastModified);
+              for (Function<byte[], Void> watchers : configFileInfo.changeWatchers) {
+                try {
+                  watchers.apply(newContents);
+                } catch (Exception e) {
+                  LOG.error(
+                      "Exception in watcher callback for {}, ignoring. New file contents were: {}",
+                      filePath, new String(newContents, Charsets.UTF_8), e);
+                }
+              }
+            } else {
+              LOG.info("File {} was modified at {} but content hash is unchanged.",
+                  filePath, lastModified);
+            }
+          } else {
+            LOG.debug("File {} not modified since {}", filePath, lastModified);
+          }
+        } catch (Exception e) {
+          // We catch and log exceptions related to the update of any specific file, but
+          // move on so others aren't affected. Issues can happen for example if the watcher
+          // races with an external file replace operation; in that case, the next run should
+          // pick up the update.
+          // TODO: Consider adding a metric to track this so we can alert on failures.
+          LOG.error("Config update check failed for {}", filePath, e);
+        }
+      }
+    }
+  }
+
+  private static byte[] read(File file) throws IOException {
+    try (FileInputStream stream = new FileInputStream(file)) {
+      ByteArrayOutputStream out = new ByteArrayOutputStream(Math.max(32, stream.available()));
+      copy(stream, out);
+      return out.toByteArray();
+    }
+  }
+
+  private static void copy(InputStream from, OutputStream to) throws IOException {
+    byte[] buf = new byte[8192];
+    while (true) {
+      int r = from.read(buf);
+      if (r == -1) {
+        break;
+      }
+      to.write(buf, 0, r);
+    }
+  }
+
+  /**
+   * Encapsulates state related to each watched config file.
+   *
+   * Thread safety note:
+   *   1. changeWatchers is thread safe since it uses a copy-on-write array list.
+   *   2. lastModifiedTimestampMillis and contentHash aren't safe to update across threads. We
+   *      initialize in addWatch() at construction time, and thereafter only the watcher task
+   *      thread accesses this state, so we are good.
+   */
+  private static class ConfigFileInfo {
+
+    private final List<Function<byte[], Void>> changeWatchers = new CopyOnWriteArrayList<>();
+    private long lastModifiedTimestampMillis;
+    private HashCode contentHash;
+
+    public ConfigFileInfo(long lastModifiedTimestampMillis, HashCode contentHash) {
+      this.lastModifiedTimestampMillis = lastModifiedTimestampMillis;
+      Preconditions.checkArgument(lastModifiedTimestampMillis > 0L);
+      this.contentHash = Preconditions.checkNotNull(contentHash);
+    }
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/PollingFileWatcher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/PollingFileWatcher.java
@@ -77,7 +77,7 @@ public class PollingFileWatcher implements FileWatcher<byte[]> {
     if (DEFAULT_INSTANCE == null) {
       synchronized (PollingFileWatcher.class) {
         if (DEFAULT_INSTANCE == null) {
-          DEFAULT_INSTANCE = new PollingFileWatcher(DEFAULT_POLL_PERIOD_MILLIS);
+          DEFAULT_INSTANCE = new PollingFileWatcher(DEFAULT_POLL_PERIOD_MILLIS, TimeUnit.MILLISECONDS);
         }
       }
     }
@@ -86,12 +86,12 @@ public class PollingFileWatcher implements FileWatcher<byte[]> {
   }
 
   @VisibleForTesting
-  PollingFileWatcher(int pollPeriodMillis) {
+  PollingFileWatcher(int pollPeriod, TimeUnit timeUnit) {
     ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor(
         new ThreadFactoryBuilder().setDaemon(true).setNameFormat("PollingFileWatcher-%d").build());
     this.watcherTask = new WatcherTask();
     service.scheduleWithFixedDelay(
-        watcherTask, pollPeriodMillis, pollPeriodMillis, TimeUnit.MILLISECONDS);
+        watcherTask, pollPeriod, pollPeriod, timeUnit);
   }
 
   /**

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/codecs/JSONArrayStringSetDecoderTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/codecs/JSONArrayStringSetDecoderTest.java
@@ -1,0 +1,81 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.codecs;
+
+import static org.junit.Assert.assertTrue;
+
+import org.json.simple.JSONArray;
+import org.junit.Test;
+
+import java.util.Set;
+
+public class JSONArrayStringSetDecoderTest {
+
+  @Test
+  public void testSimpleConfig() throws Exception {
+    String config = new StringBuilder()
+        .append("[")
+        .append("\"first\"")
+        .append(",")
+        .append("\"second\"")
+        .append("\"second\"")
+        .append(",")
+        .append("\"third\"")
+        .append(",")
+        .append("\"fourth\"")
+        .append(",")
+        .append("]")
+        .toString();
+
+    JSONArrayStringSetDecoder decoder = new JSONArrayStringSetDecoder();
+
+    Set<String> stringSet = decoder.decode(config.getBytes());
+
+    System.out.println(String.format("str:->%s, strset:->%s", config, stringSet));
+
+    assertTrue(stringSet.contains("first"));
+    assertTrue(stringSet.contains("second"));
+    assertTrue(stringSet.contains("third"));
+    assertTrue(stringSet.contains("fourth"));
+    assertTrue(stringSet.size() == 4);
+  }
+
+  @Test
+  public void testSimpleJSONArrayConfig() throws Exception {
+    JSONArray jsonArray = new JSONArray();
+    jsonArray.add("first");
+    jsonArray.add("second");
+    jsonArray.add("third");
+    jsonArray.add("fourth");
+    jsonArray.add("fourth");
+
+    JSONArrayStringSetDecoder decoder = new JSONArrayStringSetDecoder();
+
+    Set<String> stringSet = decoder.decode(jsonArray.toJSONString().getBytes());
+
+    System.out.println(String.format("str:->%s, strset:->%s", jsonArray.toJSONString(), stringSet));
+
+    assertTrue(stringSet.contains("first"));
+    assertTrue(stringSet.contains("second"));
+    assertTrue(stringSet.contains("third"));
+    assertTrue(stringSet.contains("fourth"));
+    assertTrue(stringSet.size() == 4);
+
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/codecs/LineTerminatedStringSetDecoderTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/codecs/LineTerminatedStringSetDecoderTest.java
@@ -1,0 +1,56 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.codecs;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.Set;
+
+public class LineTerminatedStringSetDecoderTest {
+
+  @Test
+  public void testSimpleConfig() throws Exception {
+    String config = new StringBuilder()
+        .append("#This is comment\n")
+        .append("first_line\n")
+        .append("\n") // Empty line
+        .append("   \n") // Empty line with white space characters
+        .append("second line as a whole\n")
+        .append("   third_line\n") // third line with leading white space characters
+        .append("fourth_line   \n") // fourth line with trailing white space characters
+        .toString();
+
+    LineTerminatedStringSetDecoder decoder = new LineTerminatedStringSetDecoder();
+
+    Set<String> stringSet = decoder.decode(config.getBytes());
+
+    System.out.println(stringSet);
+
+    assertTrue(stringSet.contains("first_line"));
+    assertTrue(stringSet.contains("second line as a whole"));
+    assertTrue(stringSet.contains("third_line"));
+    assertTrue(stringSet.contains("fourth_line"));
+    assertFalse(stringSet.contains(""));
+    assertFalse(stringSet.contains("#This is comment"));
+    assertTrue(stringSet.size() == 4);
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/config/ConfigStoreTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/config/ConfigStoreTest.java
@@ -1,0 +1,86 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.pinterest.rocksplicator.codecs.LineTerminatedStringSetDecoder;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Set;
+
+public class ConfigStoreTest extends ConfigTestBase {
+
+  @Test
+  public void testConfigStore() throws Exception {
+    File file = createTempFile();
+
+    String initialContent = new StringBuilder()
+        .append("first\n")
+        .append("second\n")
+        .toString();
+
+    String updatedContent = new StringBuilder()
+        .append("first\n")
+        .append("third\n")
+        .toString();
+
+    String finalContent = new StringBuilder()
+        .append("fourth\n")
+        .append("fifth\n")
+        .toString();
+
+    PollingFileWatcher watcher = createPollingFileWatcher();
+
+    // Initial content
+    writeContentToFile(file, initialContent);
+
+    ConfigStore<Set<String>>
+        configStore =
+        new ConfigStore<>(new LineTerminatedStringSetDecoder(), file.getAbsolutePath(), watcher);
+
+    Set<String> initialSet = configStore.get();
+
+    assertEquals(2, initialSet.size());
+    assertTrue(initialSet.contains("first"));
+    assertTrue(initialSet.contains("second"));
+
+    // Update the content
+    writeContentToFile(file, updatedContent);
+    watcher.runWatcherTaskNow();
+
+    Set<String> updatedSet = configStore.get();
+    assertEquals(2, updatedSet.size());
+    assertTrue(updatedSet.contains("first"));
+    assertTrue(updatedSet.contains("third"));
+
+    // Update the content
+    writeContentToFile(file, finalContent);
+    watcher.runWatcherTaskNow();
+
+    Set<String> finalSet = configStore.get();
+    assertEquals(2, finalSet.size());
+    assertTrue(finalSet.contains("fourth"));
+    assertTrue(finalSet.contains("fifth"));
+
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/config/ConfigTestBase.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/config/ConfigTestBase.java
@@ -25,6 +25,7 @@ import org.junit.After;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Base class for tests that deal directly or indirectly with the ConfigFileWatcher.
@@ -37,7 +38,7 @@ public class ConfigTestBase {
   public static PollingFileWatcher createPollingFileWatcher() {
     // Note: we run the watcher task directly rather than rely on polling, to avoid test timing
     // issues. Hence we can just set a high poll period.
-    return new PollingFileWatcher(1000000 /*pollPeriodSeconds*/);
+    return new PollingFileWatcher(1000, TimeUnit.SECONDS /*pollPeriodSeconds*/);
   }
 
   public static void writeContentToFile(File file, String content) throws IOException {

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/config/ConfigTestBase.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/config/ConfigTestBase.java
@@ -1,0 +1,70 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+package com.pinterest.rocksplicator.config;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Base class for tests that deal directly or indirectly with the ConfigFileWatcher.
+ * Provides utility methods as well as ability to automatically cleanup temporary files created.
+ */
+public class ConfigTestBase {
+
+  private final List<File> filesToCleanup = Lists.newArrayList();
+
+  public static PollingFileWatcher createPollingFileWatcher() {
+    // Note: we run the watcher task directly rather than rely on polling, to avoid test timing
+    // issues. Hence we can just set a high poll period.
+    return new PollingFileWatcher(1000000 /*pollPeriodSeconds*/);
+  }
+
+  public static void writeContentToFile(File file, String content) throws IOException {
+    long lastModified = file.lastModified();
+    FileUtils.writeStringToFile(file, content, Charsets.UTF_8.name());
+    // The resolution of lastModified is 1sec, so we need to explicitly update.
+    file.setLastModified(lastModified + 1000);
+  }
+
+  public static void writeRawContentToFile(File file, byte[] content) throws IOException {
+    long lastModified = file.lastModified();
+    FileUtils.writeByteArrayToFile(file, content);
+    // The resolution of lastModified is 1sec, so we need to explicitly update.
+    file.setLastModified(lastModified + 1000);
+  }
+
+  @After
+  public void afterTest() {
+    for (File file : filesToCleanup) {
+      file.delete();
+    }
+    filesToCleanup.clear();
+  }
+
+  protected File createTempFile() throws IOException {
+    File tmpFile = File.createTempFile("PollingFileWatcherTest", "txt");
+    filesToCleanup.add(tmpFile);
+    return tmpFile;
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/config/PollingFileWatcherTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/config/PollingFileWatcherTest.java
@@ -1,0 +1,266 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+package com.pinterest.rocksplicator.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+public class PollingFileWatcherTest extends ConfigTestBase {
+
+  @Test
+  public void testBasicFunctionality() throws Exception {
+    PollingFileWatcher configFileWatcher = createPollingFileWatcher();
+    File testConfigFile = createTempFile();
+    final AtomicInteger watchFiredCount = new AtomicInteger(0);
+    final AtomicReference<String> contentRetrieved = new AtomicReference<String>();
+
+    // Initial update.
+    writeContentToFile(testConfigFile, "test1");
+
+    // Setup watch and ensure it fires immediately.
+    configFileWatcher.addWatch(testConfigFile.getPath(), new Function<byte[], Void>() {
+      @Override
+      public Void apply(byte[] bytes) {
+        watchFiredCount.incrementAndGet();
+        contentRetrieved.set(new String(bytes, Charsets.UTF_8));
+        return null;
+      }
+    });
+    assertEquals(1, watchFiredCount.get());
+    assertEquals("test1", contentRetrieved.get());
+
+    // Update the contents and run the watcher task. Watch should fire.
+    writeContentToFile(testConfigFile, "test2");
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(2, watchFiredCount.get());
+    assertEquals("test2", contentRetrieved.get());
+
+    // Update the contents but keep unchanged and run the watcher task.
+    // Watch should not fire.
+    writeContentToFile(testConfigFile, "test2");
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(2, watchFiredCount.get());
+
+    // Update the contents and change the modified time to a time in the past.
+    // The watch should still fire. This is to support the restore from backup case.
+    writeContentToFile(testConfigFile, "test3");
+    testConfigFile.setLastModified(testConfigFile.lastModified() - 10000);
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(3, watchFiredCount.get());
+    assertEquals("test3", contentRetrieved.get());
+
+    // Update the contents but keep the modified time unchanged. Watch won't fire.
+    // This tests the use of modified time as an optimization.
+    long lastModifiedMillis = testConfigFile.lastModified();
+    writeContentToFile(testConfigFile, "test4");
+    testConfigFile.setLastModified(lastModifiedMillis);
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(3, watchFiredCount.get());
+    assertEquals("test3", contentRetrieved.get());
+  }
+
+  @Test
+  public void testMultipleFiles() throws IOException {
+    final AtomicInteger watchesFired = new AtomicInteger(0);
+    PollingFileWatcher configFileWatcher = createPollingFileWatcher();
+    List<File> files = Lists.newArrayList();
+    final List<AtomicReference<String>> fileContents = Lists.newArrayList();
+    // Create files and set up watches. Validate initial callback.
+    for (int i = 0; i < 10; i++) {
+      File file = createTempFile();
+      files.add(file);
+      fileContents.add(new AtomicReference<String>());
+      writeContentToFile(file, "initial" + i);
+      final int index = i;
+      configFileWatcher.addWatch(file.getPath(), new Function<byte[], Void>() {
+        @Override
+        public Void apply(byte[] bytes) {
+          watchesFired.incrementAndGet();
+          fileContents.get(index).set(new String(bytes, Charsets.UTF_8));
+          return null;
+        }
+      });
+      assertEquals(i + 1, watchesFired.get());
+      assertEquals("initial" + i, fileContents.get(i).get());
+    }
+
+    // Update contents of all files and verify callbacks.
+    for (int i = 0; i < 10; i++) {
+      writeContentToFile(files.get(i), "update" + i);
+    }
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(20, watchesFired.get());
+    for (AtomicReference<String> sRef : fileContents) {
+      assertTrue(sRef.get().startsWith("update"));
+    }
+
+    // Update contents of all files again, but now even ones have same content.
+    for (int i = 0; i < 10; i++) {
+      String contentPrefix = (i % 2) == 0 ? "update" : "newUpdate";
+      writeContentToFile(files.get(i), contentPrefix + i);
+    }
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(25, watchesFired.get());
+    for (int i = 0; i < 10; i++) {
+      String contentPrefix = (i % 2) == 0 ? "update" : "newUpdate";
+      assertTrue(fileContents.get(i).get().startsWith(contentPrefix));
+    }
+
+    // Only update files at index 2 and 5.
+    writeContentToFile(files.get(2), "yetAnotherUpdate");
+    writeContentToFile(files.get(5), "yetAnotherUpdate");
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(27, watchesFired.get());
+    for (int i = 0; i < 10; i++) {
+      if (i == 2 || i == 5) {
+        assertEquals("yetAnotherUpdate", fileContents.get(i).get());
+      } else {
+        assertNotEquals("yetAnotherUpdate", fileContents.get(i).get());
+      }
+    }
+
+    // Now delete file at index 0, and update the one at index 3. the index 3 update
+    // should still fire.
+    files.get(0).delete();
+    writeContentToFile(files.get(3), "yetAnotherUpdate");
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(28, watchesFired.get());
+    assertEquals("yetAnotherUpdate", fileContents.get(2).get());
+
+    // Now recreate the file at index 0, watch should fire.
+    writeContentToFile(files.get(0), "recreated");
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(29, watchesFired.get());
+    assertEquals("recreated", fileContents.get(0).get());
+
+  }
+
+  @Test
+  public void testMultipleWatchersOnSingleFile() throws IOException {
+    final AtomicInteger watchesFired = new AtomicInteger(0);
+    final List<AtomicReference<String>> fileContents = Lists.newArrayList();
+    PollingFileWatcher configFileWatcher = createPollingFileWatcher();
+    File testConfigFile = createTempFile();
+    writeContentToFile(testConfigFile, "initial");
+    for (int i = 0; i < 10; i++) {
+      fileContents.add(new AtomicReference<String>());
+      final int index = i;
+      configFileWatcher.addWatch(testConfigFile.getPath(), new Function<byte[], Void>() {
+        @Override
+        public Void apply(byte[] bytes) {
+          watchesFired.incrementAndGet();
+          fileContents.get(index).set(new String(bytes, Charsets.UTF_8));
+          return null;
+        }
+      });
+    }
+    assertEquals(10, watchesFired.get());
+    for (AtomicReference<String> sRef : fileContents) {
+      assertEquals("initial", sRef.get());
+    }
+
+    // Now update the contents and run the watcher task. All watches should fire.
+    writeContentToFile(testConfigFile, "update");
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(20, watchesFired.get());
+    for (AtomicReference<String> sRef : fileContents) {
+      assertEquals("update", sRef.get());
+    }
+
+    // Now update the contents but keep unchanged. No watches should fire.
+    writeContentToFile(testConfigFile, "update");
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(20, watchesFired.get());
+  }
+
+  @Test
+  public void testExceptionInWatcherCallback() throws IOException {
+    final AtomicInteger watchesFired = new AtomicInteger(0);
+    PollingFileWatcher configFileWatcher = createPollingFileWatcher();
+    File testConfigFile = createTempFile();
+    writeContentToFile(testConfigFile, "initial");
+
+    // Add a watcher that throws an exception in its callback. It should not prevent other
+    // watchers from getting notified.
+    configFileWatcher.addWatch(testConfigFile.getPath(), new Function<byte[], Void>() {
+      @Override
+      public Void apply(byte[] bytes) {
+        if (new String(bytes, Charset.defaultCharset()).equals("update")) {
+          throw new RuntimeException();
+        }
+        return null;
+      }
+    });
+
+    configFileWatcher.addWatch(testConfigFile.getPath(), new Function<byte[], Void>() {
+      @Override
+      public Void apply(byte[] bytes) {
+        watchesFired.incrementAndGet();
+        return null;
+      }
+    });
+
+    assertEquals(1, watchesFired.get());
+
+    writeContentToFile(testConfigFile, "update");
+    configFileWatcher.runWatcherTaskNow();
+    assertEquals(2, watchesFired.get());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testEmptyFilePath() throws IOException {
+    PollingFileWatcher configFileWatcher = createPollingFileWatcher();
+    configFileWatcher.addWatch("", new Function<byte[], Void>() {
+      @Override
+      public Void apply(byte[] bytes) {
+        return null;
+      }
+    });
+  }
+
+  @Test(expected = FileNotFoundException.class)
+  public void testNonExistentFile() throws IOException {
+    PollingFileWatcher configFileWatcher = createPollingFileWatcher();
+    configFileWatcher.addWatch("/foo/bar", new Function<byte[], Void>() {
+      @Override
+      public Void apply(byte[] bytes) {
+        return null;
+      }
+    });
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullCallback() throws IOException {
+    PollingFileWatcher configFileWatcher = createPollingFileWatcher();
+    configFileWatcher.addWatch("/tmp/foo", null);
+  }
+}


### PR DESCRIPTION
We need a mechanism to dynamically specify which resources to log leader events for. In order to do that, we implement a very simple polling on a config file which can be provided as either json array or line separated string values specifying resources to watch.