### PR TITLE
[rocksdb_admin] enable option to backup/restore with meta

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -307,6 +307,7 @@ public class Utils {
       Admin.Client client = getAdminClient(host, adminPort);
 
       BackupDBRequest req = new BackupDBRequest(dbName, hdfsPath);
+      req.setInclude_meta(true);
       client.backupDB(req);
     } catch (TException e) {
       LOG.error("Failed to backup DB: ", e.toString());
@@ -377,6 +378,7 @@ public class Utils {
       Admin.Client client = getAdminClient(host, adminPort);
 
       BackupDBToS3Request req = new BackupDBToS3Request(dbName, s3Bucket, s3Path);
+      req.setInclude_meta(true);
       client.backupDBToS3(req);
     } catch (TException e) {
       LOG.error("Failed to backup DB: ", e.toString());

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -686,6 +686,7 @@ bool AdminHandler::backupDBHelper(const std::string& db_name,
       LOG(ERROR) << "Failed to encode DBMetaData";
       return false;
     } else {
+      LOG(INFO) << "Create new backup with encoded meta: " << db_meta;
       return backup_engine->CreateNewBackupWithMetadata(db->rocksdb(), db_meta).ok();
     }
   } else {
@@ -761,7 +762,7 @@ bool AdminHandler::restoreDBHelper(const std::string& db_name,
 
   DBMetaData meta;
   if (!DecodeThriftStruct(backup_infos.back().app_metadata, &meta)) {
-    LOG(ERROR) << "Failed to decode DBMetaData from backupInfo";
+    LOG(ERROR) << "Failed to decode DBMetaData from backupInfo.app_metadata: " << backup_infos.back().app_metadata;
     return false;
   }
 

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -765,8 +765,6 @@ bool AdminHandler::restoreDBHelper(const std::string& db_name,
     return false;
   }
 
-  // const std::string& s3_bucket = meta.__isset.s3_bucket ? meta.s3_bucket : "";
-  // const std::string& s3_path = meta.__isset.s3_path ? meta.s3_path : "";
   if (!writeMetaData(db_name, meta.s3_bucket, meta.s3_path)) {
     LOG(ERROR) << "Failed to write DBMetaData from restore's app_metadata";
     return false;

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -185,7 +185,7 @@ class AdminHandler : virtual public AdminSvIf {
                       const bool enable_backup_rate_limit,
                       const uint32_t backup_rate_limit,
                       const bool share_files_with_checksum,
-                      const bool backup_with_meta,
+                      const bool include_meta,
                       AdminException* e);
 
   bool restoreDBHelper(const std::string& db_name,

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -185,6 +185,7 @@ class AdminHandler : virtual public AdminSvIf {
                       const bool enable_backup_rate_limit,
                       const uint32_t backup_rate_limit,
                       const bool share_files_with_checksum,
+                      const bool backup_with_meta,
                       AdminException* e);
 
   bool restoreDBHelper(const std::string& db_name,

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -98,8 +98,12 @@ struct BackupDBToS3Request {
   # rate limit in MB/S, a non positive value means no limit
   4: optional i32 limit_mbs = 0,
   5: optional bool share_files_with_checksum = false,
+<<<<<<< HEAD
   # enable backup with metadata
   6: optional bool include_meta = false,
+=======
+  6: optional bool backup_with_meta = false,
+>>>>>>> make backupDBRequest and backupDBToS3request with same options
 }
 
 struct  BackupDBToS3Response {

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -98,12 +98,8 @@ struct BackupDBToS3Request {
   # rate limit in MB/S, a non positive value means no limit
   4: optional i32 limit_mbs = 0,
   5: optional bool share_files_with_checksum = false,
-<<<<<<< HEAD
   # enable backup with metadata
   6: optional bool include_meta = false,
-=======
-  6: optional bool backup_with_meta = false,
->>>>>>> make backupDBRequest and backupDBToS3request with same options
 }
 
 struct  BackupDBToS3Response {

--- a/rocksdb_admin/tests/CMakeLists.txt
+++ b/rocksdb_admin/tests/CMakeLists.txt
@@ -17,7 +17,10 @@ endforeach(testsourcefile ${TEST_SOURCES})
 
 add_executable(hbase_backup_integration_test hbase_backup_integration_test.cpp)
 target_link_libraries(hbase_backup_integration_test gtest rocksdb_admin boost_filesystem rocksdb_glogger kafka_consumer rdkafka++)
+# uncomment following line to include the integration test
+#add_test(NAME hbase_backup_integration_test COMMAND hbase_backup_integration_test)
 
 add_executable(s3_backup_integration_test s3_backup_integration_test.cpp)
 target_link_libraries(s3_backup_integration_test common gtest rocksdb_admin boost_filesystem rocksdb_glogger kafka_consumer rdkafka++)
+# uncomment following line to include the integration test
 #add_test(NAME s3_backup_integration_test COMMAND s3_backup_integration_test)

--- a/rocksdb_admin/tests/CMakeLists.txt
+++ b/rocksdb_admin/tests/CMakeLists.txt
@@ -20,3 +20,4 @@ target_link_libraries(hbase_backup_integration_test gtest rocksdb_admin boost_fi
 
 add_executable(s3_backup_integration_test s3_backup_integration_test.cpp)
 target_link_libraries(s3_backup_integration_test common gtest rocksdb_admin boost_filesystem rocksdb_glogger kafka_consumer rdkafka++)
+#add_test(NAME s3_backup_integration_test COMMAND s3_backup_integration_test)

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -22,6 +22,7 @@
 #include "rocksdb_admin/admin_handler.h"
 #undef private
 #include "rocksdb_admin/gen-cpp2/Admin.h"
+#include "rocksdb_admin/utils.h"
 
 using admin::AdminAsyncClient;
 using admin::AdminException;
@@ -29,6 +30,7 @@ using admin::AdminHandler;
 using admin::ApplicationDBManager;
 using admin::CheckDBRequest;
 using admin::CheckDBResponse;
+using admin::DBMetaData;
 using apache::thrift::async::TAsyncSocket;
 using apache::thrift::HeaderClientChannel;
 using apache::thrift::ThriftServer;
@@ -106,37 +108,66 @@ TEST(AdminHandlerTest, MetaData) {
   EXPECT_FALSE(meta.__isset.s3_path);
   EXPECT_FALSE(meta.__isset.last_kafka_msg_timestamp_ms);
 
-  EXPECT_TRUE(handler.writeMetaData(db_name, s3_bucket, s3_path, timestamp_ms));
+  // EXPECT_TRUE(handler.writeMetaData(db_name, s3_bucket, s3_path, timestamp_ms));
 
-  meta = handler.getMetaData(db_name);
-  EXPECT_EQ(meta.db_name, db_name);
-  EXPECT_TRUE(meta.__isset.s3_bucket);
-  EXPECT_EQ(meta.s3_bucket, s3_bucket);
-  EXPECT_TRUE(meta.__isset.s3_path);
-  EXPECT_EQ(meta.s3_path, s3_path);
-  EXPECT_TRUE(meta.__isset.last_kafka_msg_timestamp_ms);
-  EXPECT_EQ(meta.last_kafka_msg_timestamp_ms, timestamp_ms);
+  // meta = handler.getMetaData(db_name);
+  // EXPECT_EQ(meta.db_name, db_name);
+  // EXPECT_TRUE(meta.__isset.s3_bucket);
+  // EXPECT_EQ(meta.s3_bucket, s3_bucket);
+  // EXPECT_TRUE(meta.__isset.s3_path);
+  // EXPECT_EQ(meta.s3_path, s3_path);
+  // EXPECT_TRUE(meta.__isset.last_kafka_msg_timestamp_ms);
+  // EXPECT_EQ(meta.last_kafka_msg_timestamp_ms, timestamp_ms);
 
-  EXPECT_TRUE(handler.clearMetaData(db_name));
+  // EXPECT_TRUE(handler.clearMetaData(db_name));
 
-  // Test last_kafka_msg_timestamp_ms's default value
-  EXPECT_TRUE(handler.writeMetaData(db_name, s3_bucket, s3_path));
-  meta = handler.getMetaData(db_name);
-  EXPECT_EQ(meta.db_name, db_name);
-  EXPECT_TRUE(meta.__isset.s3_bucket);
-  EXPECT_EQ(meta.s3_bucket, s3_bucket);
-  EXPECT_TRUE(meta.__isset.s3_path);
-  EXPECT_EQ(meta.s3_path, s3_path);
-  EXPECT_TRUE(meta.__isset.last_kafka_msg_timestamp_ms);
-  EXPECT_EQ(meta.last_kafka_msg_timestamp_ms, -1);
+  // // Test last_kafka_msg_timestamp_ms's default value
+  // EXPECT_TRUE(handler.writeMetaData(db_name, s3_bucket, s3_path));
+  // meta = handler.getMetaData(db_name);
+  // EXPECT_EQ(meta.db_name, db_name);
+  // EXPECT_TRUE(meta.__isset.s3_bucket);
+  // EXPECT_EQ(meta.s3_bucket, s3_bucket);
+  // EXPECT_TRUE(meta.__isset.s3_path);
+  // EXPECT_EQ(meta.s3_path, s3_path);
+  // EXPECT_TRUE(meta.__isset.last_kafka_msg_timestamp_ms);
+  // EXPECT_EQ(meta.last_kafka_msg_timestamp_ms, -1);
 
-  EXPECT_TRUE(handler.clearMetaData(db_name));
+  // EXPECT_TRUE(handler.clearMetaData(db_name));
 
-  meta = handler.getMetaData(db_name);
-  EXPECT_EQ(meta.db_name, db_name);
+  // meta = handler.getMetaData(db_name);
+  // EXPECT_EQ(meta.db_name, db_name);
+  // EXPECT_FALSE(meta.__isset.s3_bucket);
+  // EXPECT_FALSE(meta.__isset.s3_path);
+  // EXPECT_FALSE(meta.__isset.last_kafka_msg_timestamp_ms);
+
+  // Test DBMetaData inheritance from Leader to Follower
+
+  // Verify write empty meta is ok && get db_name("") is also ok 
+  DBMetaData db_meta;
+  meta = handler.getMetaData(db_meta.db_name);
+  EXPECT_TRUE(meta.db_name.empty());
   EXPECT_FALSE(meta.__isset.s3_bucket);
   EXPECT_FALSE(meta.__isset.s3_path);
-  EXPECT_FALSE(meta.__isset.last_kafka_msg_timestamp_ms);
+
+  // verify meta is written, meta from get always has s3_path/s3_bucket isset
+  EXPECT_TRUE(handler.writeMetaData(db_meta.db_name, db_meta.s3_bucket, db_meta.s3_path));
+  meta = handler.getMetaData(db_meta.db_name);
+  EXPECT_TRUE(meta.db_name.empty());
+  EXPECT_TRUE(meta.__isset.s3_bucket);
+  EXPECT_TRUE(meta.s3_bucket.empty());
+  EXPECT_TRUE(meta.__isset.s3_path);
+  EXPECT_TRUE(meta.s3_path.empty());
+  
+  EXPECT_TRUE(handler.clearMetaData(db_meta.db_name));
+
+  std::string meta_from_backup = "";
+  EXPECT_FALSE(DecodeThriftStruct(meta_from_backup, &meta));
+  EXPECT_TRUE(meta.db_name.empty());
+  
+  // failed decode did not impact meta's old values
+  meta.set_db_name(db_name);
+  EXPECT_FALSE(DecodeThriftStruct(meta_from_backup, &meta));
+  EXPECT_EQ(meta.db_name, db_name);
 }
 
 TEST(AdminHandlerTest, CheckDB) {

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -108,40 +108,39 @@ TEST(AdminHandlerTest, MetaData) {
   EXPECT_FALSE(meta.__isset.s3_path);
   EXPECT_FALSE(meta.__isset.last_kafka_msg_timestamp_ms);
 
-  // EXPECT_TRUE(handler.writeMetaData(db_name, s3_bucket, s3_path, timestamp_ms));
+  EXPECT_TRUE(handler.writeMetaData(db_name, s3_bucket, s3_path, timestamp_ms));
 
-  // meta = handler.getMetaData(db_name);
-  // EXPECT_EQ(meta.db_name, db_name);
-  // EXPECT_TRUE(meta.__isset.s3_bucket);
-  // EXPECT_EQ(meta.s3_bucket, s3_bucket);
-  // EXPECT_TRUE(meta.__isset.s3_path);
-  // EXPECT_EQ(meta.s3_path, s3_path);
-  // EXPECT_TRUE(meta.__isset.last_kafka_msg_timestamp_ms);
-  // EXPECT_EQ(meta.last_kafka_msg_timestamp_ms, timestamp_ms);
+  meta = handler.getMetaData(db_name);
+  EXPECT_EQ(meta.db_name, db_name);
+  EXPECT_TRUE(meta.__isset.s3_bucket);
+  EXPECT_EQ(meta.s3_bucket, s3_bucket);
+  EXPECT_TRUE(meta.__isset.s3_path);
+  EXPECT_EQ(meta.s3_path, s3_path);
+  EXPECT_TRUE(meta.__isset.last_kafka_msg_timestamp_ms);
+  EXPECT_EQ(meta.last_kafka_msg_timestamp_ms, timestamp_ms);
 
-  // EXPECT_TRUE(handler.clearMetaData(db_name));
+  EXPECT_TRUE(handler.clearMetaData(db_name));
 
-  // // Test last_kafka_msg_timestamp_ms's default value
-  // EXPECT_TRUE(handler.writeMetaData(db_name, s3_bucket, s3_path));
-  // meta = handler.getMetaData(db_name);
-  // EXPECT_EQ(meta.db_name, db_name);
-  // EXPECT_TRUE(meta.__isset.s3_bucket);
-  // EXPECT_EQ(meta.s3_bucket, s3_bucket);
-  // EXPECT_TRUE(meta.__isset.s3_path);
-  // EXPECT_EQ(meta.s3_path, s3_path);
-  // EXPECT_TRUE(meta.__isset.last_kafka_msg_timestamp_ms);
-  // EXPECT_EQ(meta.last_kafka_msg_timestamp_ms, -1);
+  // Test last_kafka_msg_timestamp_ms's default value
+  EXPECT_TRUE(handler.writeMetaData(db_name, s3_bucket, s3_path));
+  meta = handler.getMetaData(db_name);
+  EXPECT_EQ(meta.db_name, db_name);
+  EXPECT_TRUE(meta.__isset.s3_bucket);
+  EXPECT_EQ(meta.s3_bucket, s3_bucket);
+  EXPECT_TRUE(meta.__isset.s3_path);
+  EXPECT_EQ(meta.s3_path, s3_path);
+  EXPECT_TRUE(meta.__isset.last_kafka_msg_timestamp_ms);
+  EXPECT_EQ(meta.last_kafka_msg_timestamp_ms, -1);
 
-  // EXPECT_TRUE(handler.clearMetaData(db_name));
+  EXPECT_TRUE(handler.clearMetaData(db_name));
 
-  // meta = handler.getMetaData(db_name);
-  // EXPECT_EQ(meta.db_name, db_name);
-  // EXPECT_FALSE(meta.__isset.s3_bucket);
-  // EXPECT_FALSE(meta.__isset.s3_path);
-  // EXPECT_FALSE(meta.__isset.last_kafka_msg_timestamp_ms);
+  meta = handler.getMetaData(db_name);
+  EXPECT_EQ(meta.db_name, db_name);
+  EXPECT_FALSE(meta.__isset.s3_bucket);
+  EXPECT_FALSE(meta.__isset.s3_path);
+  EXPECT_FALSE(meta.__isset.last_kafka_msg_timestamp_ms);
 
   // Test DBMetaData inheritance from Leader to Follower
-
   // Verify write empty meta is ok && get db_name("") is also ok 
   DBMetaData db_meta;
   meta = handler.getMetaData(db_meta.db_name);

--- a/rocksdb_admin/tests/s3_backup_integration_test.cpp
+++ b/rocksdb_admin/tests/s3_backup_integration_test.cpp
@@ -50,7 +50,7 @@ using std::string;
 using std::to_string;
 using std::unique_ptr;
 
-DEFINE_bool(backup_with_meta, true, "Whether backup with meta");
+DEFINE_bool(include_meta, true, "Whether backup with meta");
 DEFINE_string(s3_backup_prefix, "tmp/backup_test", "The s3 key prefix for backup");
 DEFINE_string(s3_bucket, "pinterest-jackson", "The s3 bucket");
 DEFINE_string(local_backup_dir, "/tmp/backup_test/backup/", "");
@@ -134,7 +134,7 @@ TEST(S3BackupRestoreTest, Basics) {
   EXPECT_TRUE(status.ok());
   unique_ptr<BackupEngine> backup_engine_holder(backup_engine);
 
-  if (FLAGS_backup_with_meta) {
+  if (FLAGS_include_meta) {
     std::string db_meta;
     DBMetaData meta;
     meta.db_name = test_db_name;
@@ -155,7 +155,7 @@ TEST(S3BackupRestoreTest, Basics) {
   status = BackupEngine::Open(Env::Default(), backup_options, &restore_engine);
   EXPECT_TRUE(status.ok());
   unique_ptr<BackupEngine> restore_engine_holder(restore_engine);
-  if (FLAGS_backup_with_meta) {
+  if (FLAGS_include_meta) {
     std::vector<BackupInfo> backup_infos;
     backup_engine->GetBackupInfo(&backup_infos);
     if (backup_infos.size() < 1) {

--- a/rocksdb_admin/tests/s3_backup_integration_test.cpp
+++ b/rocksdb_admin/tests/s3_backup_integration_test.cpp
@@ -50,7 +50,6 @@ using std::string;
 using std::to_string;
 using std::unique_ptr;
 
-DEFINE_bool(include_meta, true, "Whether backup with meta");
 DEFINE_string(s3_backup_prefix, "tmp/backup_test", "The s3 key prefix for backup");
 DEFINE_string(s3_bucket, "pinterest-jackson", "The s3 bucket");
 DEFINE_string(local_backup_dir, "/tmp/backup_test/backup/", "");
@@ -117,188 +116,210 @@ TEST(S3BackupRestoreTest, Basics) {
     EXPECT_TRUE(status.ok());
   }
 
-  // back up db. backup can be found in the s3 by using the following command
-  // aws s3 ls s3://FLAGS_s3_bucket/FLAGS_s3_backup_prefix/test_db_name
-  auto local_s3_util = common::S3Util::BuildS3Util(50, FLAGS_s3_bucket);
-  Env* backup_s3_env = new rocksdb::S3Env(s3_db_path, local_db_path, local_s3_util);
-  unique_ptr<Env> backup_s3_env_holder(backup_s3_env);
+  vector<bool> backup_with_metas = {true, false};
+  vector<bool> restore_by_ids = {true, false};
+  for (const auto& backup_with_meta : backup_with_metas) {
+    for (const auto& restore_by_id : restore_by_ids) {
+      LOG(INFO) << "Backup/Restore Test with backup_with_meta=" + to_string(backup_with_meta) +
+                       " restore_by_id=" + to_string(restore_by_id);
 
-  BackupableDBOptions backup_options(s3_db_path);
-  backup_options.backup_env = backup_s3_env;
-  common::RocksdbGLogger logger;
-  backup_options.info_log = &logger;
-  backup_options.max_background_operations = 1;
+      // back up db. backup can be found in the s3 by using the following command
+      // aws s3 ls s3://FLAGS_s3_bucket/FLAGS_s3_backup_prefix/test_db_name
+      auto local_s3_util = common::S3Util::BuildS3Util(50, FLAGS_s3_bucket);
+      Env* backup_s3_env = new rocksdb::S3Env(s3_db_path, local_db_path, local_s3_util);
+      unique_ptr<Env> backup_s3_env_holder(backup_s3_env);
 
-  BackupEngine* backup_engine;
-  auto status = BackupEngine::Open(Env::Default(), backup_options, &backup_engine);
-  EXPECT_TRUE(status.ok());
-  unique_ptr<BackupEngine> backup_engine_holder(backup_engine);
+      BackupableDBOptions backup_options(s3_db_path);
+      backup_options.backup_env = backup_s3_env;
+      common::RocksdbGLogger logger;
+      backup_options.info_log = &logger;
+      backup_options.max_background_operations = 1;
 
-  if (FLAGS_include_meta) {
-    std::string db_meta;
-    DBMetaData meta;
-    meta.db_name = test_db_name;
-    if (!EncodeThriftStruct(meta, &db_meta)) {
-      LOG(ERROR) << "Failed to encode DBMetadata from meta: " << db_meta;
-      ASSERT(false);
-    } else {
-      LOG(INFO) << "Succesfully encode DBMetadata to: " << db_meta;
+      BackupEngine* backup_engine;
+      auto status = BackupEngine::Open(Env::Default(), backup_options, &backup_engine);
+      EXPECT_TRUE(status.ok());
+      unique_ptr<BackupEngine> backup_engine_holder(backup_engine);
+
+      // call rocksdb API based on backup_with_meta or not
+      if (backup_with_meta) {
+        std::string db_meta;
+        DBMetaData meta;
+        meta.db_name = test_db_name;
+        if (!EncodeThriftStruct(meta, &db_meta)) {
+          LOG(ERROR) << "Failed to encode DBMetadata from meta: " << db_meta;
+          EXPECT_TRUE(false);
+        } else {
+          LOG(INFO) << "Succesfully encode DBMetadata to: " << db_meta;
+        }
+        status = backup_engine->CreateNewBackupWithMetadata(original_db.get(), db_meta);
+      } else {
+        status = backup_engine->CreateNewBackup(original_db.get());
+      }
+      EXPECT_TRUE(status.ok());
+
+      // restore db
+      std::string local_restored_db_path = FLAGS_local_restore_dir + test_db_name;
+      Env* restore_s3_env = new rocksdb::S3Env(s3_db_path, local_restored_db_path, local_s3_util);
+      unique_ptr<Env> restore_s3_env_holder(restore_s3_env);
+      backup_options.backup_env = restore_s3_env;
+
+      BackupEngine* restore_engine;
+      status = BackupEngine::Open(Env::Default(), backup_options, &restore_engine);
+      EXPECT_TRUE(status.ok());
+      unique_ptr<BackupEngine> restore_engine_holder(restore_engine);
+
+      // call rocksdb API based on restore by backup_id or not
+      if (restore_by_id) {
+        std::vector<BackupInfo> backup_infos;
+        backup_engine->GetBackupInfo(&backup_infos);
+        if (backup_infos.size() < 1) {
+          LOG(ERROR) << "Failed to getBackupInfo with backupEngine";
+        }
+        std::sort(backup_infos.begin(), backup_infos.end(), [](BackupInfo& a, BackupInfo& b) {
+          return a.backup_id < b.backup_id;
+        });
+        std::string db_meta = backup_infos.back().app_metadata;
+        DBMetaData meta;
+
+        // DBMetaData has required field db_name. Thus, it can't decode from empty meta data.
+        bool decode_meta_status = DecodeThriftStruct(db_meta, &meta);
+
+        // verify metadata retrieval match backup's metadata
+        if (backup_with_meta) {
+          LOG(INFO) << "Successfully decode DBMetaData from: " << db_meta;
+          EXPECT_TRUE(decode_meta_status);
+          EXPECT_EQ(meta.db_name, test_db_name);
+        } else {
+          LOG(ERROR) << "Failed to decode DBMetaData from backup_info.app_metadata: " << db_meta;
+          EXPECT_FALSE(decode_meta_status);
+          EXPECT_EQ(meta.db_name, "");
+        }
+        EXPECT_FALSE(meta.__isset.s3_bucket);
+        EXPECT_FALSE(meta.__isset.s3_path);
+
+        uint32_t latest_backup_id = backup_infos.back().backup_id;
+
+        LOG(INFO) << "Ready to restore from backupId " << to_string(latest_backup_id);
+        status = backup_engine->RestoreDBFromBackup(
+            latest_backup_id, local_restored_db_path, local_restored_db_path);
+      } else {
+        status = restore_engine->RestoreDBFromLatestBackup(local_restored_db_path,
+                                                           local_restored_db_path);
+      }
+      EXPECT_TRUE(status.ok());
+
+      {
+        // compare the original db with the restored db
+        auto restored_db = OpenDB(local_restored_db_path);
+        EXPECT_EQ(restored_db->GetLatestSequenceNumber(), expected_seq_no);
+        for (int i = 0; i < expected_seq_no; ++i) {
+          string value;
+          status = restored_db->Get(ReadOptions(), "key" + to_string(i), &value);
+          EXPECT_TRUE(status.ok());
+          EXPECT_EQ(value, "value" + to_string(i));
+        }
+      }
+
+      status = DestroyDB(local_restored_db_path, Options());
+      EXPECT_TRUE(status.ok());
     }
-    status = backup_engine->CreateNewBackupWithMetadata(original_db.get(), db_meta);
-  } else {
-    status = backup_engine->CreateNewBackup(original_db.get());
-  }
-  EXPECT_TRUE(status.ok());
-
-  // restore db
-  std::string local_restored_db_path = FLAGS_local_restore_dir + test_db_name;
-  Env* restore_s3_env = new rocksdb::S3Env(s3_db_path, local_restored_db_path, local_s3_util);
-  unique_ptr<Env> restore_s3_env_holder(restore_s3_env);
-  backup_options.backup_env = restore_s3_env;
-
-  BackupEngine* restore_engine;
-  status = BackupEngine::Open(Env::Default(), backup_options, &restore_engine);
-  EXPECT_TRUE(status.ok());
-  unique_ptr<BackupEngine> restore_engine_holder(restore_engine);
-  if (FLAGS_include_meta) {
-    std::vector<BackupInfo> backup_infos;
-    backup_engine->GetBackupInfo(&backup_infos);
-    if (backup_infos.size() < 1) {
-      LOG(ERROR) << "Failed to getBackupInfo with backupEngine";
-    }
-    std::sort(backup_infos.begin(), backup_infos.end(), [](BackupInfo& a, BackupInfo& b) {
-      return a.backup_id < b.backup_id;
-    });
-    std::string db_meta = backup_infos.back().app_metadata;
-    DBMetaData meta;
-    if (!DecodeThriftStruct(db_meta, &meta)) {
-      LOG(ERROR) << "Failed to decode DBMetaData from backup_info.app_metadata: " << db_meta;
-      ASSERT(false);
-    } else {
-      LOG(INFO) << "Successfully decode DBMetaData from: " << db_meta;
-    }
-    EXPECT_EQ(meta.db_name, test_db_name);
-    EXPECT_FALSE(meta.__isset.s3_bucket);
-    EXPECT_FALSE(meta.__isset.s3_path);
-
-    uint32_t latest_backup_id = backup_infos.back().backup_id;
-
-    LOG(INFO) << "Ready to restore from backupId " << to_string(latest_backup_id);
-    status = backup_engine->RestoreDBFromBackup(
-        latest_backup_id, local_restored_db_path, local_restored_db_path);
-  } else {
-    status =
-        restore_engine->RestoreDBFromLatestBackup(local_restored_db_path,
-        local_restored_db_path);
-  }
-
-  EXPECT_TRUE(status.ok());
-
-  // compare the original db with the restored db
-  auto restored_db = OpenDB(local_restored_db_path);
-  EXPECT_EQ(restored_db->GetLatestSequenceNumber(), expected_seq_no);
-  for (int i = 0; i < expected_seq_no; ++i) {
-    string value;
-    status = restored_db->Get(ReadOptions(), "key" + to_string(i), &value);
-    EXPECT_TRUE(status.ok());
-    EXPECT_EQ(value, "value" + to_string(i));
   }
 }
 
-TEST(S3BackupRestoreCheckpointTest, Basics) {
-  boost::system::error_code remove_err;
-  boost::system::error_code create_err;
-  boost::filesystem::remove_all(FLAGS_local_backup_dir, remove_err);
-  boost::filesystem::create_directories(FLAGS_local_backup_dir, create_err);
-  boost::filesystem::remove_all(FLAGS_local_backup_dir_checkpoint, remove_err);
-  boost::filesystem::create_directories(FLAGS_local_backup_dir_checkpoint, create_err);
-  boost::filesystem::remove_all(FLAGS_local_restore_dir_checkpoint, remove_err);
-  boost::filesystem::create_directories(FLAGS_local_restore_dir_checkpoint, create_err);
-  EXPECT_FALSE(remove_err || create_err);
-  SCOPE_EXIT {
-    boost::filesystem::remove_all(FLAGS_local_backup_dir, remove_err);
-    boost::filesystem::remove_all(FLAGS_local_backup_dir_checkpoint, remove_err);
-    boost::filesystem::remove_all(FLAGS_local_restore_dir_checkpoint, remove_err);
-  };
-  EXPECT_FALSE(remove_err || create_err);
+// TEST(S3BackupRestoreCheckpointTest, Basics) {
+//   boost::system::error_code remove_err;
+//   boost::system::error_code create_err;
+//   boost::filesystem::remove_all(FLAGS_local_backup_dir, remove_err);
+//   boost::filesystem::create_directories(FLAGS_local_backup_dir, create_err);
+//   boost::filesystem::remove_all(FLAGS_local_backup_dir_checkpoint, remove_err);
+//   boost::filesystem::create_directories(FLAGS_local_backup_dir_checkpoint, create_err);
+//   boost::filesystem::remove_all(FLAGS_local_restore_dir_checkpoint, remove_err);
+//   boost::filesystem::create_directories(FLAGS_local_restore_dir_checkpoint, create_err);
+//   EXPECT_FALSE(remove_err || create_err);
+//   SCOPE_EXIT {
+//     boost::filesystem::remove_all(FLAGS_local_backup_dir, remove_err);
+//     boost::filesystem::remove_all(FLAGS_local_backup_dir_checkpoint, remove_err);
+//     boost::filesystem::remove_all(FLAGS_local_restore_dir_checkpoint, remove_err);
+//   };
+//   EXPECT_FALSE(remove_err || create_err);
 
-  int expected_seq_no = 10;
+//   int expected_seq_no = 10;
 
-  std::string test_db_name = getDBName();
+//   std::string test_db_name = getDBName();
 
-  // create a new db
-  std::string local_db_path = FLAGS_local_backup_dir + test_db_name;
-  std::string s3_db_path = FLAGS_s3_backup_prefix_checkpoint + "/" + test_db_name;
+//   // create a new db
+//   std::string local_db_path = FLAGS_local_backup_dir + test_db_name;
+//   std::string s3_db_path = FLAGS_s3_backup_prefix_checkpoint + "/" + test_db_name;
 
-  // create a new db
-  auto original_db = CleanAndOpenDB(local_db_path);
-  for (int i = 0; i < expected_seq_no; ++i) {
-    EXPECT_EQ(original_db->GetLatestSequenceNumber(), i);
-    auto status =
-        original_db->Put(rocksdb::WriteOptions(), "key" + to_string(i), "value" + to_string(i));
-    EXPECT_TRUE(status.ok());
-  }
+//   // create a new db
+//   auto original_db = CleanAndOpenDB(local_db_path);
+//   for (int i = 0; i < expected_seq_no; ++i) {
+//     EXPECT_EQ(original_db->GetLatestSequenceNumber(), i);
+//     auto status =
+//         original_db->Put(rocksdb::WriteOptions(), "key" + to_string(i), "value" + to_string(i));
+//     EXPECT_TRUE(status.ok());
+//   }
 
-  // back up db. backup can be found in the s3 by using the following command
-  // aws s3 ls s3://FLAGS_s3_bucket/FLAGS_s3_backup_dir_checkpoint/test_db_name
-  auto local_s3_util = common::S3Util::BuildS3Util(50, FLAGS_s3_bucket);
-  rocksdb::Checkpoint* checkpoint;
-  auto status = rocksdb::Checkpoint::Create(original_db.get(), &checkpoint);
-  EXPECT_TRUE(status.ok());
+//   // back up db. backup can be found in the s3 by using the following command
+//   // aws s3 ls s3://FLAGS_s3_bucket/FLAGS_s3_backup_dir_checkpoint/test_db_name
+//   auto local_s3_util = common::S3Util::BuildS3Util(50, FLAGS_s3_bucket);
+//   rocksdb::Checkpoint* checkpoint;
+//   auto status = rocksdb::Checkpoint::Create(original_db.get(), &checkpoint);
+//   EXPECT_TRUE(status.ok());
 
-  auto ts = common::timeutil::GetCurrentTimestamp();
-  std::string local_db_checkpoint_path =
-      folly::stringPrintf("%s%s/%d", FLAGS_local_backup_dir.c_str(), test_db_name.c_str(), ts);
-  std::string formatted_s3_dir_path = folly::stringPrintf(
-      "%s/%s/%d/", FLAGS_s3_backup_prefix_checkpoint.c_str(), test_db_name.c_str(), ts);
+//   auto ts = common::timeutil::GetCurrentTimestamp();
+//   std::string local_db_checkpoint_path =
+//       folly::stringPrintf("%s%s/%d", FLAGS_local_backup_dir.c_str(), test_db_name.c_str(), ts);
+//   std::string formatted_s3_dir_path = folly::stringPrintf(
+//       "%s/%s/%d/", FLAGS_s3_backup_prefix_checkpoint.c_str(), test_db_name.c_str(), ts);
 
-  LOG(INFO) << "Create checkpoint for localDB: " << local_db_path
-            << " to path: " << local_db_checkpoint_path;
-  status = checkpoint->CreateCheckpoint(local_db_checkpoint_path);
-  EXPECT_TRUE(status.ok());
-  std::unique_ptr<rocksdb::Checkpoint> checkpoint_holder(checkpoint);
+//   LOG(INFO) << "Create checkpoint for localDB: " << local_db_path
+//             << " to path: " << local_db_checkpoint_path;
+//   status = checkpoint->CreateCheckpoint(local_db_checkpoint_path);
+//   EXPECT_TRUE(status.ok());
+//   std::unique_ptr<rocksdb::Checkpoint> checkpoint_holder(checkpoint);
 
-  std::vector<std::string> checkpoint_files;
-  status = rocksdb::Env::Default()->GetChildren(local_db_checkpoint_path, &checkpoint_files);
-  EXPECT_TRUE(status.ok());
+//   std::vector<std::string> checkpoint_files;
+//   status = rocksdb::Env::Default()->GetChildren(local_db_checkpoint_path, &checkpoint_files);
+//   EXPECT_TRUE(status.ok());
 
-  // Upload checkpoint to s3
-  for (const auto& file : checkpoint_files) {
-    if (file == "." || file == "..") {
-      continue;
-    }
-    std::string local_file_path = local_db_checkpoint_path + "/" + file;
-    std::string s3_file_path = formatted_s3_dir_path + file;
-    LOG(INFO) << "PutObject from localPath: " << local_file_path << " to path: " << s3_file_path;
-    auto copy_resp = local_s3_util->putObject(s3_file_path, local_file_path);
-    EXPECT_TRUE(copy_resp.Error().empty());
-  }
+//   // Upload checkpoint to s3
+//   for (const auto& file : checkpoint_files) {
+//     if (file == "." || file == "..") {
+//       continue;
+//     }
+//     std::string local_file_path = local_db_checkpoint_path + "/" + file;
+//     std::string s3_file_path = formatted_s3_dir_path + file;
+//     LOG(INFO) << "PutObject from localPath: " << local_file_path << " to path: " << s3_file_path;
+//     auto copy_resp = local_s3_util->putObject(s3_file_path, local_file_path);
+//     EXPECT_TRUE(copy_resp.Error().empty());
+//   }
 
-  // restore db
-  auto resp = local_s3_util->listAllObjects(formatted_s3_dir_path);
-  EXPECT_TRUE(resp.Error().empty());
-  std::string formatted_local_path = local_db_path + "/";
+//   // restore db
+//   auto resp = local_s3_util->listAllObjects(formatted_s3_dir_path);
+//   EXPECT_TRUE(resp.Error().empty());
+//   std::string formatted_local_path = local_db_path + "/";
 
-  for (auto& v : resp.Body().objects) {
-    // If there is error in one file downloading, then we fail the whole restore process
-    auto get_resp = local_s3_util->getObject(
-        v, formatted_local_path + v.substr(formatted_s3_dir_path.size()), false);
-    EXPECT_TRUE(get_resp.Error().empty());
-  }
+//   for (auto& v : resp.Body().objects) {
+//     // If there is error in one file downloading, then we fail the whole restore process
+//     auto get_resp = local_s3_util->getObject(
+//         v, formatted_local_path + v.substr(formatted_s3_dir_path.size()), false);
+//     EXPECT_TRUE(get_resp.Error().empty());
+//   }
 
-  rocksdb::DB* restored_db;
-  status = rocksdb::DB::Open(rocksdb::Options(), formatted_local_path, &restored_db);
-  EXPECT_TRUE(status.ok());
+//   rocksdb::DB* restored_db;
+//   status = rocksdb::DB::Open(rocksdb::Options(), formatted_local_path, &restored_db);
+//   EXPECT_TRUE(status.ok());
 
-  // compare the original db with the restored db
-  EXPECT_EQ(restored_db->GetLatestSequenceNumber(), expected_seq_no);
-  for (int i = 0; i < expected_seq_no; ++i) {
-    string value;
-    status = restored_db->Get(ReadOptions(), "key" + to_string(i), &value);
-    EXPECT_TRUE(status.ok());
-    EXPECT_EQ(value, "value" + to_string(i));
-  }
-}
+//   // compare the original db with the restored db
+//   EXPECT_EQ(restored_db->GetLatestSequenceNumber(), expected_seq_no);
+//   for (int i = 0; i < expected_seq_no; ++i) {
+//     string value;
+//     status = restored_db->Get(ReadOptions(), "key" + to_string(i), &value);
+//     EXPECT_TRUE(status.ok());
+//     EXPECT_EQ(value, "value" + to_string(i));
+//   }
+// }
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/rocksdb_admin/tests/s3_backup_integration_test.cpp
+++ b/rocksdb_admin/tests/s3_backup_integration_test.cpp
@@ -138,7 +138,12 @@ TEST(S3BackupRestoreTest, Basics) {
     std::string db_meta;
     DBMetaData meta;
     meta.db_name = test_db_name;
-    EncodeThriftStruct(meta, &db_meta);
+    if (!EncodeThriftStruct(meta, &db_meta)) {
+      LOG(ERROR) << "Failed to encode DBMetadata from meta: " << db_meta;
+      ASSERT(false);
+    } else {
+      LOG(INFO) << "Succesfully encode DBMetadata to: " << db_meta;
+    }
     status = backup_engine->CreateNewBackupWithMetadata(original_db.get(), db_meta);
   } else {
     status = backup_engine->CreateNewBackup(original_db.get());
@@ -166,7 +171,12 @@ TEST(S3BackupRestoreTest, Basics) {
     });
     std::string db_meta = backup_infos.back().app_metadata;
     DBMetaData meta;
-    DecodeThriftStruct(db_meta, &meta);
+    if (!DecodeThriftStruct(db_meta, &meta)) {
+      LOG(ERROR) << "Failed to decode DBMetaData from backup_info.app_metadata: " << db_meta;
+      ASSERT(false);
+    } else {
+      LOG(INFO) << "Successfully decode DBMetaData from: " << db_meta;
+    }
     EXPECT_EQ(meta.db_name, test_db_name);
     EXPECT_FALSE(meta.__isset.s3_bucket);
     EXPECT_FALSE(meta.__isset.s3_path);

--- a/rocksdb_admin/tests/s3_backup_integration_test.cpp
+++ b/rocksdb_admin/tests/s3_backup_integration_test.cpp
@@ -18,48 +18,49 @@
 
 #include "rocksdb_admin/admin_handler.h"
 
+#include <cstdlib>
+#include <vector>
+
+#include "boost/filesystem.hpp"
 #include "common/rocksdb_env_s3.h"
 #include "common/rocksdb_glogger/rocksdb_glogger.h"
 #include "common/s3util.h"
 #include "common/timeutil.h"
-#include "boost/filesystem.hpp"
 #include "gtest/gtest.h"
 #include "rocksdb/db.h"
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
 #include "rocksdb/utilities/backupable_db.h"
 #include "rocksdb/utilities/checkpoint.h"
+#include "rocksdb_admin/gen-cpp2/rocksdb_admin_types.h"
+#include "rocksdb_admin/utils.h"
 
+using admin::DBMetaData;
 using rocksdb::BackupableDBOptions;
 using rocksdb::BackupEngine;
+using rocksdb::BackupInfo;
 using rocksdb::DB;
 using rocksdb::DestroyDB;
 using rocksdb::Env;
-using rocksdb::S3Env;
 using rocksdb::Options;
 using rocksdb::ReadOptions;
+using rocksdb::S3Env;
 using rocksdb::SequenceNumber;
 using std::string;
 using std::to_string;
 using std::unique_ptr;
 
-
-DEFINE_string(s3_backup_dir, "tmp/backup_test", "The s3 key prefix for backup");
-
-DEFINE_string(s3_bucket, "pinterest-realpin", "The s3 bucket");
-
+DEFINE_bool(backup_with_meta, true, "Whether backup with meta");
+DEFINE_string(s3_backup_prefix, "tmp/backup_test", "The s3 key prefix for backup");
+DEFINE_string(s3_bucket, "pinterest-jackson", "The s3 bucket");
 DEFINE_string(local_backup_dir, "/tmp/backup_test/backup/", "");
-
 DEFINE_string(local_restore_dir, "/tmp/backup_test/restore/", "");
 
-DEFINE_string(original_db_path, "/tmp/test_s3_backup_original",
-              "The dir for the original rocksdb instance");
-
-DEFINE_string(restored_db_path, "/tmp/test_s3_backup_copy",
-              "The dir for the restored racksdb instance");
-DEFINE_string(s3_backup_dir_checkpoint, "tmp/backup_test/backup/checkpoint", "The s3 key prefix for backup checkpoint");
-
-DEFINE_string(local_backup_dir_checkpoint, "/tmp/backup_test/backup/checkpoint", "");
+DEFINE_string(s3_backup_prefix_checkpoint,
+              "tmp/backup_test/checkpoint",
+              "The s3 key prefix for backup checkpoint");
+DEFINE_string(local_backup_dir_checkpoint, "/tmp/backup_test/backup/checkpoint/", "");
+DEFINE_string(local_restore_dir_checkpoint, "/tmp/backup_test/restore/checkpoint/", "");
 
 // helper function to open a rocksdb instance
 unique_ptr<DB> OpenDB(const string& path, bool error_if_exists = false) {
@@ -80,6 +81,11 @@ unique_ptr<DB> CleanAndOpenDB(const string& path) {
   return OpenDB(path, true);
 }
 
+std::string getDBName() {
+  static thread_local unsigned int seed = time(nullptr);
+  return "test_db_" + to_string(rand_r(&seed));
+}
+
 TEST(S3BackupRestoreTest, Basics) {
   boost::system::error_code remove_err;
   boost::system::error_code create_err;
@@ -89,29 +95,35 @@ TEST(S3BackupRestoreTest, Basics) {
   boost::filesystem::create_directories(FLAGS_local_restore_dir, create_err);
   EXPECT_FALSE(remove_err || create_err);
   SCOPE_EXIT {
-      boost::filesystem::remove_all(FLAGS_local_backup_dir, remove_err);
-      boost::filesystem::remove_all(FLAGS_local_restore_dir, remove_err);
+    boost::filesystem::remove_all(FLAGS_local_backup_dir, remove_err);
+    boost::filesystem::remove_all(FLAGS_local_restore_dir, remove_err);
   };
   EXPECT_FALSE(remove_err || create_err);
 
   int expected_seq_no = 10;
 
+  std::string test_db_name = getDBName();
+  LOG(INFO) << "Local test db name: " << test_db_name;
+
   // create a new db
-  auto original_db = CleanAndOpenDB(FLAGS_original_db_path);
+  std::string local_db_path = FLAGS_local_backup_dir + test_db_name;
+  std::string s3_db_path = FLAGS_s3_backup_prefix + "/" + test_db_name;
+
+  auto original_db = CleanAndOpenDB(local_db_path);
   for (int i = 0; i < expected_seq_no; ++i) {
     EXPECT_EQ(original_db->GetLatestSequenceNumber(), i);
-    auto status = original_db->Put(rocksdb::WriteOptions(),
-                    "key" + to_string(i), "value" + to_string(i));
+    auto status =
+        original_db->Put(rocksdb::WriteOptions(), "key" + to_string(i), "value" + to_string(i));
     EXPECT_TRUE(status.ok());
   }
 
   // back up db. backup can be found in the s3 by using the following command
-  // aws s3 ls s3://FLAGS_s3_bucket/FLAGS_s3_backup_dir
+  // aws s3 ls s3://FLAGS_s3_bucket/FLAGS_s3_backup_prefix/test_db_name
   auto local_s3_util = common::S3Util::BuildS3Util(50, FLAGS_s3_bucket);
-  Env* backup_s3_env = new rocksdb::S3Env(FLAGS_s3_backup_dir, FLAGS_local_backup_dir, local_s3_util);
+  Env* backup_s3_env = new rocksdb::S3Env(s3_db_path, local_db_path, local_s3_util);
   unique_ptr<Env> backup_s3_env_holder(backup_s3_env);
 
-  BackupableDBOptions backup_options(FLAGS_s3_backup_dir);
+  BackupableDBOptions backup_options(s3_db_path);
   backup_options.backup_env = backup_s3_env;
   common::RocksdbGLogger logger;
   backup_options.info_log = &logger;
@@ -122,11 +134,20 @@ TEST(S3BackupRestoreTest, Basics) {
   EXPECT_TRUE(status.ok());
   unique_ptr<BackupEngine> backup_engine_holder(backup_engine);
 
-  status = backup_engine->CreateNewBackup(original_db.get());
+  if (FLAGS_backup_with_meta) {
+    std::string db_meta;
+    DBMetaData meta;
+    meta.db_name = test_db_name;
+    EncodeThriftStruct(meta, &db_meta);
+    status = backup_engine->CreateNewBackupWithMetadata(original_db.get(), db_meta);
+  } else {
+    status = backup_engine->CreateNewBackup(original_db.get());
+  }
   EXPECT_TRUE(status.ok());
 
   // restore db
-  Env* restore_s3_env = new rocksdb::S3Env(FLAGS_s3_backup_dir, FLAGS_local_restore_dir, local_s3_util);
+  std::string local_restored_db_path = FLAGS_local_restore_dir + test_db_name;
+  Env* restore_s3_env = new rocksdb::S3Env(s3_db_path, local_restored_db_path, local_s3_util);
   unique_ptr<Env> restore_s3_env_holder(restore_s3_env);
   backup_options.backup_env = restore_s3_env;
 
@@ -134,61 +155,101 @@ TEST(S3BackupRestoreTest, Basics) {
   status = BackupEngine::Open(Env::Default(), backup_options, &restore_engine);
   EXPECT_TRUE(status.ok());
   unique_ptr<BackupEngine> restore_engine_holder(restore_engine);
-  status = restore_engine->RestoreDBFromLatestBackup(FLAGS_restored_db_path, FLAGS_restored_db_path);
+  if (FLAGS_backup_with_meta) {
+    std::vector<BackupInfo> backup_infos;
+    backup_engine->GetBackupInfo(&backup_infos);
+    if (backup_infos.size() < 1) {
+      LOG(ERROR) << "Failed to getBackupInfo with backupEngine";
+    }
+    std::sort(backup_infos.begin(), backup_infos.end(), [](BackupInfo& a, BackupInfo& b) {
+      return a.backup_id < b.backup_id;
+    });
+    std::string db_meta = backup_infos.back().app_metadata;
+    DBMetaData meta;
+    DecodeThriftStruct(db_meta, &meta);
+    EXPECT_EQ(meta.db_name, test_db_name);
+    EXPECT_FALSE(meta.__isset.s3_bucket);
+    EXPECT_FALSE(meta.__isset.s3_path);
+
+    uint32_t latest_backup_id = backup_infos.back().backup_id;
+
+    LOG(INFO) << "Ready to restore from backupId " << to_string(latest_backup_id);
+    status = backup_engine->RestoreDBFromBackup(
+        latest_backup_id, local_restored_db_path, local_restored_db_path);
+  } else {
+    status =
+        restore_engine->RestoreDBFromLatestBackup(local_restored_db_path,
+        local_restored_db_path);
+  }
+
   EXPECT_TRUE(status.ok());
 
   // compare the original db with the restored db
-  auto restored_db = OpenDB(FLAGS_restored_db_path);
+  auto restored_db = OpenDB(local_restored_db_path);
   EXPECT_EQ(restored_db->GetLatestSequenceNumber(), expected_seq_no);
   for (int i = 0; i < expected_seq_no; ++i) {
     string value;
     status = restored_db->Get(ReadOptions(), "key" + to_string(i), &value);
     EXPECT_TRUE(status.ok());
-    EXPECT_EQ(value, "value" + to_string(i));  
+    EXPECT_EQ(value, "value" + to_string(i));
   }
 }
 
 TEST(S3BackupRestoreCheckpointTest, Basics) {
   boost::system::error_code remove_err;
   boost::system::error_code create_err;
+  boost::filesystem::remove_all(FLAGS_local_backup_dir, remove_err);
+  boost::filesystem::create_directories(FLAGS_local_backup_dir, create_err);
   boost::filesystem::remove_all(FLAGS_local_backup_dir_checkpoint, remove_err);
   boost::filesystem::create_directories(FLAGS_local_backup_dir_checkpoint, create_err);
-  boost::filesystem::remove_all(FLAGS_restored_db_path, remove_err);
-  boost::filesystem::create_directories(FLAGS_restored_db_path, create_err);
+  boost::filesystem::remove_all(FLAGS_local_restore_dir_checkpoint, remove_err);
+  boost::filesystem::create_directories(FLAGS_local_restore_dir_checkpoint, create_err);
   EXPECT_FALSE(remove_err || create_err);
   SCOPE_EXIT {
-      boost::filesystem::remove_all(FLAGS_local_backup_dir_checkpoint, remove_err);
-      boost::filesystem::remove_all(FLAGS_restored_db_path, remove_err);
+    boost::filesystem::remove_all(FLAGS_local_backup_dir, remove_err);
+    boost::filesystem::remove_all(FLAGS_local_backup_dir_checkpoint, remove_err);
+    boost::filesystem::remove_all(FLAGS_local_restore_dir_checkpoint, remove_err);
   };
   EXPECT_FALSE(remove_err || create_err);
 
   int expected_seq_no = 10;
 
+  std::string test_db_name = getDBName();
+
   // create a new db
-  auto original_db = CleanAndOpenDB(FLAGS_original_db_path);
+  std::string local_db_path = FLAGS_local_backup_dir + test_db_name;
+  std::string s3_db_path = FLAGS_s3_backup_prefix_checkpoint + "/" + test_db_name;
+
+  // create a new db
+  auto original_db = CleanAndOpenDB(local_db_path);
   for (int i = 0; i < expected_seq_no; ++i) {
     EXPECT_EQ(original_db->GetLatestSequenceNumber(), i);
-    auto status = original_db->Put(rocksdb::WriteOptions(),
-                                   "key" + to_string(i), "value" + to_string(i));
+    auto status =
+        original_db->Put(rocksdb::WriteOptions(), "key" + to_string(i), "value" + to_string(i));
     EXPECT_TRUE(status.ok());
   }
 
   // back up db. backup can be found in the s3 by using the following command
-  // aws s3 ls s3://FLAGS_s3_bucket/FLAGS_s3_backup_dir_checkpoint
+  // aws s3 ls s3://FLAGS_s3_bucket/FLAGS_s3_backup_dir_checkpoint/test_db_name
   auto local_s3_util = common::S3Util::BuildS3Util(50, FLAGS_s3_bucket);
   rocksdb::Checkpoint* checkpoint;
   auto status = rocksdb::Checkpoint::Create(original_db.get(), &checkpoint);
   EXPECT_TRUE(status.ok());
 
   auto ts = common::timeutil::GetCurrentTimestamp();
-  std::string formatted_local_dir_path = folly::stringPrintf("%s/test%d", FLAGS_local_backup_dir_checkpoint.c_str(), ts);
-  std::string formatted_s3_dir_path = folly::stringPrintf("%s/test%d/", FLAGS_s3_backup_dir_checkpoint.c_str(), ts);
-  status = checkpoint->CreateCheckpoint(formatted_local_dir_path);
+  std::string local_db_checkpoint_path =
+      folly::stringPrintf("%s%s/%d", FLAGS_local_backup_dir.c_str(), test_db_name.c_str(), ts);
+  std::string formatted_s3_dir_path = folly::stringPrintf(
+      "%s/%s/%d/", FLAGS_s3_backup_prefix_checkpoint.c_str(), test_db_name.c_str(), ts);
+
+  LOG(INFO) << "Create checkpoint for localDB: " << local_db_path
+            << " to path: " << local_db_checkpoint_path;
+  status = checkpoint->CreateCheckpoint(local_db_checkpoint_path);
   EXPECT_TRUE(status.ok());
   std::unique_ptr<rocksdb::Checkpoint> checkpoint_holder(checkpoint);
 
   std::vector<std::string> checkpoint_files;
-  status = rocksdb::Env::Default()->GetChildren(formatted_local_dir_path, &checkpoint_files);
+  status = rocksdb::Env::Default()->GetChildren(local_db_checkpoint_path, &checkpoint_files);
   EXPECT_TRUE(status.ok());
 
   // Upload checkpoint to s3
@@ -196,18 +257,22 @@ TEST(S3BackupRestoreCheckpointTest, Basics) {
     if (file == "." || file == "..") {
       continue;
     }
-    auto copy_resp = local_s3_util->putObject(formatted_s3_dir_path + file, formatted_local_dir_path + "/" + file);
+    std::string local_file_path = local_db_checkpoint_path + "/" + file;
+    std::string s3_file_path = formatted_s3_dir_path + file;
+    LOG(INFO) << "PutObject from localPath: " << local_file_path << " to path: " << s3_file_path;
+    auto copy_resp = local_s3_util->putObject(s3_file_path, local_file_path);
     EXPECT_TRUE(copy_resp.Error().empty());
   }
 
   // restore db
   auto resp = local_s3_util->listAllObjects(formatted_s3_dir_path);
   EXPECT_TRUE(resp.Error().empty());
-  std::string formatted_local_path = FLAGS_restored_db_path + "/";
+  std::string formatted_local_path = local_db_path + "/";
 
   for (auto& v : resp.Body().objects) {
     // If there is error in one file downloading, then we fail the whole restore process
-    auto get_resp = local_s3_util->getObject(v, formatted_local_path + v.substr(formatted_s3_dir_path.size()), false);
+    auto get_resp = local_s3_util->getObject(
+        v, formatted_local_path + v.substr(formatted_s3_dir_path.size()), false);
     EXPECT_TRUE(get_resp.Error().empty());
   }
 
@@ -229,4 +294,3 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/rocksdb_admin/utils.h
+++ b/rocksdb_admin/utils.h
@@ -12,18 +12,20 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
-
 #pragma once
 
 #include <string>
+
+#include "folly/ExceptionWrapper.h"
+#include "folly/Range.h"
+#include "thrift/lib/cpp2/protocol/Serializer.h"
 
 namespace admin {
 
 /*
  * Convert a segment name to a db name
  */
-std::string SegmentToDbName(const std::string& segment,
-                            const int shard_id);
+std::string SegmentToDbName(const std::string& segment, const int shard_id);
 /*
  * Convert a db name to segment name
  */
@@ -33,5 +35,24 @@ std::string DbNameToSegment(const std::string& db_name);
  * Extract the shard id from a db name
  */
 int ExtractShardId(const std::string& db_name);
+
+template <typename T>
+bool DecodeThriftStruct(const std::string& data, T* obj) {
+  auto ex = folly::try_and_catch<std::exception>([data, obj]() {
+    apache::thrift::CompactSerializer::deserialize(folly::StringPiece(data.data(), data.size()),
+                                                   *obj);
+  });
+
+  return !ex;
+}
+
+template <typename T>
+bool EncodeThriftStruct(const T& obj, std::string* data) {
+  data->clear();
+  auto ex = folly::try_and_catch<std::exception>(
+      [obj, data]() { apache::thrift::CompactSerializer::serialize(obj, data); });
+
+  return !ex;
+}
 
 }  // namespace admin

--- a/rocksdb_admin/utils.h
+++ b/rocksdb_admin/utils.h
@@ -42,7 +42,7 @@ bool DecodeThriftStruct(const std::string& data, T* obj) {
     apache::thrift::CompactSerializer::deserialize(folly::StringPiece(data.data(), data.size()),
                                                    *obj);
   });
-
+  ex.with_exception([](std::exception& e) { LOG(ERROR) << e.what(); });
   return !ex;
 }
 
@@ -51,7 +51,7 @@ bool EncodeThriftStruct(const T& obj, std::string* data) {
   data->clear();
   auto ex = folly::try_and_catch<std::exception>(
       [obj, data]() { apache::thrift::CompactSerializer::serialize(obj, data); });
-
+  ex.with_exception([](std::exception& e) { LOG(ERROR) << e.what(); });
   return !ex;
 }
 


### PR DESCRIPTION
During state transition, such as Offline->Follower,  the Follower replica will get a full snapshot of its Leader. 
Here, we also make Follower to make a copy of its Leader's DBMetaData (db_name, s3_bucket, s3_path, etc.)
- this make sense, since Follower is literally get a full copy of its leader, it should also inherit its DBMetaData

**code change to this PR**:
- during backup, we read the Leader's DBMetadata and push to s3. 
- during restore, we get the rocksdb::BackupInfo list from s3, and restore from the latest version, and store the latest version's metadata locally to DBMetadata. 

*Impact to our view of mutable DB*:
- currently, mutable DB (read-write system) does not have a local DBMetaData; while readonly DB (ie. readonly system) has a local DBMetaData to store the s3_path of the serving data. 
- Here, we re-design our view of mutable DB:
- - each mutable DB will have two tiers: a mutable tier locally, and an immutable tier at S3. 
- - each mutable DB will have a local DBMetaData to store its 2nd tier data info (e.g. version, s3_path, etc.)
-- during serving, if we need to combine this two tiers, we will ingest the tier2 data into tier1 through ingestion process, and update the local DBMetaData to indicate the "combination process", e.g. ingested or not. 

*Useful*:
- this is useful: if we ingest data to the Leader and store the ingested data's s3_path into Leader's DBMetaData, then, when Follower get the full snapshot from its Leader. Since the "snapshot" already contains the ingested data, the follower should have its DBMetaDat indicate a "s3_path" to indicate it contains the ingested data. 