### PR TITLE
json shardmap conversion utililies to be used for posting client leader events.

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/JSONArrayStringSetDecoder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/JSONArrayStringSetDecoder.java
@@ -19,29 +19,19 @@
 package com.pinterest.rocksplicator.codecs;
 
 import com.google.common.collect.ImmutableSet;
-import org.json.simple.JSONArray;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Set;
 
 /**
- * Decodes byte[] content as a JSONArray
+ * Decodes byte[] content as a Set of Strings, where content is in JSONArray format.
  * ["first", "second", "third"]
  */
 public class JSONArrayStringSetDecoder implements Decoder<byte[], Set<String>> {
 
+  private final SimpleJsonArrayDecoder decoder = new SimpleJsonArrayDecoder();
+
   @Override
   public Set<String> decode(byte[] data) throws CodecException {
-    JSONParser parser = new JSONParser();
-    try {
-      JSONArray array = (JSONArray) parser.parse(new String(data, "UTF-8"));
-      return ImmutableSet.copyOf(array);
-    } catch (ParseException e) {
-      throw new CodecException(e);
-    } catch (UnsupportedEncodingException e) {
-      throw new CodecException(e);
-    }
+    return ImmutableSet.copyOf(decoder.decode(data));
   }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/SimpleJsonArrayDecoder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/SimpleJsonArrayDecoder.java
@@ -1,0 +1,22 @@
+package com.pinterest.rocksplicator.codecs;
+
+import org.json.simple.JSONArray;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.UnsupportedEncodingException;
+
+public class SimpleJsonArrayDecoder implements Decoder<byte[], JSONArray> {
+
+  @Override
+  public JSONArray decode(byte[] data) throws CodecException {
+    JSONParser parser = new JSONParser();
+    try {
+      return (JSONArray) parser.parse(new String(data, "UTF-8"));
+    } catch (ParseException e) {
+      throw new CodecException(e);
+    } catch (UnsupportedEncodingException e) {
+      throw new CodecException(e);
+    }
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/SimpleJsonObjectDecoder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/codecs/SimpleJsonObjectDecoder.java
@@ -1,0 +1,22 @@
+package com.pinterest.rocksplicator.codecs;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.UnsupportedEncodingException;
+
+public class SimpleJsonObjectDecoder implements Decoder<byte[], JSONObject> {
+
+  @Override
+  public JSONObject decode(byte[] data) throws CodecException {
+    JSONParser parser = new JSONParser();
+    try {
+      return (JSONObject) parser.parse(new String(data, "UTF-8"));
+    } catch (ParseException e) {
+      throw new CodecException(e);
+    } catch (UnsupportedEncodingException e) {
+      throw new CodecException(e);
+    }
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Instance.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Instance.java
@@ -3,6 +3,7 @@ package com.pinterest.rocksplicator.shardmap;
 import java.util.Objects;
 
 public class Instance {
+
   private final String host;
   private final int port;
   private final String domain;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Instance.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Instance.java
@@ -1,0 +1,54 @@
+package com.pinterest.rocksplicator.shardmap;
+
+import java.util.Objects;
+
+public class Instance {
+  private final String host;
+  private final int port;
+  private final String domain;
+  private final String instanceId;
+
+  public Instance(String hostWithDomainName) {
+    String[] parts = hostWithDomainName.split(":");
+    this.host = parts[0];
+    this.port = Integer.parseInt(parts[1]);
+    this.domain = parts[2];
+    this.instanceId = String.format("%s_%d", this.host, this.port);
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public String getDomain() {
+    return domain;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Instance instance = (Instance) o;
+    return port == instance.port &&
+        host.equals(instance.host) &&
+        domain.equals(instance.domain) &&
+        instanceId.equals(instance.instanceId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(host, port, domain, instanceId);
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Instance.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Instance.java
@@ -51,4 +51,14 @@ public class Instance {
   public int hashCode() {
     return Objects.hash(host, port, domain, instanceId);
   }
+
+  @Override
+  public String toString() {
+    return "Instance{" +
+        "host='" + host + '\'' +
+        ", port=" + port +
+        ", domain='" + domain + '\'' +
+        ", instanceId='" + instanceId + '\'' +
+        '}';
+  }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/JsonShardMap.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/JsonShardMap.java
@@ -1,0 +1,158 @@
+package com.pinterest.rocksplicator.shardmap;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class JsonShardMap implements ShardMap {
+
+  private final Map<String, ResourceMap> resourceMap;
+
+  JsonShardMap(JSONObject shardMapObj) {
+    resourceMap = new HashMap<>(shardMapObj.size());
+
+    for (Object resourceNameObj : shardMapObj.keySet()) {
+      String resourceName = (String) resourceNameObj;
+      JSONObject resourceObj = (JSONObject) shardMapObj.get(resourceNameObj);
+      if (resourceObj != null) {
+        resourceMap.put(resourceName, new JsonResourceMapImpl(resourceName, resourceObj));
+      }
+    }
+  }
+
+  @Override
+  public Set<String> getResources() {
+    return resourceMap.keySet();
+  }
+
+  @Override
+  public ResourceMap getResourceMap(String resource) {
+    return resourceMap.get(resource);
+  }
+
+
+  private class JsonResourceMapImpl implements ResourceMap {
+
+    private final String resourceName;
+    private final int numShards;
+
+    private Map<Partition, List<Replica>> replicasByPartition;
+    private Map<Instance, List<Replica>> replicasByInstance;
+    private Set<Partition> allPartitions;
+
+    JsonResourceMapImpl(String resourceName, JSONObject resourceMapObj) {
+      this.resourceName = resourceName;
+      this.replicasByPartition = new HashMap<>();
+      this.replicasByInstance = new HashMap();
+
+      Object numShardsObj = resourceMapObj.get("num_shards");
+      if (numShardsObj.getClass().equals(Integer.class)) {
+        this.numShards = (Integer) numShardsObj;
+      } else if (numShardsObj.getClass().equals(Long.class)) {
+        this.numShards = ((Long) numShardsObj).intValue();
+      } else {
+        throw new RuntimeException("Illegal format for num_shards for resource:" + resourceName + ", json string is " + resourceMapObj.toJSONString());
+      }
+
+
+
+      ImmutableSet.Builder<Partition> setBuilder = ImmutableSet.builder();
+      for (int partitionId = 0; partitionId < numShards; ++partitionId) {
+        setBuilder.add(new Partition(resourceName, partitionId));
+      }
+      this.allPartitions = setBuilder.build();
+
+      // Now for all instance info, construct Replicas information.
+      for (Object key : resourceMapObj.keySet()) {
+        if ("num_shards".equalsIgnoreCase((String) key)) {
+          continue;
+        }
+        String encodedInstanceStr = (String) key;
+        Instance instance = new Instance(encodedInstanceStr);
+
+        JSONArray partitionsOnInstance = (JSONArray) resourceMapObj.get(key);
+        for (Object encodedPartitionObj : partitionsOnInstance) {
+          String encodedPartitionStr = (String) encodedPartitionObj;
+          String parts[] = encodedPartitionStr.split(":");
+          Partition partition = new Partition(parts[0]);
+          ReplicaState replicaState = ReplicaState.ONLINE;
+          if (parts.length == 2) {
+            String state = parts[1];
+            if (":M".equalsIgnoreCase(state)) {
+              replicaState = ReplicaState.LEADER;
+            } else {
+              replicaState = ReplicaState.FOLLOWER;
+            }
+          }
+
+          Replica replica = new Replica(partition, instance, replicaState);
+          if (!replicasByPartition.containsKey(partition)) {
+            replicasByPartition.put(partition, new ArrayList<>());
+          }
+          replicasByPartition.get(partition).add(replica);
+
+          if (!replicasByInstance.containsKey(instance)) {
+            replicasByInstance.put(instance, new LinkedList<>());
+          }
+          replicasByInstance.get(instance).add(replica);
+        }
+      }
+    }
+
+    @Override
+    public String getResource() {
+      return resourceName;
+    }
+
+    @Override
+    public int getNumShards() {
+      return numShards;
+    }
+
+    @Override
+    public Set<Instance> getInstances() {
+      return replicasByInstance.keySet();
+    }
+
+    @Override
+    public Set<Partition> getAllKnownPartitions() {
+      return replicasByPartition.keySet();
+    }
+
+    @Override
+    public Set<Partition> getAllMissingPartitions() {
+      return Sets.difference(allPartitions, replicasByPartition.keySet());
+    }
+
+    @Override
+    public Set<Partition> getAllPartitions() {
+      return allPartitions;
+    }
+
+    @Override
+    public List<Replica> getAllReplicasForPartition(Partition partition) {
+      if (replicasByPartition.containsKey(partition)) {
+        return replicasByPartition.get(partition);
+      } else {
+        return ImmutableList.of();
+      }
+    }
+
+    @Override
+    public List<Replica> getAllReplicasOnInstance(Instance instance) {
+      if (replicasByInstance.containsKey(instance)) {
+        return replicasByInstance.get(instance);
+      }
+      return ImmutableList.of();
+    }
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/JsonShardMap.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/JsonShardMap.java
@@ -60,10 +60,10 @@ class JsonShardMap implements ShardMap {
       } else if (numShardsObj.getClass().equals(Long.class)) {
         this.numShards = ((Long) numShardsObj).intValue();
       } else {
-        throw new RuntimeException("Illegal format for num_shards for resource:" + resourceName + ", json string is " + resourceMapObj.toJSONString());
+        throw new RuntimeException(
+            "Illegal format for num_shards for resource:" + resourceName + ", json string is "
+                + resourceMapObj.toJSONString());
       }
-
-
 
       ImmutableSet.Builder<Partition> setBuilder = ImmutableSet.builder();
       for (int partitionId = 0; partitionId < numShards; ++partitionId) {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/JsonShardMap.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/JsonShardMap.java
@@ -83,13 +83,13 @@ class JsonShardMap implements ShardMap {
         for (Object encodedPartitionObj : partitionsOnInstance) {
           String encodedPartitionStr = (String) encodedPartitionObj;
           String parts[] = encodedPartitionStr.split(":");
-          Partition partition = new Partition(parts[0]);
+          Partition partition = new Partition(resourceName, parts[0]);
           ReplicaState replicaState = ReplicaState.ONLINE;
           if (parts.length == 2) {
             String state = parts[1];
             if (":M".equalsIgnoreCase(state)) {
               replicaState = ReplicaState.LEADER;
-            } else {
+            } else if (":S".equalsIgnoreCase(state)) {
               replicaState = ReplicaState.FOLLOWER;
             }
           }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/JsonShardMap.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/JsonShardMap.java
@@ -87,9 +87,9 @@ class JsonShardMap implements ShardMap {
           ReplicaState replicaState = ReplicaState.ONLINE;
           if (parts.length == 2) {
             String state = parts[1];
-            if (":M".equalsIgnoreCase(state)) {
+            if ("M".equalsIgnoreCase(state)) {
               replicaState = ReplicaState.LEADER;
-            } else if (":S".equalsIgnoreCase(state)) {
+            } else if ("S".equalsIgnoreCase(state)) {
               replicaState = ReplicaState.FOLLOWER;
             }
           }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Partition.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Partition.java
@@ -3,6 +3,7 @@ package com.pinterest.rocksplicator.shardmap;
 import java.util.Objects;
 
 public class Partition {
+
   private final String partitionName;
 
   public Partition(String resourceName, int partitionId) {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Partition.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Partition.java
@@ -1,0 +1,36 @@
+package com.pinterest.rocksplicator.shardmap;
+
+import java.util.Objects;
+
+public class Partition {
+  private final String partitionName;
+
+  public Partition(String resourceName, int partitionId) {
+    this(String.format("%s_%05d", resourceName, partitionId));
+  }
+
+  public Partition(String partitionName) {
+    this.partitionName = partitionName;
+  }
+
+  public String getPartitionName() {
+    return this.partitionName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Partition partition = (Partition) o;
+    return partitionName.equals(partition.partitionName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(partitionName);
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Partition.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Partition.java
@@ -6,7 +6,11 @@ public class Partition {
   private final String partitionName;
 
   public Partition(String resourceName, int partitionId) {
-    this(String.format("%s_%05d", resourceName, partitionId));
+    this(String.format("%s_%d", resourceName, partitionId));
+  }
+
+  public Partition(String resourceName, String partitionStr) {
+    this(String.format("%s_%d", resourceName, Integer.parseInt(partitionStr)));
   }
 
   public Partition(String partitionName) {
@@ -32,5 +36,12 @@ public class Partition {
   @Override
   public int hashCode() {
     return Objects.hash(partitionName);
+  }
+
+  @Override
+  public String toString() {
+    return "Partition{" +
+        "partitionName='" + partitionName + '\'' +
+        '}';
   }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Replica.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Replica.java
@@ -1,0 +1,25 @@
+package com.pinterest.rocksplicator.shardmap;
+
+public class Replica {
+  private final Instance instance;
+  private final Partition partition;
+  private final ReplicaState replicaState;
+
+  public Replica(Partition partition, Instance instance, ReplicaState replicaState) {
+    this.partition = partition;
+    this.instance = instance;
+    this.replicaState = replicaState;
+  }
+
+  public ReplicaState getReplicaState() {
+    return replicaState;
+  }
+
+  public Instance getInstance() {
+    return instance;
+  }
+
+  public Partition getPartition() {
+    return partition;
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Replica.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Replica.java
@@ -1,5 +1,7 @@
 package com.pinterest.rocksplicator.shardmap;
 
+import java.util.Objects;
+
 public class Replica {
   private final Instance instance;
   private final Partition partition;
@@ -21,5 +23,33 @@ public class Replica {
 
   public Partition getPartition() {
     return partition;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Replica replica = (Replica) o;
+    return instance.equals(replica.instance) &&
+        partition.equals(replica.partition) &&
+        replicaState == replica.replicaState;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(instance, partition, replicaState);
+  }
+
+  @Override
+  public String toString() {
+    return "Replica{" +
+        "instance=" + instance +
+        ", partition=" + partition +
+        ", replicaState=" + replicaState +
+        '}';
   }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Replica.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/Replica.java
@@ -3,6 +3,7 @@ package com.pinterest.rocksplicator.shardmap;
 import java.util.Objects;
 
 public class Replica {
+
   private final Instance instance;
   private final Partition partition;
   private final ReplicaState replicaState;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ReplicaState.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ReplicaState.java
@@ -3,6 +3,5 @@ package com.pinterest.rocksplicator.shardmap;
 public enum ReplicaState {
   LEADER,
   FOLLOWER,
-  ONLINE,
-  OFFLINE
+  ONLINE
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ReplicaState.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ReplicaState.java
@@ -1,0 +1,8 @@
+package com.pinterest.rocksplicator.shardmap;
+
+public enum ReplicaState {
+  LEADER,
+  FOLLOWER,
+  ONLINE,
+  OFFLINE
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ResourceMap.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ResourceMap.java
@@ -2,7 +2,6 @@ package com.pinterest.rocksplicator.shardmap;
 
 import java.util.List;
 import java.util.Set;
-import javax.swing.Painter;
 
 public interface ResourceMap {
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ResourceMap.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ResourceMap.java
@@ -1,0 +1,24 @@
+package com.pinterest.rocksplicator.shardmap;
+
+import java.util.List;
+import java.util.Set;
+import javax.swing.Painter;
+
+public interface ResourceMap {
+
+  String getResource();
+
+  int getNumShards();
+
+  Set<Instance> getInstances();
+
+  Set<Partition> getAllKnownPartitions();
+
+  Set<Partition> getAllMissingPartitions();
+
+  Set<Partition> getAllPartitions();
+
+  List<Replica> getAllReplicasForPartition(Partition partition);
+
+  List<Replica> getAllReplicasOnInstance(Instance instance);
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ShardMap.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ShardMap.java
@@ -1,0 +1,8 @@
+package com.pinterest.rocksplicator.shardmap;
+
+import java.util.Set;
+
+public interface ShardMap {
+  Set<String> getResources();
+  ResourceMap getResourceMap(String resource);
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ShardMap.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ShardMap.java
@@ -3,6 +3,8 @@ package com.pinterest.rocksplicator.shardmap;
 import java.util.Set;
 
 public interface ShardMap {
+
   Set<String> getResources();
+
   ResourceMap getResourceMap(String resource);
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ShardMaps.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ShardMaps.java
@@ -3,6 +3,7 @@ package com.pinterest.rocksplicator.shardmap;
 import org.json.simple.JSONObject;
 
 public class ShardMaps {
+
   public static ShardMap fromJson(JSONObject shardMapJsonObject) {
     return new JsonShardMap(shardMapJsonObject);
   }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ShardMaps.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmap/ShardMaps.java
@@ -1,0 +1,9 @@
+package com.pinterest.rocksplicator.shardmap;
+
+import org.json.simple.JSONObject;
+
+public class ShardMaps {
+  public static ShardMap fromJson(JSONObject shardMapJsonObject) {
+    return new JsonShardMap(shardMapJsonObject);
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/codecs/SimpleJsonArrayDecoderTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/codecs/SimpleJsonArrayDecoderTest.java
@@ -1,0 +1,65 @@
+package com.pinterest.rocksplicator.codecs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.json.simple.JSONArray;
+import org.junit.Test;
+
+public class SimpleJsonArrayDecoderTest {
+
+  @Test
+  public void testSimpleConfig() throws Exception {
+    String config = new StringBuilder()
+        .append("[")
+        .append("\"first\"")
+        .append(",")
+        .append("\"second\"")
+        .append("\"second\"")
+        .append(",")
+        .append("\"third\"")
+        .append(",")
+        .append("\"fourth\"")
+        .append(",")
+        .append("]")
+        .toString();
+
+    SimpleJsonArrayDecoder decoder = new SimpleJsonArrayDecoder();
+
+    JSONArray array = decoder.decode(config.getBytes());
+
+    System.out.println(String.format("json string:->%s, json array object:->%s", config, array));
+
+    assertEquals("first", array.get(0));
+    assertEquals("second", array.get(1));
+    assertEquals("second", array.get(2));
+    assertEquals("third", array.get(3));
+    assertEquals("fourth", array.get(4));
+    assertTrue(array.size() == 5);
+  }
+
+  @Test
+  public void testSimpleJSONArrayConfig() throws Exception {
+    JSONArray srcArray = new JSONArray();
+    srcArray.add("first");
+    srcArray.add("second");
+    srcArray.add("third");
+    srcArray.add("fourth");
+    srcArray.add("fourth");
+
+    SimpleJsonArrayDecoder decoder = new SimpleJsonArrayDecoder();
+
+    JSONArray decodecArray = decoder.decode(srcArray.toJSONString().getBytes());
+
+    System.out.println(String
+        .format("json array obj (src):->%s, json array obj (dest):->%s", srcArray.toJSONString(),
+            decodecArray));
+
+    assertEquals("first", decodecArray.get(0));
+    assertEquals("second", decodecArray.get(1));
+    assertEquals("third", decodecArray.get(2));
+    assertEquals("fourth", decodecArray.get(3));
+    assertEquals("fourth", decodecArray.get(4));
+    assertTrue(decodecArray.size() == 5);
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/codecs/SimpleJsonObjectDecoderTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/codecs/SimpleJsonObjectDecoderTest.java
@@ -1,0 +1,125 @@
+package com.pinterest.rocksplicator.codecs;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.math.IntMath;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SimpleJsonObjectDecoderTest {
+
+  @Test
+  public void testJsonDecoding() throws Exception {
+    JSONObject shardMap = new JSONObject();
+    List<String> resources = ImmutableList.<String>builder()
+        .add("resource0")
+        .add("resource1")
+        .add("resource2")
+        .add("resource3")
+        .build();
+
+    List<String> instances = ImmutableList
+        .<String>builder()
+        .add("host0:port:az:pg")
+        .add("host1:port:az:pg")
+        .add("host2:port:az:pg")
+        .add("host3:port:az:pg")
+        .build();
+
+    int num_shards = 0;
+    for (String resource : resources) {
+      JSONObject resourceMap = new JSONObject();
+      ++num_shards;
+      resourceMap.put("num_shards", num_shards);
+
+      Map<String, JSONArray> instanceToPartitionsMap = new HashMap<>();
+
+      for (int partitionId = 0; partitionId < num_shards; ++partitionId) {
+        int instanceId = IntMath.mod(partitionId, instances.size());
+        String instance = instances.get(instanceId);
+        JSONArray partitionsArray = null;
+        if (!instanceToPartitionsMap.containsKey(instance)) {
+          instanceToPartitionsMap.put(instance, new JSONArray());
+        }
+        partitionsArray = instanceToPartitionsMap.get(instance);
+
+        String partitionStr = String.format("%05d", partitionId);
+        partitionsArray.add(partitionStr);
+      }
+      resourceMap.putAll(instanceToPartitionsMap);
+
+      shardMap.put(resource, resourceMap);
+    }
+
+    String prettyPrintedJsonStr = "{\n"
+        + "  \"resource2\": {\n"
+        + "    \"num_shards\": 3,\n"
+        + "    \"host0:port:az:pg\": [\n"
+        + "      \"00000\"\n"
+        + "    ],\n"
+        + "    \"host1:port:az:pg\": [\n"
+        + "      \"00001\"\n"
+        + "    ],\n"
+        + "    \"host2:port:az:pg\": [\n"
+        + "      \"00002\"\n"
+        + "    ]\n"
+        + "  },\n"
+        + "  \"resource3\": {\n"
+        + "    \"num_shards\": 4,\n"
+        + "    \"host0:port:az:pg\": [\n"
+        + "      \"00000\"\n"
+        + "    ],\n"
+        + "    \"host1:port:az:pg\": [\n"
+        + "      \"00001\"\n"
+        + "    ],\n"
+        + "    \"host3:port:az:pg\": [\n"
+        + "      \"00003\"\n"
+        + "    ],\n"
+        + "    \"host2:port:az:pg\": [\n"
+        + "      \"00002\"\n"
+        + "    ]\n"
+        + "  },\n"
+        + "  \"resource0\": {\n"
+        + "    \"num_shards\": 1,\n"
+        + "    \"host0:port:az:pg\": [\n"
+        + "      \"00000\"\n"
+        + "    ]\n"
+        + "  },\n"
+        + "  \"resource1\": {\n"
+        + "    \"num_shards\": 2,\n"
+        + "    \"host0:port:az:pg\": [\n"
+        + "      \"00000\"\n"
+        + "    ],\n"
+        + "    \"host1:port:az:pg\": [\n"
+        + "      \"00001\"\n"
+        + "    ]\n"
+        + "  }\n"
+        + "}\n";
+
+    String compactJsonStr = "{\"resource2\":{\"num_shards\":3,\"host0:port:az:pg\":[\"00000\"],"
+        + "\"host1:port:az:pg\":[\"00001\"],\"host2:port:az:pg\":[\"00002\"]},"
+        + "\"resource3\":{\"num_shards\":4,\"host0:port:az:pg\":[\"00000\"],"
+        + "\"host1:port:az:pg\":[\"00001\"],\"host3:port:az:pg\":[\"00003\"],"
+        + "\"host2:port:az:pg\":[\"00002\"]},\"resource0\":{\"num_shards\":1,"
+        + "\"host0:port:az:pg\":[\"00000\"]},\"resource1\":{\"num_shards\":2,"
+        + "\"host0:port:az:pg\":[\"00000\"],\"host1:port:az:pg\":[\"00001\"]}}\n";
+
+    SimpleJsonObjectDecoder decoder = new SimpleJsonObjectDecoder();
+    JSONObject decodedFromPrettyPrintedStr = decoder.decode(prettyPrintedJsonStr.getBytes());
+    JSONObject decodedFromCompactJsonStr = decoder.decode(compactJsonStr.getBytes());
+
+    /**
+     * Note that we can't directly compare JSONObjects since we saw an issue where a numeric
+     * value was being returned as Integer or Long object. Due to this, the test for equality
+     * directly on the JSONObject is flaky.
+     */
+    assertEquals(shardMap.toJSONString(), decodedFromPrettyPrintedStr.toJSONString());
+    assertEquals(shardMap.toJSONString(), decodedFromCompactJsonStr.toJSONString());
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/shardmap/JsonShardMapTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/shardmap/JsonShardMapTest.java
@@ -1,0 +1,134 @@
+package com.pinterest.rocksplicator.shardmap;
+
+import static org.junit.Assert.assertEquals;
+
+import com.pinterest.rocksplicator.codecs.SimpleJsonObjectDecoder;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.math.IntMath;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class JsonShardMapTest {
+
+  @Test
+  public void testJsonShardMap() throws Exception {
+    JSONObject shardMapJsonObj = new JSONObject();
+    List<String> resources = ImmutableList.<String>builder()
+        .add("resource0")
+        .add("resource1")
+        .add("resource2")
+        .add("resource3")
+        .build();
+
+    List<String> instances = ImmutableList
+        .<String>builder()
+        .add("host0:9090:az_pg")
+        .add("host1:9090:az_pg")
+        .add("host2:9090:az_pg")
+        .add("host3:9090:az_pg")
+        .build();
+
+    int num_shards = 0;
+    for (String resource : resources) {
+      JSONObject resourceMapJsonObj = new JSONObject();
+      ++num_shards;
+      resourceMapJsonObj.put("num_shards", num_shards);
+
+      Map<String, JSONArray> instanceToPartitionsMap = new HashMap<>();
+
+      for (int partitionId = 0; partitionId < num_shards; ++partitionId) {
+        int instanceId = IntMath.mod(partitionId, instances.size());
+        String instance = instances.get(instanceId);
+        JSONArray partitionsArray = null;
+        if (!instanceToPartitionsMap.containsKey(instance)) {
+          instanceToPartitionsMap.put(instance, new JSONArray());
+        }
+        partitionsArray = instanceToPartitionsMap.get(instance);
+
+        String partitionStr = String.format("%05d", partitionId);
+        partitionsArray.add(partitionStr);
+      }
+      resourceMapJsonObj.putAll(instanceToPartitionsMap);
+
+      shardMapJsonObj.put(resource, resourceMapJsonObj);
+    }
+
+    String prettyPrintedJsonStr = "{\n"
+        + "  \"resource2\": {\n"
+        + "    \"num_shards\": 3,\n"
+        + "    \"host0:9090:az_pg\": [\n"
+        + "      \"00000\"\n"
+        + "    ],\n"
+        + "    \"host1:9090:az_pg\": [\n"
+        + "      \"00001\"\n"
+        + "    ],\n"
+        + "    \"host2:9090:az_pg\": [\n"
+        + "      \"00002\"\n"
+        + "    ]\n"
+        + "  },\n"
+        + "  \"resource3\": {\n"
+        + "    \"num_shards\": 4,\n"
+        + "    \"host0:9090:az_pg\": [\n"
+        + "      \"00000\"\n"
+        + "    ],\n"
+        + "    \"host1:9090:az_pg\": [\n"
+        + "      \"00001\"\n"
+        + "    ],\n"
+        + "    \"host3:9090:az_pg\": [\n"
+        + "      \"00003\"\n"
+        + "    ],\n"
+        + "    \"host2:9090:az_pg\": [\n"
+        + "      \"00002\"\n"
+        + "    ]\n"
+        + "  },\n"
+        + "  \"resource0\": {\n"
+        + "    \"num_shards\": 1,\n"
+        + "    \"host0:9090:az_pg\": [\n"
+        + "      \"00000\"\n"
+        + "    ]\n"
+        + "  },\n"
+        + "  \"resource1\": {\n"
+        + "    \"num_shards\": 2,\n"
+        + "    \"host0:9090:az_pg\": [\n"
+        + "      \"00000\"\n"
+        + "    ],\n"
+        + "    \"host1:9090:az_pg\": [\n"
+        + "      \"00001\"\n"
+        + "    ]\n"
+        + "  }\n"
+        + "}\n";
+
+    String compactJsonStr = "{\"resource2\":{\"num_shards\":3,\"host0:9090:az_pg\":[\"00000\"],"
+        + "\"host1:9090:az_pg\":[\"00001\"],\"host2:9090:az_pg\":[\"00002\"]},"
+        + "\"resource3\":{\"num_shards\":4,\"host0:9090:az_pg\":[\"00000\"],"
+        + "\"host1:9090:az_pg\":[\"00001\"],\"host3:9090:az_pg\":[\"00003\"],"
+        + "\"host2:9090:az_pg\":[\"00002\"]},\"resource0\":{\"num_shards\":1,"
+        + "\"host0:9090:az_pg\":[\"00000\"]},\"resource1\":{\"num_shards\":2,"
+        + "\"host0:9090:az_pg\":[\"00000\"],\"host1:9090:az_pg\":[\"00001\"]}}\n";
+
+    SimpleJsonObjectDecoder decoder = new SimpleJsonObjectDecoder();
+    JSONObject decodedFromCompactJsonStr = decoder.decode(compactJsonStr.getBytes());
+    JSONObject decodedFromPrettyPrintedStr = decoder.decode(prettyPrintedJsonStr.getBytes());
+
+    ShardMap firstOne = ShardMaps.fromJson(shardMapJsonObj);
+    ShardMap secondOne = ShardMaps.fromJson(decodedFromCompactJsonStr);
+    ShardMap thirdOne = ShardMaps.fromJson(decodedFromPrettyPrintedStr);
+
+    assertEquals(4, firstOne.getResources().size());
+    assertEquals(4, secondOne.getResources().size());
+    assertEquals(4, thirdOne.getResources().size());
+
+    assertEquals(new HashSet<>(resources), firstOne.getResources());
+    assertEquals(new HashSet<>(resources), secondOne.getResources());
+    assertEquals(new HashSet<>(resources), thirdOne.getResources());
+
+    
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/shardmap/JsonShardMapTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/shardmap/JsonShardMapTest.java
@@ -129,6 +129,63 @@ public class JsonShardMapTest {
     assertEquals(new HashSet<>(resources), secondOne.getResources());
     assertEquals(new HashSet<>(resources), thirdOne.getResources());
 
-    
+    for (String resource : firstOne.getResources()) {
+      ResourceMap resourceMapFirst = firstOne.getResourceMap(resource);
+      ResourceMap resourceMapSecond = secondOne.getResourceMap(resource);
+      ResourceMap resourceMapThird = thirdOne.getResourceMap(resource);
+
+      assertEquals(resourceMapFirst.getAllMissingPartitions(),
+          resourceMapSecond.getAllMissingPartitions());
+      assertEquals(resourceMapFirst.getAllMissingPartitions(),
+          resourceMapThird.getAllMissingPartitions());
+
+      assertEquals(resourceMapFirst.getAllPartitions(), resourceMapSecond.getAllPartitions());
+      assertEquals(resourceMapFirst.getAllPartitions(), resourceMapThird.getAllPartitions());
+
+      assertEquals(resourceMapFirst.getAllKnownPartitions(),
+          resourceMapSecond.getAllKnownPartitions());
+      assertEquals(resourceMapFirst.getAllKnownPartitions(),
+          resourceMapThird.getAllKnownPartitions());
+
+      assertEquals(resourceMapFirst.getInstances(), resourceMapSecond.getInstances());
+      assertEquals(resourceMapFirst.getInstances(), resourceMapThird.getInstances());
+
+      for (Instance eachInstance : resourceMapFirst.getInstances()) {
+        assertEquals(resourceMapFirst.getAllReplicasOnInstance(eachInstance),
+            resourceMapSecond.getAllReplicasOnInstance(eachInstance));
+        assertEquals(resourceMapFirst.getAllReplicasOnInstance(eachInstance),
+            resourceMapThird.getAllReplicasOnInstance(eachInstance));
+      }
+
+      for (Partition partition : resourceMapFirst.getAllKnownPartitions()) {
+        assertEquals(resourceMapFirst.getAllReplicasForPartition(partition),
+            resourceMapSecond.getAllReplicasForPartition(partition));
+        assertEquals(resourceMapFirst.getAllReplicasForPartition(partition),
+            resourceMapThird.getAllReplicasForPartition(partition));
+      }
+    }
+
+    ResourceMap resourceMap = firstOne.getResourceMap("resource3");
+    assertEquals(4, resourceMap.getNumShards());
+    assertEquals(ImmutableList.of(
+            new Replica(
+                new Partition("resource3_0"),
+                new Instance("host0:9090:az_pg"),
+                ReplicaState.ONLINE)),
+        resourceMap.getAllReplicasForPartition(new Partition("resource3_0")));
+
+    assertEquals(ImmutableList.of(
+        new Replica(
+            new Partition("resource3_1"),
+            new Instance("host1:9090:az_pg"),
+            ReplicaState.ONLINE)),
+        resourceMap.getAllReplicasForPartition(new Partition("resource3", "00001")));
+
+    assertEquals(ImmutableList.of(
+        new Replica(
+            new Partition("resource3_2"),
+            new Instance("host2:9090:az_pg"),
+            ReplicaState.ONLINE)),
+        resourceMap.getAllReplicasForPartition(new Partition("resource3", 2)));
   }
 }


### PR DESCRIPTION
This basically converts a JSON shardmap config into internal strongly typed representation for easily iterating over all data for posting leader events from client's perspective. The shard_map file will be watched for changes and post the leader events when status of leader changes in the shard_map config.