### PR TITLE
[rocksdb_replicator] Add a new thrift field to identify when a leader…

### DIFF
--- a/rocksdb_replicator/thrift/replicator.thrift
+++ b/rocksdb_replicator/thrift/replicator.thrift
@@ -60,6 +60,7 @@ enum ErrorCode {
   OTHER = 0,
   SOURCE_NOT_FOUND = 1, # could not find the upstream db
   SOURCE_READ_ERROR = 2,
+  SOURCE_REMOVED = 3, # leader db has moved to a different instance
 }
 
 exception ReplicateException {


### PR DESCRIPTION
… db is moved.

We use the error code `SOURCE_NOT_FOUND` in two cases:
1. An instance has no information about the db in the replicate request.
2. An instance identifies it is no longer hostting the db requested.

Although the difference is subtle, we want to handle these two
situations differently: we would like to reset the leader only in the
first case (since a new leader might not yet be available in the second
case).

To handle this difference, I'm adding a new field to the `ErrorCode`
struct. Using the new field will be part of a subsequent PR.