### PR TITLE
writeMetaData at all DB creation time

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1202,8 +1202,9 @@ void AdminHandler::async_tm_restoreDBFromS3(
     }
 
     // FIXME: restoreDBFromS3-checkpoint
-    if (!writeMetaData(request->db_name, request->s3_bucket, request->s3_backup_dir)) {
-      std::string errMsg = "RestoreDBFromS3 failed to write DBMetaData from request for " + request->db_name;
+    if (!writeMetaData(request->db_name, "", "")) {
+      // TODO: enable backup with meta for checkpoint, then, restore will writ the meta from the backup
+      std::string errMsg = "RestoreDBFromS3 failed to write DBMetaData for " + request->db_name;
       SetException(errMsg, AdminErrorCode::DB_ADMIN_ERROR, &callback);
       common::Stats::get()->Incr(kS3RestoreFailure);
       return;
@@ -1660,7 +1661,7 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
   }
 
   // FIXME: addS3SstFilestoDB
-  if (writeMetaData(request->db_name, request->s3_bucket, request->s3_path)) {
+  if (!writeMetaData(request->db_name, request->s3_bucket, request->s3_path)) {
     std::string errMsg = "AddS3SstFilesToDB failed to write DBMetaData from request for " + request->db_name;
     SetException(errMsg, AdminErrorCode::DB_ADMIN_ERROR, &callback);
     LOG(ERROR) << errMsg;

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -584,7 +584,6 @@ void AdminHandler::async_tm_addDB(
   rocksdb::Status status;
   if (request->overwrite) {
     LOG(INFO) << "Clearing DB: " << request->db_name;
-    // FIXME: addDB
     clearMetaData(request->db_name);
     status = rocksdb::DestroyDB(db_path, rocksdb_options_(segment));
     if (!OKOrSetException(status,
@@ -622,7 +621,6 @@ void AdminHandler::async_tm_addDB(
     }
   }
 
-  // FIXME: admin::AddDB
   if (!writeMetaData(request->db_name, "", "")) {
     std::string errMsg = "AddDB failed to write initial DBMetaData for " + request->db_name;
     SetException(errMsg, admin::AdminErrorCode::DB_ADMIN_ERROR, &callback);
@@ -690,7 +688,6 @@ bool AdminHandler::backupDBHelper(const std::string& db_name,
 
   if (include_meta) {
     std::string db_meta;
-    // FIXME: backupDBHelper
     const auto meta = getMetaData(db_name);
     if (!EncodeThriftStruct(meta, &db_meta)) {
       e->errorCode = AdminErrorCode::DB_ADMIN_ERROR;
@@ -781,7 +778,6 @@ bool AdminHandler::restoreDBHelper(const std::string& db_name,
       return false;
   } 
   meta.set_db_name(db_name);
-  // FIXME: restoreDB helper
   if (!writeMetaData(meta.db_name, meta.s3_bucket, meta.s3_path)) {
     e->errorCode = AdminErrorCode::DB_ADMIN_ERROR;
     e->message = "RestoreDBHelper failed to write DBMetaData from restore's app_metadata for " + meta.db_name;
@@ -1201,7 +1197,6 @@ void AdminHandler::async_tm_restoreDBFromS3(
       return;
     }
 
-    // FIXME: restoreDBFromS3-checkpoint
     if (!writeMetaData(request->db_name, "", "")) {
       // TODO: enable backup with meta for checkpoint, then, restore will writ the meta from the backup
       std::string errMsg = "RestoreDBFromS3 failed to write DBMetaData for " + request->db_name;
@@ -1388,7 +1383,6 @@ void AdminHandler::async_tm_clearDB(
   auto options = rocksdb_options_(admin::DbNameToSegment(request->db_name));
   auto db_path = FLAGS_rocksdb_dir + request->db_name;
   LOG(INFO) << "Clearing DB: " << request->db_name;
-  // FIXME: clearDB
   clearMetaData(request->db_name);
 
   if (FLAGS_enable_async_delete_dbs) {
@@ -1433,7 +1427,6 @@ void AdminHandler::async_tm_clearDB(
       return;
     }
 
-    // FIXME: clearDB with reopen db
     if (!writeMetaData(request->db_name, "", "")) {
       e.message = "ClearDB with reopen failed to write initial DBMetaData for " + request->db_name;
       callback.release()->exceptionInThread(std::move(e));
@@ -1508,7 +1501,6 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     return;
   }
 
-  // FIXME: addS3SstFilestoDB
   auto meta = getMetaData(request->db_name);
   if (meta.__isset.s3_bucket && meta.s3_bucket == request->s3_bucket &&
       meta.__isset.s3_path && meta.s3_path == request->s3_path) {
@@ -1591,7 +1583,6 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     sst_file_paths.push_back(local_path + file_name);
   }
 
-  // FIXME: addS3SstFilesToDB
   clearMetaData(request->db_name);
 
   auto segment = admin::DbNameToSegment(request->db_name);
@@ -1660,7 +1651,6 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     return;
   }
 
-  // FIXME: addS3SstFilestoDB
   if (!writeMetaData(request->db_name, request->s3_bucket, request->s3_path)) {
     std::string errMsg = "AddS3SstFilesToDB failed to write DBMetaData from request for " + request->db_name;
     SetException(errMsg, AdminErrorCode::DB_ADMIN_ERROR, &callback);
@@ -1709,7 +1699,6 @@ void AdminHandler::async_tm_startMessageIngestion(
 
   // Compare the value in local_meta_db with replay_timestamp_ms and choose
   // the latest.
-  // FIXME: startMessageIngestion
   const auto meta = getMetaData(db_name);
   replay_timestamp_ms = std::max(meta.last_kafka_msg_timestamp_ms,
                                  replay_timestamp_ms);
@@ -1885,9 +1874,7 @@ void AdminHandler::async_tm_startMessageIngestion(
     // Update meta_db with kafka message timestamp periodically.
     if (message_count % FLAGS_kafka_ts_update_interval == 0) {
       const auto timestamp_ms = message->timestamp().timestamp;
-      // FIXME: startMessgaeIngestion.kafka_watcher
       const auto meta = getMetaData(db_name);
-      // FIXME: startMessageIngestion
       if (!writeMetaData(db_name, meta.s3_bucket, meta.s3_path, timestamp_ms)) {
         LOG(ERROR) << "StartMessageIngestion failed to write DBMetaData for " << db_name;
         return;

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -584,6 +584,7 @@ void AdminHandler::async_tm_addDB(
   rocksdb::Status status;
   if (request->overwrite) {
     LOG(INFO) << "Clearing DB: " << request->db_name;
+    // FIXME: addDB
     clearMetaData(request->db_name);
     status = rocksdb::DestroyDB(db_path, rocksdb_options_(segment));
     if (!OKOrSetException(status,
@@ -619,6 +620,14 @@ void AdminHandler::async_tm_addDB(
       callback.release()->exceptionInThread(std::move(e));
       return;
     }
+  }
+
+  // FIXME: admin::AddDB
+  if (!writeMetaData(request->db_name, "", "")) {
+    std::string errMsg = "AddDB failed to write initial DBMetaData for " + request->db_name;
+    SetException(errMsg, admin::AdminErrorCode::DB_ADMIN_ERROR, &callback);
+    LOG(ERROR) << errMsg;
+    return;
   }
 
   if (!db_manager_->addDB(request->db_name,
@@ -681,6 +690,7 @@ bool AdminHandler::backupDBHelper(const std::string& db_name,
 
   if (include_meta) {
     std::string db_meta;
+    // FIXME: backupDBHelper
     const auto meta = getMetaData(db_name);
     if (!EncodeThriftStruct(meta, &db_meta)) {
       e->errorCode = AdminErrorCode::DB_ADMIN_ERROR;
@@ -771,6 +781,7 @@ bool AdminHandler::restoreDBHelper(const std::string& db_name,
       return false;
   } 
   meta.set_db_name(db_name);
+  // FIXME: restoreDB helper
   if (!writeMetaData(meta.db_name, meta.s3_bucket, meta.s3_path)) {
     e->errorCode = AdminErrorCode::DB_ADMIN_ERROR;
     e->message = "RestoreDBHelper failed to write DBMetaData from restore's app_metadata for " + meta.db_name;
@@ -1190,6 +1201,14 @@ void AdminHandler::async_tm_restoreDBFromS3(
       return;
     }
 
+    // FIXME: restoreDBFromS3-checkpoint
+    if (!writeMetaData(request->db_name, request->s3_bucket, request->s3_backup_dir)) {
+      std::string errMsg = "RestoreDBFromS3 failed to write DBMetaData from request for " + request->db_name;
+      SetException(errMsg, AdminErrorCode::DB_ADMIN_ERROR, &callback);
+      common::Stats::get()->Incr(kS3RestoreFailure);
+      return;
+    }
+
     std::string err_msg;
     if (!db_manager_->addDB(request->db_name,
                             std::unique_ptr<rocksdb::DB>(restore_db),
@@ -1368,6 +1387,7 @@ void AdminHandler::async_tm_clearDB(
   auto options = rocksdb_options_(admin::DbNameToSegment(request->db_name));
   auto db_path = FLAGS_rocksdb_dir + request->db_name;
   LOG(INFO) << "Clearing DB: " << request->db_name;
+  // FIXME: clearDB
   clearMetaData(request->db_name);
 
   if (FLAGS_enable_async_delete_dbs) {
@@ -1408,6 +1428,13 @@ void AdminHandler::async_tm_clearDB(
     auto db = GetRocksdb(db_path, options);
     if (db == nullptr) {
       e.message = "Failed to open DB: " + request->db_name;
+      callback.release()->exceptionInThread(std::move(e));
+      return;
+    }
+
+    // FIXME: clearDB with reopen db
+    if (!writeMetaData(request->db_name, "", "")) {
+      e.message = "ClearDB with reopen failed to write initial DBMetaData for " + request->db_name;
       callback.release()->exceptionInThread(std::move(e));
       return;
     }
@@ -1480,6 +1507,7 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     return;
   }
 
+  // FIXME: addS3SstFilestoDB
   auto meta = getMetaData(request->db_name);
   if (meta.__isset.s3_bucket && meta.s3_bucket == request->s3_bucket &&
       meta.__isset.s3_path && meta.s3_path == request->s3_path) {
@@ -1562,6 +1590,7 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     sst_file_paths.push_back(local_path + file_name);
   }
 
+  // FIXME: addS3SstFilesToDB
   clearMetaData(request->db_name);
 
   auto segment = admin::DbNameToSegment(request->db_name);
@@ -1630,7 +1659,14 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     return;
   }
 
-  writeMetaData(request->db_name, request->s3_bucket, request->s3_path);
+  // FIXME: addS3SstFilestoDB
+  if (writeMetaData(request->db_name, request->s3_bucket, request->s3_path)) {
+    std::string errMsg = "AddS3SstFilesToDB failed to write DBMetaData from request for " + request->db_name;
+    SetException(errMsg, AdminErrorCode::DB_ADMIN_ERROR, &callback);
+    LOG(ERROR) << errMsg;
+    return;
+  }
+  
 
   if (FLAGS_compact_db_after_load_sst) {
     auto status = db->rocksdb()->CompactRange(nullptr, nullptr);
@@ -1672,6 +1708,7 @@ void AdminHandler::async_tm_startMessageIngestion(
 
   // Compare the value in local_meta_db with replay_timestamp_ms and choose
   // the latest.
+  // FIXME: startMessageIngestion
   const auto meta = getMetaData(db_name);
   replay_timestamp_ms = std::max(meta.last_kafka_msg_timestamp_ms,
                                  replay_timestamp_ms);
@@ -1847,8 +1884,13 @@ void AdminHandler::async_tm_startMessageIngestion(
     // Update meta_db with kafka message timestamp periodically.
     if (message_count % FLAGS_kafka_ts_update_interval == 0) {
       const auto timestamp_ms = message->timestamp().timestamp;
+      // FIXME: startMessgaeIngestion.kafka_watcher
       const auto meta = getMetaData(db_name);
-      writeMetaData(db_name, meta.s3_bucket, meta.s3_path, timestamp_ms);
+      // FIXME: startMessageIngestion
+      if (!writeMetaData(db_name, meta.s3_bucket, meta.s3_path, timestamp_ms)) {
+        LOG(ERROR) << "StartMessageIngestion failed to write DBMetaData for " << db_name;
+        return;
+      } 
       LOG(INFO) << "[meta_db] Writing timestamp " << timestamp_ms
                 << " for db: " << db_name;
     }


### PR DESCRIPTION
Each Rocksplicator process has a metaDB inside its Admin Handler. It stores one entry for each DB it manages. 
For OnlineOffline/Boostrap state model, the MetaDB stores the db_name, and s3_path of the serving data. 

Here, we extend this to LeaderFollower statemodel (ie. read-write tables) as well, each DB, regardless of its statemodel:
- always have en initial entry (ie. only write db_name to meta_db) in Admin Handler's metaDB. 
- always write the s3_path to metadb if bootstrap or ingest from a s3_path
- new DB will inherit its leader's metaDAta (#450 )

note: for easy code review, I have a **FIXME** comment above each `writeMetaData` to indicate which following API it corresponds to. Will remove them when code reviewed. 

Our code is **comprehensive** to make sure all DB creation will have a `DBMetaData` write to `meta_db`:
There are 7 places in AdminHandler that a DB is DB::Open:
```
DB::open
- openMetaDB
- createDBBasedOnConfig (getRocskdbFuture) // it reload DBs from local config_shardmap when process restart
- addDB
- restoreDB (open after restore)
- restoreDBFromS3 with checkpoint
- AddS3SstFilestoDB
- clearDB with reopen
```
and 5 places in AdminHandler that a DB is added to ApplicationDBManager
```
db_manager_->addDB
- restoreDBfromS3 -checkpoint
- restoreDBHelper
- changeDBRoleAndUpstream (removeDb, then addDB; only role/upstream change, no need to update DBMetaData)
- clearDB
- addS3SstFilestoDB
```
And, we have add `writeMetaData` at 6 places, which corresponds to all places a DB::Open is called, except that AdminHandler reload the shardMap when process restart. 
```
Add DBMetadata (ie. writeMetaData)
- CreateDBBasedOnConfig (No need to writeMetaData since AdminHandler only reload the existing DB when process restart)
- admin::addDB
- restoreDB - checkpoint (write dummy DBmetaData till backup-checkpoint also backup the meta)
- restoreDBHelper (S3/hdfs)
- addS3SstFilesToDB 
- clearDB with reopen dB
- startMessageIngestion
```