### PR TITLE
add a new optional for backupRequst struct of admin thrift

### DIFF
--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -64,7 +64,8 @@ struct BackupDBRequest {
   3: optional i32 limit_mbs = 0,
   # enable appending checksum to sst file name during backup
   4: optional bool share_files_with_checksum = false,
-  5: optional bool backup_with_meta = true,
+  # enable backup with metadata
+  5: optional bool with_meta = true,
 }
 
 struct BackupDBResponse {
@@ -97,7 +98,8 @@ struct BackupDBToS3Request {
   # rate limit in MB/S, a non positive value means no limit
   4: optional i32 limit_mbs = 0,
   5: optional bool share_files_with_checksum = false,
-  6: optional bool backup_with_meta = false,
+  # enable backup with metadata
+  6: optional bool with_meta = false,
 }
 
 struct  BackupDBToS3Response {

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -65,7 +65,7 @@ struct BackupDBRequest {
   # enable appending checksum to sst file name during backup
   4: optional bool share_files_with_checksum = false,
   # enable backup with metadata
-  5: optional bool with_meta = true,
+  5: optional bool with_meta = false,
 }
 
 struct BackupDBResponse {

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -65,7 +65,7 @@ struct BackupDBRequest {
   # enable appending checksum to sst file name during backup
   4: optional bool share_files_with_checksum = false,
   # enable backup with metadata
-  5: optional bool with_meta = false,
+  5: optional bool include_meta = false,
 }
 
 struct BackupDBResponse {
@@ -99,7 +99,7 @@ struct BackupDBToS3Request {
   4: optional i32 limit_mbs = 0,
   5: optional bool share_files_with_checksum = false,
   # enable backup with metadata
-  6: optional bool with_meta = false,
+  6: optional bool include_meta = false,
 }
 
 struct  BackupDBToS3Response {

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -64,6 +64,7 @@ struct BackupDBRequest {
   3: optional i32 limit_mbs = 0,
   # enable appending checksum to sst file name during backup
   4: optional bool share_files_with_checksum = false,
+  5: optional bool backup_with_meta = true,
 }
 
 struct BackupDBResponse {
@@ -95,6 +96,8 @@ struct BackupDBToS3Request {
   3: required string s3_backup_dir,
   # rate limit in MB/S, a non positive value means no limit
   4: optional i32 limit_mbs = 0,
+  5: optional bool share_files_with_checksum = false,
+  6: optional bool backup_with_meta = false,
 }
 
 struct  BackupDBToS3Response {


### PR DESCRIPTION
Add "backup_with_meta" optional to backup request struct, so that we can new rocksdb::createNewBackupWithMeta API to backup DB along with storing some meta data. 