### PR TITLE
Refactor Publisher code for shard_map

### DIFF
--- a/cluster_management/pom.xml
+++ b/cluster_management/pom.xml
@@ -206,6 +206,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>3.7.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/cluster_management/pom.xml
+++ b/cluster_management/pom.xml
@@ -202,6 +202,11 @@
       <artifactId>snappy-java</artifactId>
       <version>1.1.8.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.7.0</version>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
@@ -20,6 +20,7 @@ package com.pinterest.rocksplicator;
 
 import com.pinterest.rocksplicator.eventstore.ExternalViewLeaderEventLogger;
 import com.pinterest.rocksplicator.monitoring.mbeans.RocksplicatorMonitor;
+import com.pinterest.rocksplicator.publisher.ShardMapPublisher;
 import com.pinterest.rocksplicator.utils.AutoCloseableLock;
 import com.pinterest.rocksplicator.utils.ExternalViewUtils;
 
@@ -35,10 +36,6 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.participant.CustomCodeCallbackHandler;
 import org.apache.helix.spectator.RoutingTableProvider;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
@@ -46,7 +43,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -175,41 +171,37 @@ public class ConfigGenerator extends RoutingTableProvider implements CustomCodeC
   private static final Logger LOG = LoggerFactory.getLogger(ConfigGenerator.class);
 
   private final String clusterName;
-  private final String postUrl;
-  private final boolean enableDumpToLocal;
   private final Map<String, String> hostToHostWithDomain;
-  private final JSONObject dataParameters;
   private final RocksplicatorMonitor monitor;
   private final ReentrantLock synchronizedCallbackLock;
+  private final ShardMapPublisher shardMapPublisher;
   private HelixManager helixManager;
   private HelixAdmin helixAdmin;
-  private String lastPostedContent;
   private Set<String> disabledHosts;
   private ExternalViewLeaderEventLogger externalViewLeaderEventLogger;
 
   @VisibleForTesting
