### PR TITLE
Implement re-watchable ConfigNotifier class to drive notifications for config file change after decoding the raw bytes

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/ConfigNotifier.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/ConfigNotifier.java
@@ -1,0 +1,164 @@
+package com.pinterest.rocksplicator.config;
+
+import com.pinterest.rocksplicator.codecs.CodecException;
+import com.pinterest.rocksplicator.codecs.Decoder;
+import com.pinterest.rocksplicator.utils.AutoCloseableLock;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+
+public class ConfigNotifier<R> implements Closeable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigNotifier.class);
+
+  private final Decoder<byte[], R> decoder;
+  private final Lock exclusionLock = new ReentrantLock();
+  private final AtomicBoolean isClosed = new AtomicBoolean(false);
+  private final AtomicBoolean isStarted = new AtomicBoolean(false);
+  private final WatchedFileNotificationCallback callback;
+  private final FileWatcher<byte[]> fileWatcher;
+  private final String filePath;
+
+  @VisibleForTesting
+  ConfigNotifier(Decoder<byte[], R> decoder, String filePath,
+                        Function<Context<R>, Void> notifier) throws IOException {
+    this(decoder, filePath, FileWatchers.getPollingFileWatcher(), notifier);
+  }
+
+  public ConfigNotifier(Decoder<byte[], R> decoder, String filePath,
+                        FileWatcher<byte[]> fileWatcher, Function<Context<R>, Void> notifier)
+      throws IOException {
+    this.filePath = filePath;
+    this.fileWatcher = fileWatcher;
+    this.decoder = decoder;
+    this.callback = new WatchedFileNotificationCallback(notifier);
+
+    WatchedFileNotificationCallback fakeCallback = new WatchedFileNotificationCallback(
+        new Function<Context<R>, Void>() {
+          @Override
+          public Void apply(Context<R> rContext) {
+            LOGGER.warn("Successfully");
+            return null;
+          }
+        });
+
+    // Add the watch to ensure the file exists.
+    this.fileWatcher.addWatch(filePath, fakeCallback);
+    // Immediately release the watch.
+    this.fileWatcher.removeWatch(filePath, fakeCallback);
+  }
+
+  public synchronized boolean isStarted() {
+    try (AutoCloseableLock autoLock = new AutoCloseableLock(exclusionLock)) {
+      return this.isStarted.get();
+    }
+  }
+
+  public synchronized boolean isClosed() {
+    try (AutoCloseableLock autoLock = new AutoCloseableLock(exclusionLock)) {
+      return this.isClosed.get();
+    }
+  }
+
+  public synchronized void start() throws IOException {
+    try (AutoCloseableLock autoLock = new AutoCloseableLock(exclusionLock)) {
+      if (isClosed()) {
+        throw new IOException("Cannot start once closed");
+      } else if (!isStarted()) {
+        this.fileWatcher.addWatch(filePath, callback);
+        this.isStarted.set(true);
+      }
+    }
+  }
+
+  public synchronized void stop() {
+    try (AutoCloseableLock autoLock = new AutoCloseableLock(exclusionLock)) {
+      if (!isClosed() && isStarted()) {
+        this.fileWatcher.removeWatch(filePath, callback);
+        this.isStarted.set(false);
+      }
+    }
+  }
+
+  @Override
+  public synchronized void close() throws IOException {
+    try (AutoCloseableLock autoLock = new AutoCloseableLock(exclusionLock)) {
+      isClosed.getAndSet(true);
+    }
+  }
+
+  public static class Context<R> {
+
+    private final R item;
+    private final long src_change_time_millis;
+    private final long notification_received_time_millis;
+    private final long deserialization_time_in_millis;
+
+    public Context(
+        final R item,
+        final long src_change_time_millis,
+        final long notification_received_time_millis,
+        final long deserialization_time_in_millis) {
+      this.item = item;
+      this.src_change_time_millis = src_change_time_millis;
+      this.notification_received_time_millis = notification_received_time_millis;
+      this.deserialization_time_in_millis = deserialization_time_in_millis;
+
+    }
+
+    public R getItem() {
+      return item;
+    }
+
+    public long getSrc_change_time_millis() {
+      return src_change_time_millis;
+    }
+
+    public long getNotification_received_time_millis() {
+      return notification_received_time_millis;
+    }
+
+    public long getDeserialization_time_in_millis() {
+      return deserialization_time_in_millis;
+    }
+  }
+
+  private class WatchedFileNotificationCallback
+      implements Function<WatchedFileContext<byte[]>, Void> {
+
+    private final Function<Context<R>, Void> notifier;
+
+    public WatchedFileNotificationCallback(Function<Context<R>, Void> notifier) {
+      this.notifier = notifier;
+    }
+
+    @Override
+    public Void apply(WatchedFileContext<byte[]> context) {
+      try (AutoCloseableLock autoLock = new AutoCloseableLock(exclusionLock)) {
+        // If the notifier is already closed, do nothing.
+        if (isClosed.get()) {
+          return null;
+        }
+        long notification_received_time_millis = System.currentTimeMillis();
+        R newConfigRef = ConfigNotifier.this.decoder.decode(context.getData());
+        long
+            deserialization_time_in_millis =
+            notification_received_time_millis - System.currentTimeMillis();
+        notifier.apply(new Context<>(newConfigRef, context.getLastModifiedTimeMillis(),
+            notification_received_time_millis, deserialization_time_in_millis));
+      } catch (CodecException e) {
+        e.printStackTrace();
+      }
+      return null;
+    }
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/ConfigNotifier.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/ConfigNotifier.java
@@ -10,14 +10,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 public class ConfigNotifier<R> implements Closeable {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigNotifier.class);
 
   private final Decoder<byte[], R> decoder;
@@ -30,7 +29,7 @@ public class ConfigNotifier<R> implements Closeable {
 
   @VisibleForTesting
   ConfigNotifier(Decoder<byte[], R> decoder, String filePath,
-                        Function<Context<R>, Void> notifier) throws IOException {
+                 Function<Context<R>, Void> notifier) throws IOException {
     this(decoder, filePath, FileWatchers.getPollingFileWatcher(), notifier);
   }
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/FileWatcher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/FileWatcher.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 public interface FileWatcher<R> {
 
   void addWatch(String filePath, Function<WatchedFileContext<R>, Void> onUpdate) throws IOException;
+
   void removeWatch(String filePath, Function<WatchedFileContext<R>, Void> onUpdate);
 }
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/FileWatcher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/FileWatcher.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 
 public interface FileWatcher<R> {
 
-  void addWatch(String filePath, Function<R, Void> onUpdate) throws IOException;
+  void addWatch(String filePath, Function<WatchedFileContext<R>, Void> onUpdate) throws IOException;
+  void removeWatch(String filePath, Function<WatchedFileContext<R>, Void> onUpdate);
 }
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/FileWatchers.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/FileWatchers.java
@@ -20,6 +20,10 @@ package com.pinterest.rocksplicator.config;
 
 public class FileWatchers {
   public static FileWatcher<byte[]> getPollingFileWatcher() {
-    return PollingFileWatcher.defaultInstance();
+    return PollingFileWatcher.defaultPerTenSecondsWatcher();
+  }
+
+  public static FileWatcher<byte[]> getPollingPerSecondFileWatcher() {
+    return PollingFileWatcher.defaultPerSecondWatcher();
   }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/PollingFileWatcher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/PollingFileWatcher.java
@@ -61,8 +61,11 @@ public class PollingFileWatcher implements FileWatcher<byte[]> {
 
   private static final Logger LOG = LoggerFactory.getLogger(PollingFileWatcher.class);
   private static final HashFunction HASH_FUNCTION = Hashing.md5();
-  public static final int DEFAULT_POLL_PERIOD_MILLIS = 10000;
+  private static final int DEFAULT_POLL_PERIOD_MILLIS = 10000;
+  private static final int DEFAULT_HIGH_RESOLUTION_POLL_PERIOD_MILLIS = 1000;
+
   private static volatile PollingFileWatcher DEFAULT_INSTANCE = null;
+  private static volatile PollingFileWatcher HIGH_RESOLUTION_INSTANCE = null;
 
   // Thread safety note: only addWatch() can add new entries to this map, and that method
   // is synchronized. The reason for using a concurrent map is only to allow the watcher
@@ -73,7 +76,7 @@ public class PollingFileWatcher implements FileWatcher<byte[]> {
   /**
    * Creates the default ConfigFileWatcher instance on demand.
    */
-  public static PollingFileWatcher defaultInstance() {
+  public static PollingFileWatcher defaultPerTenSecondsWatcher() {
     if (DEFAULT_INSTANCE == null) {
       synchronized (PollingFileWatcher.class) {
         if (DEFAULT_INSTANCE == null) {
@@ -83,6 +86,22 @@ public class PollingFileWatcher implements FileWatcher<byte[]> {
     }
 
     return DEFAULT_INSTANCE;
+  }
+
+  /**
+   * Creates the default ConfigFileWatcher instance on demand.
+   */
+  public static PollingFileWatcher defaultPerSecondWatcher() {
+    if (HIGH_RESOLUTION_INSTANCE == null) {
+      synchronized (PollingFileWatcher.class) {
+        if (HIGH_RESOLUTION_INSTANCE == null) {
+          HIGH_RESOLUTION_INSTANCE = new PollingFileWatcher(
+              DEFAULT_HIGH_RESOLUTION_POLL_PERIOD_MILLIS, TimeUnit.MILLISECONDS);
+        }
+      }
+    }
+
+    return HIGH_RESOLUTION_INSTANCE;
   }
 
   @VisibleForTesting
@@ -107,7 +126,8 @@ public class PollingFileWatcher implements FileWatcher<byte[]> {
    *                 important that the function be non-blocking.
    */
   @Override
-  public synchronized void addWatch(String filePath, Function<byte[], Void> onUpdate)
+  public synchronized void addWatch(String filePath,
+                                    Function<WatchedFileContext<byte[]>, Void> onUpdate)
       throws IOException {
     Preconditions.checkNotNull(filePath);
     Preconditions.checkArgument(!filePath.isEmpty());
@@ -115,8 +135,9 @@ public class PollingFileWatcher implements FileWatcher<byte[]> {
 
     // Read the file and make the initial onUpdate call.
     File file = new File(filePath);
+    long lastModifiedTimeMillis = file.lastModified();
     byte[] contents = read(file);
-    onUpdate.apply(contents);
+    onUpdate.apply(new WatchedFileContext<>(contents, lastModifiedTimeMillis));
 
     // Add the file to our map if it isn't already there, and register the new change watcher.
     ConfigFileInfo configFileInfo = watchedFileMap.get(filePath);
@@ -126,6 +147,16 @@ public class PollingFileWatcher implements FileWatcher<byte[]> {
       watchedFileMap.put(filePath, configFileInfo);
     }
     configFileInfo.changeWatchers.add(onUpdate);
+  }
+
+  @Override
+  public synchronized void removeWatch(
+      String filePath,
+      Function<WatchedFileContext<byte[]>, Void> onUpdate) {
+    ConfigFileInfo configFileInfo = watchedFileMap.get(filePath);
+    if (configFileInfo != null) {
+      configFileInfo.changeWatchers.remove(onUpdate);
+    }
   }
 
   @VisibleForTesting
@@ -158,9 +189,9 @@ public class PollingFileWatcher implements FileWatcher<byte[]> {
             if (!newContentHash.equals(configFileInfo.contentHash)) {
               configFileInfo.contentHash = newContentHash;
               LOG.info("File {} was modified at {}, notifying watchers.", filePath, lastModified);
-              for (Function<byte[], Void> watchers : configFileInfo.changeWatchers) {
+              for (Function<WatchedFileContext<byte[]>, Void> watchers : configFileInfo.changeWatchers) {
                 try {
-                  watchers.apply(newContents);
+                  watchers.apply(new WatchedFileContext<>(newContents, lastModified));
                 } catch (Exception e) {
                   LOG.error(
                       "Exception in watcher callback for {}, ignoring. New file contents were: {}",
@@ -216,7 +247,7 @@ public class PollingFileWatcher implements FileWatcher<byte[]> {
    */
   private static class ConfigFileInfo {
 
-    private final List<Function<byte[], Void>> changeWatchers = new CopyOnWriteArrayList<>();
+    private final List<Function<WatchedFileContext<byte[]>, Void>> changeWatchers = new CopyOnWriteArrayList<>();
     private long lastModifiedTimestampMillis;
     private HashCode contentHash;
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/config/WatchedFileContext.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/config/WatchedFileContext.java
@@ -1,0 +1,19 @@
+package com.pinterest.rocksplicator.config;
+
+public class WatchedFileContext<R> {
+  private R data;
+  private long lastModifiedTimeMillis;
+
+  public WatchedFileContext(R data, long lastModifiedTimeMillis) {
+    this.data = data;
+    this.lastModifiedTimeMillis = lastModifiedTimeMillis;
+  }
+
+  public R getData() {
+    return data;
+  }
+
+  public long getLastModifiedTimeMillis() {
+    return lastModifiedTimeMillis;
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/config/PollingFileWatcherTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/config/PollingFileWatcherTest.java
@@ -47,11 +47,11 @@ public class PollingFileWatcherTest extends ConfigTestBase {
     writeContentToFile(testConfigFile, "test1");
 
     // Setup watch and ensure it fires immediately.
-    configFileWatcher.addWatch(testConfigFile.getPath(), new Function<byte[], Void>() {
+    configFileWatcher.addWatch(testConfigFile.getPath(), new Function<WatchedFileContext<byte[]>, Void>() {
       @Override
-      public Void apply(byte[] bytes) {
+      public Void apply(WatchedFileContext<byte[]> context) {
         watchFiredCount.incrementAndGet();
-        contentRetrieved.set(new String(bytes, Charsets.UTF_8));
+        contentRetrieved.set(new String(context.getData(), Charsets.UTF_8));
         return null;
       }
     });
@@ -101,11 +101,11 @@ public class PollingFileWatcherTest extends ConfigTestBase {
       fileContents.add(new AtomicReference<String>());
       writeContentToFile(file, "initial" + i);
       final int index = i;
-      configFileWatcher.addWatch(file.getPath(), new Function<byte[], Void>() {
+      configFileWatcher.addWatch(file.getPath(), new Function<WatchedFileContext<byte[]>, Void>() {
         @Override
-        public Void apply(byte[] bytes) {
+        public Void apply(WatchedFileContext<byte[]> context) {
           watchesFired.incrementAndGet();
-          fileContents.get(index).set(new String(bytes, Charsets.UTF_8));
+          fileContents.get(index).set(new String(context.getData(), Charsets.UTF_8));
           return null;
         }
       });
@@ -174,11 +174,11 @@ public class PollingFileWatcherTest extends ConfigTestBase {
     for (int i = 0; i < 10; i++) {
       fileContents.add(new AtomicReference<String>());
       final int index = i;
-      configFileWatcher.addWatch(testConfigFile.getPath(), new Function<byte[], Void>() {
+      configFileWatcher.addWatch(testConfigFile.getPath(), new Function<WatchedFileContext<byte[]>, Void>() {
         @Override
-        public Void apply(byte[] bytes) {
+        public Void apply(WatchedFileContext<byte[]> context) {
           watchesFired.incrementAndGet();
-          fileContents.get(index).set(new String(bytes, Charsets.UTF_8));
+          fileContents.get(index).set(new String(context.getData(), Charsets.UTF_8));
           return null;
         }
       });
@@ -211,19 +211,19 @@ public class PollingFileWatcherTest extends ConfigTestBase {
 
     // Add a watcher that throws an exception in its callback. It should not prevent other
     // watchers from getting notified.
-    configFileWatcher.addWatch(testConfigFile.getPath(), new Function<byte[], Void>() {
+    configFileWatcher.addWatch(testConfigFile.getPath(), new Function<WatchedFileContext<byte[]>, Void>() {
       @Override
-      public Void apply(byte[] bytes) {
-        if (new String(bytes, Charset.defaultCharset()).equals("update")) {
+      public Void apply(WatchedFileContext<byte[]> context) {
+        if (new String(context.getData(), Charset.defaultCharset()).equals("update")) {
           throw new RuntimeException();
         }
         return null;
       }
     });
 
-    configFileWatcher.addWatch(testConfigFile.getPath(), new Function<byte[], Void>() {
+    configFileWatcher.addWatch(testConfigFile.getPath(), new Function<WatchedFileContext<byte[]>, Void>() {
       @Override
-      public Void apply(byte[] bytes) {
+      public Void apply(WatchedFileContext<byte[]> context) {
         watchesFired.incrementAndGet();
         return null;
       }
@@ -239,9 +239,9 @@ public class PollingFileWatcherTest extends ConfigTestBase {
   @Test(expected = IllegalArgumentException.class)
   public void testEmptyFilePath() throws IOException {
     PollingFileWatcher configFileWatcher = createPollingFileWatcher();
-    configFileWatcher.addWatch("", new Function<byte[], Void>() {
+    configFileWatcher.addWatch("", new Function<WatchedFileContext<byte[]>, Void>() {
       @Override
-      public Void apply(byte[] bytes) {
+      public Void apply(WatchedFileContext<byte[]> context) {
         return null;
       }
     });
@@ -250,9 +250,9 @@ public class PollingFileWatcherTest extends ConfigTestBase {
   @Test(expected = FileNotFoundException.class)
   public void testNonExistentFile() throws IOException {
     PollingFileWatcher configFileWatcher = createPollingFileWatcher();
-    configFileWatcher.addWatch("/foo/bar", new Function<byte[], Void>() {
+    configFileWatcher.addWatch("/foo/bar", new Function<WatchedFileContext<byte[]>, Void>() {
       @Override
-      public Void apply(byte[] bytes) {
+      public Void apply(WatchedFileContext<byte[]> context) {
         return null;
       }
     });


### PR DESCRIPTION
In order to publish client events, it needs a FileWatcher implementation that polls for timestamp modification every second.
Moreover current implementation of ConfigStore doesn't provide notification. It is a store that basically holds data after decoding. This is not sufficient for shard_map notification. Hence ConfigNotifier forwards notification from underlying poller and decodes the data and forwards it to notification callback. It also provides more context around the meta data of the file, like the timestamp of the file being watched when the poller polled for changes in the file, when it actually got notified, and how much time it took to deserialize raw bytes into format required by client. This is helpful in understanding the time lost in decoding raw bytes as well as the time the file actually got updated. This will help with understanding the latency once shard_map is posted to given url and then the contents are actually received on client side.