### PR TITLE
Rename the Local dumped file for shardmap based on cluster name

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -18,8 +18,6 @@
 
 package com.pinterest.rocksplicator;
 
-import com.pinterest.rocksplicator.eventstore.ClientShardMapLeaderEventLogger;
-import com.pinterest.rocksplicator.eventstore.ClientShardMapLeaderEventLoggerImpl;
 import com.pinterest.rocksplicator.eventstore.ClientShardMapLeaderEventLoggerDriver;
 import com.pinterest.rocksplicator.eventstore.LeaderEventsLogger;
 import com.pinterest.rocksplicator.eventstore.LeaderEventsLoggerImpl;
@@ -30,7 +28,6 @@ import com.pinterest.rocksplicator.task.BackupTaskFactory;
 import com.pinterest.rocksplicator.task.DedupTaskFactory;
 import com.pinterest.rocksplicator.task.RestoreTaskFactory;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -437,7 +434,10 @@ public class Participant {
       ConfigGenerator configGenerator = new ConfigGenerator(
           clusterName,
           helixManager,
-          ShardMapPublisherBuilder.create().withPostUrl(postUrl).withLocalDump().build(),
+          ShardMapPublisherBuilder.create(helixManager.getClusterName())
+              .withPostUrl(postUrl)
+              .withLocalDump()
+              .build(),
           monitor,
           new ExternalViewLeaderEventsLoggerImpl(staticSpectatorLeaderEventsLogger));
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Spectator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Spectator.java
@@ -284,7 +284,10 @@ public class Spectator {
       this.configGenerator = new ConfigGenerator(
           helixManager.getClusterName(),
           helixManager,
-          ShardMapPublisherBuilder.create().withPostUrl(postUrl).withLocalDump().build(),
+          ShardMapPublisherBuilder.create(helixManager.getClusterName())
+              .withPostUrl(postUrl)
+              .withLocalDump()
+              .build(),
           monitor, new ExternalViewLeaderEventsLoggerImpl(spectatorLeaderEventsLogger));
 
       /**

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisherBuilder.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ShardMapPublisherBuilder.java
@@ -18,6 +18,7 @@
 
 package com.pinterest.rocksplicator.publisher;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.json.simple.JSONObject;
 
@@ -29,12 +30,14 @@ public class ShardMapPublisherBuilder {
   private String postUrl = null;
   private boolean enableLocalDump = false;
 
-  private ShardMapPublisherBuilder() {
+  private final String clusterName;
 
+  private ShardMapPublisherBuilder(String clusterName) {
+    this.clusterName = Preconditions.checkNotNull(clusterName);
   }
 
-  public static ShardMapPublisherBuilder create() {
-    return new ShardMapPublisherBuilder();
+  public static ShardMapPublisherBuilder create(String clusterName) {
+    return new ShardMapPublisherBuilder(clusterName);
   }
 
   public ShardMapPublisherBuilder withPostUrl(String postUrl) {
@@ -59,7 +62,7 @@ public class ShardMapPublisherBuilder {
       publishers.add(new HttpPostShardMapPublisher(this.postUrl));
     }
     if (enableLocalDump) {
-      publishers.add(new LocalFileShardMapPublisher(enableLocalDump));
+      publishers.add(new LocalFileShardMapPublisher(enableLocalDump, clusterName));
     }
     return new DedupingShardMapPublisher(
         new ParallelShardMapPublisher<String>(ImmutableList.copyOf(publishers)));


### PR DESCRIPTION
In DistrubtedSpectator environment, the spectator instances are multi-tenant. We need to separate out the name for locally dumped file for shard_map of the cluster.