### PR TITLE
Add a function in helix_client to call the getleaderInstanceId function.

### DIFF
--- a/rocksdb_admin/helix_client.h
+++ b/rocksdb_admin/helix_client.h
@@ -51,4 +51,10 @@ void JoinCluster(const std::string& zk_connect_str,
  */
 void DisconnectHelixManager();
 
+std::string GetLeaderInstanceId(
+  const std::string& zk_connect_str,
+  const std::string& cluster,
+  const std::string& resource,
+  const std::string& partition);
+
 }  // namespace admin


### PR DESCRIPTION
This is a continuation of
https://github.com/pinterest/rocksplicator/commit/0d7f168a6850e18744257bee2a86270a011c8a8a

This PR adds a c++ function to call the `getleaderInstanceId` Java
function in the running JVM.

Testing done:
In a test service, I added a perioidic call to this new cpp function and
verified that the correct results were returned.