### PR TITLE
Fix running junit4 and disable testng to run junit tests

### DIFF
--- a/cluster_management/pom.xml
+++ b/cluster_management/pom.xml
@@ -49,6 +49,32 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <configuration>
+          <properties>
+            <property>
+              <name>junit</name>
+              <value>false</value>
+            </property>
+          </properties>
+          <threadCount>1</threadCount>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>3.0.0-M5</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-testng</artifactId>
+            <version>3.0.0-M5</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>
@@ -138,7 +164,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.0.1</version>
+      <version>6.9.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
After upgraing Junit to 4.x, we saw the junit tests were not running and only testng tests ran. In order to make sure both junit and testng tests run through their respective providers... this change is necessary.