### PR TITLE
Fix timeout for awaiting termination of threads

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/eventstore/LeaderEventHistoryStore.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/eventstore/LeaderEventHistoryStore.java
@@ -462,7 +462,7 @@ public class LeaderEventHistoryStore implements Closeable {
     for (ExecutorService service : executorServices) {
       while (!service.isTerminated()) {
         try {
-          service.awaitTermination(1000, TimeUnit.SECONDS);
+          service.awaitTermination(100, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
           LOGGER.error("Interrupted: ", e);
         }


### PR DESCRIPTION
In previous PR, I set an abnormally high (1000 seconds) as thread awaiting termination timeout by mistake. This was supposed to be 1 second. However even this may seem higher and may result in more wait around time. Fixing this to reduce it to 100 milliseconds which is reasonable.