-  ConfigGenerator(String clusterName, HelixManager helixManager, String configPostUrl) {
-    this(clusterName, helixManager, configPostUrl,
+  ConfigGenerator(
+      final String clusterName,
+      final HelixManager helixManager,
+      final ShardMapPublisher<JSONObject> shardMapPublisher) {
+    this(clusterName, helixManager, shardMapPublisher,
         new RocksplicatorMonitor(clusterName, helixManager.getInstanceName()), null);
   }
 
-  public ConfigGenerator(String clusterName, HelixManager helixManager, String configPostUrl,
-                         RocksplicatorMonitor monitor,
-                         ExternalViewLeaderEventLogger externalViewLeaderEventLogger) {
+  public ConfigGenerator(
+      final String clusterName,
+      final HelixManager helixManager,
+      final ShardMapPublisher<JSONObject> shardMapPublisher,
+      final RocksplicatorMonitor monitor,
+      final ExternalViewLeaderEventLogger externalViewLeaderEventLogger) {
     this.clusterName = clusterName;
     this.helixManager = helixManager;
     this.helixAdmin = this.helixManager.getClusterManagmentTool();
     this.hostToHostWithDomain = new HashMap<String, String>();
-    this.postUrl = configPostUrl;
-    this.dataParameters = new JSONObject();
-    this.dataParameters.put("config_version", "v3");
-    this.dataParameters.put("author", "ConfigGenerator");
-    this.dataParameters.put("comment", "new shard config");
-    this.dataParameters.put("content", "{}");
-    this.lastPostedContent = null;
+    this.shardMapPublisher = shardMapPublisher;
     this.disabledHosts = new HashSet<>();
     this.monitor = monitor;
-    this.enableDumpToLocal = new File("/var/log/helixspectator").canWrite();
     this.synchronizedCallbackLock = new ReentrantLock();
     this.externalViewLeaderEventLogger = externalViewLeaderEventLogger;
   }
@@ -391,52 +383,12 @@ public class ConfigGenerator extends RoutingTableProvider implements CustomCodeC
     // remove host that doesn't exist in the ExternalView from hostToHostWithDomain
     hostToHostWithDomain.keySet().retainAll(existingHosts);
 
-    String newContent = config.toString();
-    if (lastPostedContent != null && lastPostedContent.equals(newContent)) {
-      LOG.error("Identical external view observed, skip updating config.");
-      return;
-    }
-
-    // Write the shard config to local
-    if (enableDumpToLocal) {
-      try {
-        FileWriter shard_config_writer = new FileWriter("/var/log/helixspectator/shard_config");
-        shard_config_writer.write(newContent);
-        shard_config_writer.close();
-        LOG.error("Successfully wrote the shard config to the local.");
-      } catch (IOException e) {
-        LOG.error("An error occurred when writing shard config to local");
-        e.printStackTrace();
-      }
-    }
-
-    // Write the config to ZK
-    LOG.error("Generating a new shard config...");
-
     /**
-     * TODO: gopalrajpurohit
-     * Move shard_map updating logic into separate method.
+     * Finally publish the shard_map in json_format
      */
-    this.dataParameters.remove("content");
-    this.dataParameters.put("content", newContent);
-    HttpPost httpPost = new HttpPost(this.postUrl);
+    shardMapPublisher.publish(config);
 
     long shardPostingTimeMillis = System.currentTimeMillis();
-
-    try {
-      httpPost.setEntity(new StringEntity(this.dataParameters.toString()));
-      HttpResponse response = new DefaultHttpClient().execute(httpPost);
-      if (response.getStatusLine().getStatusCode() == 200) {
-        lastPostedContent = newContent;
-        LOG.error("Succeed to generate a new shard config");
-      } else {
-        shardPostingTimeMillis = -1;
-        LOG.error(response.getStatusLine().getReasonPhrase());
-      }
-    } catch (Exception e) {
-      shardPostingTimeMillis = -1;
-      LOG.error("Failed to post the new config", e);
-    }
 
     stopwatch.stop();
     long elapsedMs = stopwatch.elapsed(TimeUnit.MILLISECONDS);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -25,6 +25,7 @@ import com.pinterest.rocksplicator.eventstore.LeaderEventsLogger;
 import com.pinterest.rocksplicator.eventstore.LeaderEventsLoggerImpl;
 import com.pinterest.rocksplicator.eventstore.ExternalViewLeaderEventsLoggerImpl;
 import com.pinterest.rocksplicator.monitoring.mbeans.RocksplicatorMonitor;
+import com.pinterest.rocksplicator.publisher.ShardMapPublisherBuilder;
 import com.pinterest.rocksplicator.task.BackupTaskFactory;
 import com.pinterest.rocksplicator.task.DedupTaskFactory;
 import com.pinterest.rocksplicator.task.RestoreTaskFactory;
@@ -433,7 +434,11 @@ public class Participant {
 
     if (runSpectator) {
       // Add callback to create rocksplicator shard config
-      ConfigGenerator configGenerator = new ConfigGenerator(clusterName, helixManager, postUrl, monitor,
+      ConfigGenerator configGenerator = new ConfigGenerator(
+          clusterName,
+          helixManager,
+          ShardMapPublisherBuilder.create().withPostUrl(postUrl).withLocalDump().build(),
+          monitor,
           new ExternalViewLeaderEventsLoggerImpl(staticSpectatorLeaderEventsLogger));
 
       HelixCustomCodeRunner codeRunner = new HelixCustomCodeRunner(helixManager, zkConnectString)

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Spectator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Spectator.java
@@ -27,6 +27,7 @@ import com.pinterest.rocksplicator.eventstore.ExternalViewLeaderEventsLoggerImpl
 import com.pinterest.rocksplicator.eventstore.LeaderEventsLogger;
 import com.pinterest.rocksplicator.eventstore.LeaderEventsLoggerImpl;
 import com.pinterest.rocksplicator.monitoring.mbeans.RocksplicatorMonitor;
+import com.pinterest.rocksplicator.publisher.ShardMapPublisherBuilder;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -283,7 +284,7 @@ public class Spectator {
       this.configGenerator = new ConfigGenerator(
           helixManager.getClusterName(),
           helixManager,
-          postUrl,
+          ShardMapPublisherBuilder.create().withPostUrl(postUrl).withLocalDump().build(),
           monitor, new ExternalViewLeaderEventsLoggerImpl(spectatorLeaderEventsLogger));
 
       /**

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisher.java
@@ -1,0 +1,51 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.publisher;
+
+import org.json.simple.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of ShardMapPublisher that takes in shard_map in JSONObject format
+ * and dedups the shard_maps published consecutively in sequence, if last published
+ * shard_map was same as the current one.
+ */
+public class DedupingShardMapPublisher implements ShardMapPublisher<JSONObject> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DedupingShardMapPublisher.class);
+
+  private final ShardMapPublisher<String> delegateShardMapPublisher;
+  private String lastPostedContent;
+
+  public DedupingShardMapPublisher(ShardMapPublisher<String> delegateShardMapPublisher) {
+    this.delegateShardMapPublisher = delegateShardMapPublisher;
+    this.lastPostedContent = null;
+  }
+
+  @Override
+  public void publish(JSONObject jsonShardMap) {
+    String newContent = jsonShardMap.toString();
+    if (lastPostedContent != null && lastPostedContent.equals(newContent)) {
+      LOG.error("Identical external view observed, skip updating config.");
+      return;
+    }
+    delegateShardMapPublisher.publish(newContent);
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisher.java
@@ -53,6 +53,7 @@ public class DedupingShardMapPublisher implements ShardMapPublisher<JSONObject> 
       LOG.error("Identical external view observed, skip updating config.");
       return;
     }
+    lastPostedContent = newContent;
     delegateShardMapPublisher.publish(validResources, externalViews, newContent);
   }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisher.java
@@ -18,9 +18,13 @@
 
 package com.pinterest.rocksplicator.publisher;
 
+import org.apache.helix.model.ExternalView;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * Implementation of ShardMapPublisher that takes in shard_map in JSONObject format
@@ -40,12 +44,15 @@ public class DedupingShardMapPublisher implements ShardMapPublisher<JSONObject> 
   }
 
   @Override
-  public void publish(JSONObject jsonShardMap) {
+  public void publish(
+      final Set<String> validResources,
+      final List<ExternalView> externalViews,
+      final JSONObject jsonShardMap) {
     String newContent = jsonShardMap.toString();
     if (lastPostedContent != null && lastPostedContent.equals(newContent)) {
       LOG.error("Identical external view observed, skip updating config.");
       return;
     }
-    delegateShardMapPublisher.publish(newContent);
+    delegateShardMapPublisher.publish(validResources, externalViews, newContent);
   }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/HttpPostShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/HttpPostShardMapPublisher.java
@@ -1,0 +1,68 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.publisher;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.json.simple.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Given a shard_map in json string, post the contents to http service on provided url.
+ */
+public class HttpPostShardMapPublisher implements ShardMapPublisher<String> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HttpPostShardMapPublisher.class);
+
+  private final JSONObject dataParameters;
+  private final String postUrl;
+
+  public HttpPostShardMapPublisher(final String configPostUrl) {
+    this.postUrl = configPostUrl;
+    this.dataParameters = new JSONObject();
+    this.dataParameters.put("config_version", "v3");
+    this.dataParameters.put("author", "ConfigGenerator");
+    this.dataParameters.put("comment", "new shard config");
+    this.dataParameters.put("content", "{}");
+  }
+
+  public void publish(String jsonStringShardMapNewContent) {
+    // Write the config to ZK
+    LOG.error("Generating a new shard config...");
+
+    this.dataParameters.remove("content");
+    this.dataParameters.put("content", jsonStringShardMapNewContent);
+    HttpPost httpPost = new HttpPost(this.postUrl);
+
+    try {
+      httpPost.setEntity(new StringEntity(this.dataParameters.toString()));
+      HttpResponse response = new DefaultHttpClient().execute(httpPost);
+      if (response.getStatusLine().getStatusCode() == 200) {
+        LOG.error("Succeed to generate a new shard config");
+      } else {
+        LOG.error(response.getStatusLine().getReasonPhrase());
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to post the new config", e);
+    }
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/HttpPostShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/HttpPostShardMapPublisher.java
@@ -18,6 +18,7 @@
 
 package com.pinterest.rocksplicator.publisher;
 
+import org.apache.helix.model.ExternalView;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -25,6 +26,9 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * Given a shard_map in json string, post the contents to http service on provided url.
@@ -45,7 +49,11 @@ public class HttpPostShardMapPublisher implements ShardMapPublisher<String> {
     this.dataParameters.put("content", "{}");
   }
 
-  public void publish(String jsonStringShardMapNewContent) {
+  @Override
+  public synchronized void publish(
+      final Set<String> validResources,
+      final List<ExternalView> externalViews,
+      final String jsonStringShardMapNewContent) {
     // Write the config to ZK
     LOG.error("Generating a new shard config...");
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/LocalFileShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/LocalFileShardMapPublisher.java
@@ -1,0 +1,56 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.publisher;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class LocalFileShardMapPublisher implements ShardMapPublisher<String> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DedupingShardMapPublisher.class);
+
+  private final boolean enableDumpToLocal;
+
+  public LocalFileShardMapPublisher() {
+    this.enableDumpToLocal = new File("/var/log/helixspectator").canWrite();
+  }
+
+  @Override
+  public void publish(String jsonStringShardMapNewContent) {
+    if (! enableDumpToLocal) {
+      // doNothing()
+      return;
+    }
+
+    // Write the shard config to local
+    try {
+      FileWriter shard_config_writer = new FileWriter("/var/log/helixspectator/shard_config");
+      shard_config_writer.write(jsonStringShardMapNewContent);
+      shard_config_writer.close();
+      LOG.error("Successfully wrote the shard config to the local.");
+    } catch (IOException e) {
+      LOG.error("An error occurred when writing shard config to local");
+      e.printStackTrace();
+    }
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/LocalFileShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/LocalFileShardMapPublisher.java
@@ -43,7 +43,7 @@ public class LocalFileShardMapPublisher implements ShardMapPublisher<String> {
       final Set<String> validResources,
       final List<ExternalView> externalViews,
       final String jsonStringShardMapNewContent) {
-    if (! enableDumpToLocal) {
+    if (!enableDumpToLocal) {
       // doNothing()
       return;
     }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/LocalFileShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/LocalFileShardMapPublisher.java
@@ -18,12 +18,15 @@
 
 package com.pinterest.rocksplicator.publisher;
 
+import org.apache.helix.model.ExternalView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 
 public class LocalFileShardMapPublisher implements ShardMapPublisher<String> {
 
@@ -31,12 +34,15 @@ public class LocalFileShardMapPublisher implements ShardMapPublisher<String> {
 
   private final boolean enableDumpToLocal;
 
-  public LocalFileShardMapPublisher() {
-    this.enableDumpToLocal = new File("/var/log/helixspectator").canWrite();
+  public LocalFileShardMapPublisher(boolean enableDumpToLocal) {
+    this.enableDumpToLocal = enableDumpToLocal && new File("/var/log/helixspectator").canWrite();
   }
 
   @Override
-  public void publish(String jsonStringShardMapNewContent) {
+  public void publish(
+      final Set<String> validResources,
+      final List<ExternalView> externalViews,
+      final String jsonStringShardMapNewContent) {
     if (! enableDumpToLocal) {
       // doNothing()
       return;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ParallelShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ParallelShardMapPublisher.java
@@ -19,8 +19,10 @@
 package com.pinterest.rocksplicator.publisher;
 
 import com.google.common.base.Preconditions;
+import org.apache.helix.model.ExternalView;
 
 import java.util.List;
+import java.util.Set;
 
 public class ParallelShardMapPublisher<T> implements ShardMapPublisher<T> {
 
@@ -32,10 +34,12 @@ public class ParallelShardMapPublisher<T> implements ShardMapPublisher<T> {
   }
 
   @Override
-  public void publish(T shardMap) {
+  public void publish(final Set<String> validResources,
+                      final List<ExternalView> externalViews,
+                      final T shardMap) {
     for (ShardMapPublisher<T> shardMapPublisher : shardMapPublishers) {
       try {
-        shardMapPublisher.publish(shardMap);
+        shardMapPublisher.publish(validResources, externalViews, shardMap);
       } catch (Throwable throwable) {
         // Ensure that failure of one publisher doesn't effect the other
       }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ParallelShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ParallelShardMapPublisher.java
@@ -1,0 +1,44 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.publisher;
+
+import com.google.common.base.Preconditions;
+
+import java.util.List;
+
+public class ParallelShardMapPublisher<T> implements ShardMapPublisher<T> {
+
+  private final List<ShardMapPublisher<T>> shardMapPublishers;
+
+  public ParallelShardMapPublisher(final List<ShardMapPublisher<T>> shardMapPublishers) {
+    Preconditions.checkNotNull(shardMapPublishers);
+    this.shardMapPublishers = shardMapPublishers;
+  }
+
+  @Override
+  public void publish(T shardMap) {
+    for (ShardMapPublisher<T> shardMapPublisher : shardMapPublishers) {
+      try {
+        shardMapPublisher.publish(shardMap);
+      } catch (Throwable throwable) {
+        // Ensure that failure of one publisher doesn't effect the other
+      }
+    }
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisher.java
@@ -1,0 +1,27 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.publisher;
+
+public interface ShardMapPublisher<T> {
+
+  /**
+   * Publish a shardMap of type T.
+   */
+  void publish(T shardMap);
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisher.java
@@ -18,10 +18,15 @@
 
 package com.pinterest.rocksplicator.publisher;
 
+import org.apache.helix.model.ExternalView;
+
+import java.util.List;
+import java.util.Set;
+
 public interface ShardMapPublisher<T> {
 
   /**
    * Publish a shardMap of type T.
    */
-  void publish(T shardMap);
+  void publish(Set<String> validResources, List<ExternalView> externalViews, T shardMap);
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisher.java
@@ -20,13 +20,19 @@ package com.pinterest.rocksplicator.publisher;
 
 import org.apache.helix.model.ExternalView;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-public interface ShardMapPublisher<T> {
+public interface ShardMapPublisher<T> extends Closeable {
 
   /**
    * Publish a shardMap of type T.
    */
   void publish(Set<String> validResources, List<ExternalView> externalViews, T shardMap);
+
+  @Override
+  default void close() throws IOException {
+  }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisherBuilder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisherBuilder.java
@@ -59,7 +59,7 @@ public class ShardMapPublisherBuilder {
       publishers.add(new HttpPostShardMapPublisher(this.postUrl));
     }
     if (enableLocalDump) {
-      publishers.add(new LocalFileShardMapPublisher());
+      publishers.add(new LocalFileShardMapPublisher(enableLocalDump));
     }
     return new DedupingShardMapPublisher(
         new ParallelShardMapPublisher<String>(ImmutableList.copyOf(publishers)));

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisherBuilder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisherBuilder.java
@@ -1,0 +1,67 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
+package com.pinterest.rocksplicator.publisher;
+
+import com.google.common.collect.ImmutableList;
+import org.json.simple.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ShardMapPublisherBuilder {
+
+  private String postUrl = null;
+  private boolean enableLocalDump = false;
+
+  private ShardMapPublisherBuilder() {
+
+  }
+
+  public static ShardMapPublisherBuilder create() {
+    return new ShardMapPublisherBuilder();
+  }
+
+  public ShardMapPublisherBuilder withPostUrl(String postUrl) {
+    this.postUrl = postUrl;
+    return this;
+  }
+
+  public ShardMapPublisherBuilder withLocalDump() {
+    this.enableLocalDump = true;
+    return this;
+  }
+
+  public ShardMapPublisherBuilder withOutLocalDump() {
+    this.enableLocalDump = false;
+    return this;
+  }
+
+  public ShardMapPublisher<JSONObject> build() {
+    List<ShardMapPublisher<String>> publishers = new ArrayList<>();
+
+    if (postUrl != null && !postUrl.isEmpty()) {
+      publishers.add(new HttpPostShardMapPublisher(this.postUrl));
+    }
+    if (enableLocalDump) {
+      publishers.add(new LocalFileShardMapPublisher());
+    }
+    return new DedupingShardMapPublisher(
+        new ParallelShardMapPublisher<String>(ImmutableList.copyOf(publishers)));
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/TestConfigGenerator.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/TestConfigGenerator.java
@@ -14,7 +14,6 @@ import org.apache.helix.integration.task.MockTask;
 import org.apache.helix.integration.task.TaskTestBase;
 import org.apache.helix.integration.task.WorkflowGenerator;
 import org.apache.helix.model.ExternalView;
-import org.apache.helix.model.IdealState;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskCallbackContext;

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/TestConfigGenerator.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/TestConfigGenerator.java
@@ -1,5 +1,7 @@
 package com.pinterest.rocksplicator;
 
+import com.pinterest.rocksplicator.publisher.ShardMapPublisher;
+
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
@@ -26,6 +28,7 @@ import org.apache.helix.task.TaskDriver;
 import org.apache.helix.task.TaskState;
 import org.apache.helix.task.WorkflowConfig;
 
+import org.json.simple.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -192,7 +195,12 @@ public class TestConfigGenerator extends TaskTestBase {
   private class DummyGenerator extends ConfigGenerator {
 
     public DummyGenerator(String clusterName, HelixManager helixManager) {
-      super(clusterName, helixManager, "");
+      super(clusterName, helixManager, new ShardMapPublisher<JSONObject>() {
+        @Override
+        public void publish(JSONObject shardMap) {
+          // doNothing
+        }
+      });
     }
 
     @Override

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/TestConfigGenerator.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/TestConfigGenerator.java
@@ -13,6 +13,7 @@ import org.apache.helix.integration.manager.MockParticipantManager;
 import org.apache.helix.integration.task.MockTask;
 import org.apache.helix.integration.task.TaskTestBase;
 import org.apache.helix.integration.task.WorkflowGenerator;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.task.Task;
@@ -40,6 +41,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
 public class TestConfigGenerator extends TaskTestBase {
@@ -197,7 +199,10 @@ public class TestConfigGenerator extends TaskTestBase {
     public DummyGenerator(String clusterName, HelixManager helixManager) {
       super(clusterName, helixManager, new ShardMapPublisher<JSONObject>() {
         @Override
-        public void publish(JSONObject shardMap) {
+        public void publish(
+            final Set<String> validResources,
+            final List<ExternalView> externalViews,
+            final JSONObject shardMap) {
           // doNothing
         }
       });

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisherTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisherTest.java
@@ -1,0 +1,34 @@
+package com.pinterest.rocksplicator.publisher;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.apache.helix.model.ExternalView;
+import org.json.simple.JSONObject;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Set;
+
+public class DedupingShardMapPublisherTest {
+
+  @Test
+  public void testDeduping() {
+    Set<String> resources = ImmutableSet.of();
+    List<ExternalView> externalViews = ImmutableList.of();
+    JSONObject shardMapJsonObject = new JSONObject();
+
+    ShardMapPublisher<String> mockPublisher = Mockito.mock(ShardMapPublisher.class);
+
+    DedupingShardMapPublisher deDupublisher = new DedupingShardMapPublisher(mockPublisher);
+
+    shardMapJsonObject.put("resource1", new JSONObject());
+
+    deDupublisher.publish(resources, externalViews, shardMapJsonObject);
+    Mockito.verify(mockPublisher, Mockito.times(1)).publish(resources, externalViews, shardMapJsonObject.toString());
+
+    deDupublisher.publish(resources, externalViews, shardMapJsonObject);
+    Mockito.verifyNoMoreInteractions(mockPublisher);
+
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisherTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisherTest.java
@@ -1,3 +1,21 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
 package com.pinterest.rocksplicator.publisher;
 
 import static org.mockito.Mockito.mock;

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisherTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/publisher/DedupingShardMapPublisherTest.java
@@ -1,5 +1,9 @@
 package com.pinterest.rocksplicator.publisher;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.helix.model.ExternalView;
@@ -18,17 +22,20 @@ public class DedupingShardMapPublisherTest {
     List<ExternalView> externalViews = ImmutableList.of();
     JSONObject shardMapJsonObject = new JSONObject();
 
-    ShardMapPublisher<String> mockPublisher = Mockito.mock(ShardMapPublisher.class);
+    ShardMapPublisher<String> mockPublisher = mock(ShardMapPublisher.class);
 
     DedupingShardMapPublisher deDupublisher = new DedupingShardMapPublisher(mockPublisher);
 
     shardMapJsonObject.put("resource1", new JSONObject());
 
     deDupublisher.publish(resources, externalViews, shardMapJsonObject);
-    Mockito.verify(mockPublisher, Mockito.times(1)).publish(resources, externalViews, shardMapJsonObject.toString());
+    verify(mockPublisher, Mockito.times(1)).publish(resources, externalViews, shardMapJsonObject.toString());
 
     deDupublisher.publish(resources, externalViews, shardMapJsonObject);
-    Mockito.verifyNoMoreInteractions(mockPublisher);
+    verifyNoMoreInteractions(mockPublisher);
 
+    shardMapJsonObject.put("resource2", new JSONObject());
+    deDupublisher.publish(resources, externalViews, shardMapJsonObject);
+    verify(mockPublisher, Mockito.times(1)).publish(resources, externalViews, shardMapJsonObject.toString());
   }
 }

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/publisher/ParallelShardMapPublisherTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/publisher/ParallelShardMapPublisherTest.java
@@ -1,0 +1,85 @@
+package com.pinterest.rocksplicator.publisher;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.apache.helix.model.ExternalView;
+import org.json.simple.JSONObject;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ParallelShardMapPublisherTest {
+
+  @Test
+  public void testAllPublishersAreCalled() {
+    Set<String> resources = ImmutableSet.of();
+    List<ExternalView> externalViews = ImmutableList.of();
+    JSONObject shardMapJsonObject = new JSONObject();
+    shardMapJsonObject.put("resource1", new JSONObject());
+
+    ShardMapPublisher<JSONObject> mockPublisher1 = mock(ShardMapPublisher.class);
+    ShardMapPublisher<JSONObject> mockPublisher2 = mock(ShardMapPublisher.class);
+    ShardMapPublisher<JSONObject> mockPublisher3 = mock(ShardMapPublisher.class);
+    ShardMapPublisher<JSONObject> mockPublisher4 = mock(ShardMapPublisher.class);
+
+    ParallelShardMapPublisher parallelShardMapPublisher = new ParallelShardMapPublisher(
+        ImmutableList.of(mockPublisher1, mockPublisher2, mockPublisher3, mockPublisher4));
+
+    parallelShardMapPublisher.publish(resources, externalViews, shardMapJsonObject);
+
+    verify(mockPublisher1, times(1)).publish(
+        resources, externalViews, shardMapJsonObject);
+    verify(mockPublisher2, times(1)).publish(
+        resources, externalViews, shardMapJsonObject);
+    verify(mockPublisher3, times(1)).publish(
+        resources, externalViews, shardMapJsonObject);
+    verify(mockPublisher4, times(1)).publish(
+        resources, externalViews, shardMapJsonObject);
+  }
+
+  @Test
+  public void testOnePublisherDoesNotAffectOther() {
+    Set<String> resources = ImmutableSet.of();
+    List<ExternalView> externalViews = ImmutableList.of();
+    JSONObject shardMapJsonObject = new JSONObject();
+    shardMapJsonObject.put("resource1", new JSONObject());
+
+    AtomicBoolean mockPublisher1Called = new AtomicBoolean(false);
+    ShardMapPublisher<JSONObject> mockPublisher1 = spy(new ShardMapPublisher<JSONObject>() {
+      @Override
+      public void publish(Set<String> validResources,
+                          List<ExternalView> externalViews,
+                          JSONObject shardMap) {
+        mockPublisher1Called.set(true);
+        throw new RuntimeException();
+      }
+    });
+    ShardMapPublisher<JSONObject> mockPublisher2 = mock(ShardMapPublisher.class);
+    ShardMapPublisher<JSONObject> mockPublisher3 = mock(ShardMapPublisher.class);
+    ShardMapPublisher<JSONObject> mockPublisher4 = mock(ShardMapPublisher.class);
+
+    ParallelShardMapPublisher parallelShardMapPublisher = new ParallelShardMapPublisher(
+        ImmutableList.of(mockPublisher1, mockPublisher2, mockPublisher3, mockPublisher4));
+
+    parallelShardMapPublisher.publish(resources, externalViews, shardMapJsonObject);
+
+    assertTrue(mockPublisher1Called.get());
+    verify(mockPublisher1, times(1)).publish(
+        resources, externalViews, shardMapJsonObject);
+    verify(mockPublisher2, times(1)).publish(
+        resources, externalViews, shardMapJsonObject);
+    verify(mockPublisher3, times(1)).publish(
+        resources, externalViews, shardMapJsonObject);
+    verify(mockPublisher4, times(1)).publish(
+        resources, externalViews, shardMapJsonObject);
+  }
+
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/publisher/ParallelShardMapPublisherTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/publisher/ParallelShardMapPublisherTest.java
@@ -1,3 +1,21 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author Gopal Rajpurohit (grajpurohit@pinterest.com)
+//
+
 package com.pinterest.rocksplicator.publisher;
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
We want to introduce a new publisher for publishing per resource level shard_map publishing to provided zk. In order to keep the upcoming changes clean, need to refactor existing publish code.