### PR TITLE
Enabling DistributedSpectator with ConfigGenerator bindings

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/ConfigGenerator.java
@@ -461,7 +461,9 @@ public class ConfigGenerator extends RoutingTableProvider implements CustomCodeC
     // at the moment.
     try (AutoCloseableLock lock = new AutoCloseableLock(this.synchronizedCallbackLock)) {
       // Cleanup any remaining items.
-      externalViewLeaderEventLogger.close();
+      if (externalViewLeaderEventLogger != null) {
+        externalViewLeaderEventLogger.close();
+      }
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/DistributedSpectatorMain.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/DistributedSpectatorMain.java
@@ -34,6 +34,10 @@ import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.manager.zk.HelixManagerShutdownHook;
 import org.apache.helix.participant.StateMachineEngine;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.PatternLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,6 +176,11 @@ public class DistributedSpectatorMain {
   }
 
   public static void main(String[] args) throws Exception {
+    org.apache.log4j.Logger.getRootLogger().setLevel(Level.WARN);
+    BasicConfigurator.configure(new ConsoleAppender(
+        new PatternLayout("%d{HH:mm:ss.SSS} [%t] %-5p %30.30c - %m%n")
+    ));
+
     CommandLine cmd = processCommandLineArgs(args);
     String zkConnectString = cmd.getOptionValue(zkSvr);
     String clusterName = cmd.getOptionValue(cluster);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/monitoring/mbeans/RocksplicatorMonitor.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/monitoring/mbeans/RocksplicatorMonitor.java
@@ -19,13 +19,15 @@ public class RocksplicatorMonitor {
   private MBeanServer beanServer;
   private RocksplicatorSpectatorMonitor spectatorStatsMonitor;
   private String cluster;
+  private String instanceName;
 
   public RocksplicatorMonitor(String clusterName, String instanceName) {
-    beanServer = ManagementFactory.getPlatformMBeanServer();
-    cluster = clusterName;
+    this.beanServer = ManagementFactory.getPlatformMBeanServer();
+    this.cluster = clusterName;
+    this.instanceName = instanceName;
 
     try {
-      spectatorStatsMonitor = new RocksplicatorSpectatorMonitor(instanceName);
+      spectatorStatsMonitor = new RocksplicatorSpectatorMonitor(this.instanceName);
 
       register(spectatorStatsMonitor, getObjectName(getInstanceBeanName(instanceName)));
     } catch (Exception e) {
@@ -83,4 +85,23 @@ public class RocksplicatorMonitor {
     }
   }
 
+  public void close () {
+    try {
+      unregister(getObjectName(getInstanceBeanName(instanceName)));
+    } catch (MalformedObjectNameException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void unregister(ObjectName name) {
+    if (beanServer == null) {
+      LOG.warn("bean server is null, nothing to do");
+      return;
+    }
+    try {
+      beanServer.unregisterMBean(name);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/spectator/ConfigGeneratorClusterSpectatorFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/spectator/ConfigGeneratorClusterSpectatorFactory.java
@@ -27,7 +27,11 @@ public class ConfigGeneratorClusterSpectatorFactory implements ClusterSpectatorF
   }
 
   private String getConfigPostUri(String participantClusterName) {
-    return uriPattern.replace("[PARTICIPANT_CLUSTER]", participantClusterName);
+    if (uriPattern == null || uriPattern.isEmpty()) {
+      return null;
+    } else {
+      return uriPattern.replace("[PARTICIPANT_CLUSTER]", participantClusterName);
+    }
   }
 
   @Override

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/spectator/ConfigGeneratorClusterSpectatorFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/spectator/ConfigGeneratorClusterSpectatorFactory.java
@@ -26,15 +26,19 @@ public class ConfigGeneratorClusterSpectatorFactory implements ClusterSpectatorF
     this.uriPattern = uriPattern;
   }
 
-  private String getConfigPostUri(String clusterName) {
-    return uriPattern.replace("[PARTICIPANT_CLUSTER]", clusterName);
+  private String getConfigPostUri(String participantClusterName) {
+    return uriPattern.replace("[PARTICIPANT_CLUSTER]", participantClusterName);
   }
 
   @Override
   public ClusterSpectator createClusterSpectator(
-      String zkString, String clusterName,
-      String instanceName) {
-    return new ConfigGeneratorClusterSpectatorImpl(zkString, clusterName, instanceName,
-        getConfigPostUri(clusterName));
+      String zkServerConnectString,
+      String participantClusterName,
+      String myInstanceName) {
+    return new ConfigGeneratorClusterSpectatorImpl(
+        zkServerConnectString,
+        participantClusterName,
+        myInstanceName,
+        getConfigPostUri(participantClusterName));
   }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/spectator/ConfigGeneratorClusterSpectatorImpl.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/spectator/ConfigGeneratorClusterSpectatorImpl.java
@@ -136,8 +136,10 @@ public class ConfigGeneratorClusterSpectatorImpl implements ClusterSpectator {
   @Override
   public synchronized void release() {
     // No more notifications to config generator
-    if (this.helixManager != null && helixManager.isConnected()) {
-      this.helixManager.disconnect();
+    if (this.helixManager != null) {
+      if (helixManager.isConnected()) {
+        this.helixManager.disconnect();
+      }
       this.helixManager = null;
     }
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/spectator/ConfigGeneratorClusterSpectatorImpl.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/spectator/ConfigGeneratorClusterSpectatorImpl.java
@@ -78,7 +78,9 @@ public class ConfigGeneratorClusterSpectatorImpl implements ClusterSpectator {
       ShardMapPublisherBuilder publisherBuilder
           = ShardMapPublisherBuilder.create(this.clusterName).withLocalDump();
 
-      if (configPostUri != null && !configPostUri.isEmpty()) {
+      if (configPostUri != null &&
+          !configPostUri.isEmpty() &&
+          (configPostUri.startsWith("http://") || configPostUri.startsWith("https://"))) {
         publisherBuilder.withPostUrl(configPostUri);
       }
       this.shardMapPublisher = publisherBuilder.build();


### PR DESCRIPTION
This PR is first step in binding ConfigGenerator in DistributedSpectator to make it functionally equivalent to StandAlone and Embedded Spectator.

This PR does not include
1. Bindings for enabling LeaderEvents reporting for Leader Handoff publishing.