### PR TITLE
get the highest empty level of rocksdb

### DIFF
--- a/rocksdb_admin/application_db.cpp
+++ b/rocksdb_admin/application_db.cpp
@@ -135,4 +135,17 @@ rocksdb::Status ApplicationDB::CompactRange(
   return db_->CompactRange(options, begin, end);
 }
 
+uint32_t ApplicationDB::getHighestEmptyLevel() {
+  rocksdb::ColumnFamilyMetaData cf_metadata;
+  db_->GetColumnFamilyMetaData(&cf_metadata);
+  std::vector<rocksdb::LevelMetaData>& level_metas = cf_metadata.levels;
+  std::set<uint32_t> empty_levels;
+  for (const auto& level_meta : level_metas) {
+    if (level_meta.size == 0) {
+      empty_levels.insert(level_meta.level);
+    }
+  }
+  return *empty_levels.rbegin();
+}
+
 }  // namespace admin

--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -89,6 +89,9 @@ class ApplicationDB {
   rocksdb::Status CompactRange(const rocksdb::CompactRangeOptions& options,
                                const rocksdb::Slice* begin,
                                const rocksdb::Slice* end);
+  
+  // get the highest empty level of default column family
+  uint32_t getHighestEmptyLevel();
 
   // Whether this db instance is slave
   bool IsSlave() const { return role_ == replicator::DBRole::SLAVE; }

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -1,0 +1,196 @@
+/// Copyright 2016 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @kangnan li (kangnanli@pinterest.com)
+//
+
+#include <stdlib.h>
+#include <ctime>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "boost/filesystem.hpp"
+#include "gtest/gtest.h"
+#include "rocksdb/db.h"
+#include "rocksdb/merge_operator.h"
+#include "rocksdb/sst_file_writer.h"
+#include "rocksdb/status.h"
+#include "rocksdb_admin/application_db.h"
+#include "rocksdb_replicator/rocksdb_replicator.h"
+
+namespace admin {
+
+using boost::filesystem::remove_all;
+using rocksdb::AssociativeMergeOperator;
+using rocksdb::DB;
+using rocksdb::DestroyDB;
+using rocksdb::EnvOptions;
+using rocksdb::Logger;
+using rocksdb::Options;
+using rocksdb::Slice;
+using rocksdb::SstFileWriter;
+using rocksdb::Status;
+using std::list;
+using std::make_unique;
+using std::pair;
+using std::string;
+using std::to_string;
+using std::unique_ptr;
+using std::vector;
+
+class SimpleMergeOperator : public AssociativeMergeOperator {
+public:
+  bool Merge(const Slice& key,
+             const Slice* existing_value,
+             const Slice& value,
+             std::string* new_value,
+             Logger* logger) const override {
+    if (existing_value) {
+      *new_value = existing_value->ToString();
+    }
+    *new_value += value.ToString();
+    return true;
+  }
+
+  const char* Name() const override { return "SimpleMergeOperator"; }
+};
+
+class ApplicationDBTestBase : public testing::Test {
+public:
+  ApplicationDBTestBase() {
+    static thread_local unsigned int seed = time(nullptr);
+    static string db_name = "test_db_" + to_string(rand_r(&seed));
+    // default ApplicationDB with DB.allow_ingest_behind=false
+    db_ = CleanAndOpenApplicationDB(testDir() + "/" + db_name, db_name, false);
+  }
+
+  ~ApplicationDBTestBase(){};
+
+  void createSstWithContent(const string& sst_filename, list<pair<string, string>>& key_vals) {
+    EXPECT_NO_THROW(remove_all(sst_filename));
+
+    Options options;
+    SstFileWriter sst_file_writer(EnvOptions(), options, options.comparator);
+    auto s = sst_file_writer.Open(sst_filename);
+    EXPECT_TRUE(s.ok());
+
+    list<pair<string, string>>::iterator it;
+    for (it = key_vals.begin(); it != key_vals.end(); ++it) {
+      s = sst_file_writer.Put(it->first, it->second);
+      EXPECT_TRUE(s.ok());
+    }
+
+    s = sst_file_writer.Finish();
+    EXPECT_TRUE(s.ok());
+  }
+
+  void recreateDBWithAllowIngestBehind() {
+    string name = db_name();
+    string path = db_path();
+    db_.reset(nullptr);
+
+    Options options = buildDBOptions(false);
+    auto status = DestroyDB(path, options);
+    EXPECT_TRUE(status.ok());
+
+    db_ = CleanAndOpenApplicationDB(path, name, true);
+    EXPECT_NE(db_, nullptr);
+  }
+
+  const string testDir() { return "/tmp"; }
+  const string db_name() { return db_->db_name(); }
+  const string db_path() { return testDir() + "/" + db_->db_name(); }
+
+private:
+  Options buildDBOptions(bool allow_ingest_behind) {
+    static Options options;
+    options.create_if_missing = true;
+    options.error_if_exists = true;
+    options.WAL_size_limit_MB = 100;
+    options.merge_operator = std::make_shared<SimpleMergeOperator>();
+    options.allow_ingest_behind = allow_ingest_behind;
+    return options;
+  }
+
+  unique_ptr<DB> OpenDB(const string& path, bool allow_ingest_behind) {
+    Options options = buildDBOptions(allow_ingest_behind);
+    DB* db;
+    auto status = DB::Open(options, path, &db);
+    EXPECT_TRUE(status.ok());
+    return unique_ptr<DB>(db);
+  }
+
+  unique_ptr<ApplicationDB> CleanAndOpenApplicationDB(const string& path,
+                                                      const string& db_name,
+                                                      bool allow_ingest_behind) {
+    EXPECT_NO_THROW(remove_all(path));
+    auto db = OpenDB(path, allow_ingest_behind);
+    EXPECT_TRUE(db != nullptr);
+    return make_unique<ApplicationDB>(db_name, std::move(db), replicator::DBRole::SLAVE, nullptr);
+  }
+
+public:
+  unique_ptr<ApplicationDB> db_;
+};
+
+TEST_F(ApplicationDBTestBase, GetLSMLevelInfo) {
+  // Verify: DB level=7 at new create
+  EXPECT_EQ(db_->rocksdb()->NumberLevels(), 7);
+  // level num: 0, 1, ..., 6
+  EXPECT_EQ(db_->getHighestEmptyLevel(), 6);
+
+  string sst_file1 = "/tmp/file1.sst";
+  list<pair<string, string>> sst1_content = {{"1", "1"}, {"2", "2"}};
+  createSstWithContent(sst_file1, sst1_content);
+
+  // ingest sst files, and try to read the current occupied LSM level agin
+  rocksdb::IngestExternalFileOptions ifo;
+  ifo.move_files = true;
+  ifo.allow_global_seqno = true;
+  ifo.ingest_behind = true;
+  // EXPECT_EQ(db_->rocksdb()->GetLatestSequenceNumber(), (uint64_t)0);
+  EXPECT_FALSE(db_->rocksdb()->GetOptions().allow_ingest_behind);
+  auto s = db_->rocksdb()->IngestExternalFile({sst_file1}, ifo);
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(db_->getHighestEmptyLevel(), 6);
+
+  recreateDBWithAllowIngestBehind();
+
+  ifo.ingest_behind = true;
+  EXPECT_TRUE(db_->rocksdb()->GetOptions().allow_ingest_behind);
+  s = db_->rocksdb()->IngestExternalFile({sst_file1}, ifo);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(db_->getHighestEmptyLevel(), 5);  // level6 is occupied by ingested data
+
+  // compact DB
+  rocksdb::CompactRangeOptions compact_options;
+  compact_options.change_level = false;
+  // if change_level is false (default), compacted data will move to bottommost
+  db_->rocksdb()->CompactRange(compact_options, nullptr, nullptr);
+  EXPECT_EQ(db_->getHighestEmptyLevel(), 5);
+
+  compact_options.change_level = true;
+  // if change_level is false (default), compacted data will move to bottommost
+  db_->rocksdb()->CompactRange(compact_options, nullptr, nullptr);
+  EXPECT_EQ(db_->getHighestEmptyLevel(), 6);
+}
+
+}  // namespace admin
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -25,16 +25,13 @@
 #include "boost/filesystem.hpp"
 #include "gtest/gtest.h"
 #include "rocksdb/db.h"
-#include "rocksdb/merge_operator.h"
 #include "rocksdb/sst_file_writer.h"
-#include "rocksdb/status.h"
 #include "rocksdb_admin/application_db.h"
 #include "rocksdb_replicator/rocksdb_replicator.h"
 
 namespace admin {
 
 using boost::filesystem::remove_all;
-using rocksdb::AssociativeMergeOperator;
 using rocksdb::DB;
 using rocksdb::DestroyDB;
 using rocksdb::EnvOptions;
@@ -42,7 +39,6 @@ using rocksdb::Logger;
 using rocksdb::Options;
 using rocksdb::Slice;
 using rocksdb::SstFileWriter;
-using rocksdb::Status;
 using std::list;
 using std::make_unique;
 using std::pair;
@@ -50,23 +46,6 @@ using std::string;
 using std::to_string;
 using std::unique_ptr;
 using std::vector;
-
-class SimpleMergeOperator : public AssociativeMergeOperator {
-public:
-  bool Merge(const Slice& key,
-             const Slice* existing_value,
-             const Slice& value,
-             std::string* new_value,
-             Logger* logger) const override {
-    if (existing_value) {
-      *new_value = existing_value->ToString();
-    }
-    *new_value += value.ToString();
-    return true;
-  }
-
-  const char* Name() const override { return "SimpleMergeOperator"; }
-};
 
 class ApplicationDBTestBase : public testing::Test {
 public:
@@ -120,7 +99,6 @@ private:
     options.create_if_missing = true;
     options.error_if_exists = true;
     options.WAL_size_limit_MB = 100;
-    options.merge_operator = std::make_shared<SimpleMergeOperator>();
     options.allow_ingest_behind = allow_ingest_behind;
     return options;
   }


### PR DESCRIPTION
Add a util function into applicationDB to get the highest empty level of RocksDB. 

This is useful to check readiness of backfill since Rocksdb's ingest_behind only work if the highest level is empty (ie. level6 is empty). 