### PR TITLE
[Urgent Fix] Fixes Issue with surefire version with maven 3.0.5 / ubuntu 14.0 default maven version

### DIFF
--- a/cluster_management/pom.xml
+++ b/cluster_management/pom.xml
@@ -51,7 +51,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>2.19.1</version>
         <configuration>
           <properties>
             <property>
@@ -65,12 +65,12 @@
           <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>surefire-junit47</artifactId>
-            <version>3.0.0-M5</version>
+            <version>2.19.1</version>
           </dependency>
           <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>surefire-testng</artifactId>
-            <version>3.0.0-M5</version>
+            <version>2.19.1</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SUREFIRE-1628.

On Ubuntu 14, maven default is at 3.0.5. This fails the latest upgrades in rocksplicator to build in u14 environment. u18 works fine.

Tried multiple versions:
2.18.1 version seemed to allow junit tests to run with TestNG which running tests with curator-tests library using TestingServer  shows some internal runtime error while re-writing some zookeeper class.

2.19.1 version seems to properly run junit-4 tests with junit and testng tests with testng, and solves above issue.

2.19.1 version of surefire plugin also works with earlier versions of mvn, allowing the build to succeed on ubuntu-14.