### PR TITLE
support ingest behind for addS3SstFilesToDB api

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1420,9 +1420,6 @@ void AdminHandler::async_tm_clearDB(
     LOG(INFO) << "Open DB: " << request->db_name;
     admin::AdminException e;
     e.errorCode = AdminErrorCode::DB_ADMIN_ERROR;
-    if (request->__isset.allow_ingest_behind && request->allow_ingest_behind) {
-      options.allow_ingest_behind = true;
-    }
     auto db = GetRocksdb(db_path, options);
     if (db == nullptr) {
       e.message = "Failed to open DB: " + request->db_name;
@@ -1507,6 +1504,7 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     return;
   }
 
+  // it is important to check meta first to avoid double ingestion
   auto meta = getMetaData(request->db_name);
   if (meta.__isset.s3_bucket && meta.s3_bucket == request->s3_bucket &&
       meta.__isset.s3_path && meta.s3_path == request->s3_path) {
@@ -1644,10 +1642,6 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     LOG(INFO) << "Open DB: " << request->db_name;
     admin::AdminException e;
     e.errorCode = AdminErrorCode::DB_ADMIN_ERROR;
-    if (ingest_behind) {
-      // recreate DB with allow_ingest_behind to support ingest behind; default false
-      options.allow_ingest_behind = true;
-    }
     auto rocksdb_db = GetRocksdb(db_path, options);
     if (rocksdb_db == nullptr) {
       e.message = "Failed to open DB: " + request->db_name;

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1523,7 +1523,7 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     }
     if (db->getHighestEmptyLevel() != db->rocksdb()->NumberLevels() - 1) {
       // note: default num levels for DB is 7 (0, 1, ..., 6)
-      std::string errMsg = "The Lmax of DB is not empty, skipp add files " + request->db_name;
+      std::string errMsg = "The Lmax of DB is not empty, skip ingestion to " + request->db_name;
       e.message = errMsg;
       callback.release()->exceptionInThread(std::move(e));
       LOG(ERROR) << errMsg;
@@ -1612,7 +1612,8 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
       allow_overlapping_keys_segments_.find(segment) !=
       allow_overlapping_keys_segments_.end();
   // OR with the flag to make backwards compatibility
-  // If ingest to existing DB, allow overlapping keys for backfill to prevent failure
+  // It is very important to allow overlapping keys if ingest to an existing DB,
+  // and do not intend to clear the existing data
   allow_overlapping_keys =
       allow_overlapping_keys || FLAGS_rocksdb_allow_overlapping_keys;
   if (!allow_overlapping_keys) {

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1420,6 +1420,9 @@ void AdminHandler::async_tm_clearDB(
     LOG(INFO) << "Open DB: " << request->db_name;
     admin::AdminException e;
     e.errorCode = AdminErrorCode::DB_ADMIN_ERROR;
+    if (request->__isset.allow_ingest_behind && request->allow_ingest_behind) {
+      options.allow_ingest_behind = true;
+    }
     auto db = GetRocksdb(db_path, options);
     if (db == nullptr) {
       e.message = "Failed to open DB: " + request->db_name;

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -21,9 +21,9 @@
 #include <thread>
 
 #include "boost/filesystem.hpp"
-#include "common/s3util.h"
 #include "folly/SocketAddress.h"
 #include "gtest/gtest.h"
+#include "rocksdb/status.h"
 #define private public
 #include "rocksdb_admin/admin_handler.h"
 #undef private
@@ -34,6 +34,7 @@
 using admin::AddDBRequest;
 using admin::AddDBResponse;
 using admin::AddS3SstFilesToDBRequest;
+using admin::AddS3SstFilesToDBResponse;
 using admin::AdminAsyncClient;
 using admin::AdminException;
 using admin::AdminHandler;
@@ -45,6 +46,7 @@ using admin::ChangeDBRoleAndUpstreamResponse;
 using admin::CheckDBRequest;
 using admin::CheckDBResponse;
 using admin::ClearDBRequest;
+using admin::ClearDBResponse;
 using admin::CloseDBRequest;
 using admin::DBMetaData;
 using admin::RestoreDBFromS3Request;
@@ -55,6 +57,8 @@ using apache::thrift::ThriftServer;
 using apache::thrift::async::TAsyncSocket;
 using common::ThriftClientPool;
 using rocksdb::Options;
+using rocksdb::ReadOptions;
+using rocksdb::Status;
 using std::make_shared;
 using std::make_tuple;
 using std::make_unique;
@@ -76,6 +80,7 @@ DEFINE_string(s3_backup_prefix, "tmp/backup_test/admin_handler_test/",
               "The s3 key prefix for backup");
 DECLARE_string(rocksdb_dir);
 DECLARE_bool(enable_checkpoint_backup);
+DECLARE_bool(rocksdb_allow_overlapping_keys);
 
 void clearAndCreateDir(string dir_path) {
   boost::system::error_code create_err;
@@ -85,10 +90,12 @@ void clearAndCreateDir(string dir_path) {
   EXPECT_FALSE(remove_err || create_err);
 }
 
-const string generateDBName() {
+string generateRandIntAsStr() {
   static thread_local unsigned int seed = time(nullptr);
-  return "test_db_" + to_string(rand_r(&seed));
+  return to_string(rand_r(&seed));
 }
+
+const string generateDBName() { return "test_db_" + generateRandIntAsStr(); }
 
 Options getOptions(const string& segment) {
   Options options;
@@ -121,7 +128,10 @@ namespace admin {
 class AdminHandlerTestBase : public testing::Test {
  public:
   AdminHandlerTestBase() {
+    // setup local , s3 paths for test
     FLAGS_rocksdb_dir = testDir();
+    FLAGS_s3_backup_prefix =
+        FLAGS_s3_backup_prefix + testSessionIdAsStr() + "/";
 
     LOG(INFO) << "Test start, clearAndCreateDir " << testDir();
     clearAndCreateDir(testDir());
@@ -144,11 +154,14 @@ class AdminHandlerTestBase : public testing::Test {
     boost::system::error_code remove_err;
     fs::remove_all(testDir(), remove_err);
     EXPECT_FALSE(remove_err);
+    // TODO: should remove test files from S3 as well
   }
 
-  void addDBWithRole(const string db_name, const string db_role) {
+  void addDBWithRole(const string db_name, const string db_role,
+                     bool allow_ingest_behind) {
     AddDBRequest req;
     req.db_name = db_name;
+    req.set_allow_ingest_behind(allow_ingest_behind);
     req.upstream_ip = localIP();
     if (db_role == "SLAVE" || db_role == "FOLLOWER" || db_role == "NOOP") {
       req.set_db_role(db_role);
@@ -185,9 +198,52 @@ class AdminHandlerTestBase : public testing::Test {
     EXPECT_TRUE(app_db->Write(rocksdb::WriteOptions(), &batch).ok());
   }
 
+  void writeToDB(const string db_name, const string key, const string val) {
+    rocksdb::WriteBatch batch;
+    batch.Put(key, val);
+    auto app_db = db_manager_->getDB(db_name, nullptr);
+    EXPECT_TRUE(app_db->Write(rocksdb::WriteOptions(), &batch).ok());
+  }
+
+  void clearDB(const string db_name, bool reopen_db, bool allow_ingest_behind) {
+    ClearDBResponse clear_resp;
+    ClearDBRequest clear_req;
+    clear_req.db_name = db_name;
+    clear_req.set_reopen_db(reopen_db);
+    clear_req.set_allow_ingest_behind(allow_ingest_behind);
+    EXPECT_NO_THROW(clear_resp = client_->future_clearDB(clear_req).get());
+  }
+
+  void EXPECT_dbValForKey(const string db_name, const string key,
+                          const string expected_val) {
+    auto testdb_appdb = db_manager_->getDB(db_name, nullptr);
+    EXPECT_TRUE(testdb_appdb != nullptr);
+    string val;
+    auto s = testdb_appdb->Get(ReadOptions(), key, &val);
+    EXPECT_TRUE(s.ok());
+    EXPECT_EQ(val, expected_val);
+  }
+
+  void EXPECT_noValForKey(const string db_name, const string key) {
+    auto testdb_appdb = db_manager_->getDB(db_name, nullptr);
+    EXPECT_TRUE(testdb_appdb != nullptr);
+    string val;
+    auto s = testdb_appdb->Get(ReadOptions(), key, &val);
+    EXPECT_FALSE(s.ok());
+    EXPECT_EQ(s.code(), Status::Code::kNotFound);
+  }
+
   const string& testDir() {
-    static const string testDir = "/tmp/admin_handler_test/";
+    static const string testDir =
+        "/tmp/admin_handler_test/" + testSessionIdAsStr() + "/";
     return testDir;
+  }
+
+  // a random int (str) append to path to avoid collision among multiple runs of
+  // the same test
+  const string& testSessionIdAsStr() {
+    static const string testSessionIdAsStr = generateRandIntAsStr();
+    return testSessionIdAsStr;
   }
 
   const string& localIP() {
@@ -219,13 +275,165 @@ class AdminHandlerTestBase : public testing::Test {
   ApplicationDBManager* db_manager_;
 };
 
+TEST_F(AdminHandlerTestBase, AddS3SstFilesToDBTest) {
+  const string testdb = generateDBName();
+  addDBWithRole(testdb, "MASTER", false);
+  auto meta = handler_->getMetaData(testdb);
+  verifyMeta(meta, testdb, true, "", "");
+
+  string sstDir1 = FLAGS_s3_backup_prefix + "tempsst/";
+  string sstDir2 = FLAGS_s3_backup_prefix + "tempsst2/";
+
+  if (FLAGS_enable_integration_test) {
+    // not use checkpoint for db upload/download
+    {
+      EXPECT_FALSE(FLAGS_enable_checkpoint_backup);
+
+      AddS3SstFilesToDBResponse adds3_resp;
+
+      // 0st ingest from an empty s3_path -> exception
+      {
+        AddS3SstFilesToDBRequest adds3_req_emptys3path;
+        adds3_req_emptys3path.db_name = testdb;
+        adds3_req_emptys3path.s3_bucket = FLAGS_s3_bucket;
+        adds3_req_emptys3path.s3_path = sstDir1;
+        EXPECT_THROW(
+            adds3_resp =
+                client_->future_addS3SstFilesToDB(adds3_req_emptys3path).get(),
+            AdminException);
+      }
+
+      // 1st addS3 from sstDir1 -> ok
+      string sst_file1 = "/tmp/file1.sst";
+      list<pair<string, string>> sst1_content = {{"1", "1"}};
+      createSstWithContent(sst_file1, sst1_content);
+      string s3_fullpath_sst1 = sstDir1 + "/file1.sst";
+      putObjectFromLocalToS3(sst_file1, FLAGS_s3_bucket, s3_fullpath_sst1);
+
+      AddS3SstFilesToDBRequest adds3_req_sstdir1;
+      adds3_req_sstdir1.db_name = testdb;
+      adds3_req_sstdir1.s3_bucket = FLAGS_s3_bucket;
+      adds3_req_sstdir1.s3_path = sstDir1;
+
+      // 1s ingest to a new DB from a new s3_path -> ok
+      {
+        adds3_resp = client_->future_addS3SstFilesToDB(adds3_req_sstdir1).get();
+        auto meta_after_adds3 = handler_->getMetaData(testdb);
+        verifyMeta(meta_after_adds3, testdb, true, adds3_req_sstdir1.s3_bucket,
+                   adds3_req_sstdir1.s3_path);
+        EXPECT_dbValForKey(testdb, "1", "1");
+      }
+
+      // update the data at the same s3_path
+      string sst_file2 = "/tmp/file2.sst";
+      list<pair<string, string>> sst2_content = {{"2", "2"}};
+      createSstWithContent(sst_file2, sst2_content);
+      string s3_fullpath_sst2 = sstDir1 + "/file2.sst";
+      putObjectFromLocalToS3(sst_file2, FLAGS_s3_bucket, s3_fullpath_sst2);
+
+      // 2nd ingestion from ssDir1 again -> skipped
+      // Verify: addS3SstFilesToDB with same s3_path will be skipped even the
+      // data at the s3_path might have updated since last ingestion
+      {
+        EXPECT_NO_THROW(
+            adds3_resp =
+                client_->future_addS3SstFilesToDB(adds3_req_sstdir1).get());
+        auto meta_after_adds3_sames3path = handler_->getMetaData(testdb);
+        verifyMeta(meta_after_adds3_sames3path, testdb, true,
+                   adds3_req_sstdir1.s3_bucket, adds3_req_sstdir1.s3_path);
+        EXPECT_noValForKey(testdb, "2");
+      }
+
+      // 3rd ingest, ingest behind after clearDB and reopen a default DB (ie
+      // allow_ingest_behind=false) -> exception
+      {
+        adds3_req_sstdir1.set_ingest_behind(true);
+        SCOPE_EXIT { adds3_req_sstdir1.set_ingest_behind(false); };
+
+        clearDB(testdb, true, false);
+        EXPECT_THROW(
+            adds3_resp =
+                client_->future_addS3SstFilesToDB(adds3_req_sstdir1).get(),
+            AdminException);
+      }
+
+      // create a new sst a new path
+      string sst_file3 = "/tmp/file2.sst";
+      list<pair<string, string>> sst3_content = {{"3", "3"}};
+      createSstWithContent(sst_file3, sst3_content);
+      string s3_fullpath_sst3 = sstDir2 + "/file3.sst";
+      putObjectFromLocalToS3(sst_file3, FLAGS_s3_bucket, s3_fullpath_sst3);
+
+      // 4th ingest, ingest behind from ssDir1 after clearDB with reopen with
+      // allow_ingest_behind -> ok
+      // Then, ingest behind from sstDir2 will violate Lmax.empty() -> exception
+      {
+        // by default, not allow overlap, so always will recreate DB
+        EXPECT_FALSE(FLAGS_rocksdb_allow_overlapping_keys);
+
+        adds3_req_sstdir1.set_ingest_behind(true);
+        SCOPE_EXIT { adds3_req_sstdir1.set_ingest_behind(false); };
+
+        clearDB(testdb, true, true);
+        EXPECT_NO_THROW(
+            adds3_resp =
+                client_->future_addS3SstFilesToDB(adds3_req_sstdir1).get());
+
+        // violate Lmax.empty()
+        AddS3SstFilesToDBRequest adds3_req_sstdir2;
+        adds3_req_sstdir2.db_name = testdb;
+        adds3_req_sstdir2.s3_bucket = FLAGS_s3_bucket;
+        // a new s3_path is used
+        adds3_req_sstdir2.s3_path = sstDir2;
+        adds3_req_sstdir2.set_ingest_behind(true);
+        EXPECT_THROW(
+            adds3_resp =
+                client_->future_addS3SstFilesToDB(adds3_req_sstdir2).get(),
+            AdminException);
+      }
+
+      // 5th ingest ahead to existing DB from sstDir1 -> ok
+      // and, data is indeed ingested ahead
+      {
+        FLAGS_rocksdb_allow_overlapping_keys = true;
+        SCOPE_EXIT { FLAGS_rocksdb_allow_overlapping_keys = false; };
+
+        clearDB(testdb, true, true);
+        writeToDB(testdb, "1", "1_1");
+        EXPECT_NO_THROW(
+            adds3_resp =
+                client_->future_addS3SstFilesToDB(adds3_req_sstdir1).get());
+        EXPECT_dbValForKey(testdb, "1", "1");
+      }
+
+      // 6th, ingest behind to existing DB from sstDir1 -> ok
+      // and, data is indeed ingested behind
+      {
+        FLAGS_rocksdb_allow_overlapping_keys = true;
+        adds3_req_sstdir1.set_ingest_behind(true);
+        SCOPE_EXIT {
+          FLAGS_rocksdb_allow_overlapping_keys = false;
+          adds3_req_sstdir1.set_ingest_behind(false);
+        };
+
+        clearDB(testdb, true, true);
+        writeToDB(testdb, "1", "1_1");
+        EXPECT_NO_THROW(
+            adds3_resp =
+                client_->future_addS3SstFilesToDB(adds3_req_sstdir1).get());
+        EXPECT_dbValForKey(testdb, "1", "1_1");
+      }
+    }
+  }
+}
+
 TEST_F(AdminHandlerTestBase, AdminAPIsWithWriteMeta) {
   // verify: meta is written with init val (db_name, empty s3_path/bucket) at
   // addDB
-  const string testdb_1 = generateDBName();
-  addDBWithRole(testdb_1, "MASTER");
-  auto meta = handler_->getMetaData(testdb_1);
-  verifyMeta(meta, testdb_1, true, "", "");
+  const string testdb = generateDBName();
+  addDBWithRole(testdb, "MASTER", false);
+  auto meta = handler_->getMetaData(testdb);
+  verifyMeta(meta, testdb, true, "", "");
 
   if (FLAGS_enable_integration_test) {
     // use checkpoint for db upload/download
@@ -234,36 +442,36 @@ TEST_F(AdminHandlerTestBase, AdminAPIsWithWriteMeta) {
       SCOPE_EXIT { FLAGS_enable_checkpoint_backup = false; };
 
       BackupDBToS3Request backup_req;
-      backup_req.db_name = testdb_1;
+      backup_req.db_name = testdb;
       backup_req.s3_bucket = FLAGS_s3_bucket;
       backup_req.s3_backup_dir =
-          FLAGS_s3_backup_prefix + " checkpoint/" + testdb_1;
+          FLAGS_s3_backup_prefix + " checkpoint/" + testdb;
       BackupDBToS3Response backup_resp;
-      LOG(INFO) << "Backup db: " << testdb_1 << " to "
+      LOG(INFO) << "Backup db: " << testdb << " to "
                 << backup_req.s3_backup_dir;
       EXPECT_NO_THROW(backup_resp =
                           client_->future_backupDBToS3(backup_req).get());
 
       CloseDBRequest close_req;
-      close_req.db_name = testdb_1;
+      close_req.db_name = testdb;
       auto close_resp = client_->future_closeDB(close_req).get();
 
-      LOG(INFO) << "Restore db: " << testdb_1;
+      LOG(INFO) << "Restore db: " << testdb;
       RestoreDBFromS3Request restore_req;
-      restore_req.db_name = testdb_1;
+      restore_req.db_name = testdb;
       restore_req.s3_bucket = FLAGS_s3_bucket;
       restore_req.s3_backup_dir =
-          FLAGS_s3_backup_prefix + " checkpoint/" + testdb_1;
+          FLAGS_s3_backup_prefix + " checkpoint/" + testdb;
       restore_req.upstream_ip = localIP();
       restore_req.upstream_port = 8090;
       RestoreDBFromS3Response restore_resp;
       EXPECT_NO_THROW(restore_resp =
                           client_->future_restoreDBFromS3(restore_req).get());
       // the restoreDBHelper will write from an empty_meta
-      auto meta_after_restore = handler_->getMetaData(testdb_1);
-      verifyMeta(meta_after_restore, testdb_1, true, "", "");
+      auto meta_after_restore = handler_->getMetaData(testdb);
+      verifyMeta(meta_after_restore, testdb, true, "", "");
 
-      handler_->clearMetaData(testdb_1);
+      handler_->clearMetaData(testdb);
     }
 
     // not use checkpoint for db upload/download
@@ -272,64 +480,57 @@ TEST_F(AdminHandlerTestBase, AdminAPIsWithWriteMeta) {
 
       // verify: restoreDBHelper write meta
       BackupDBToS3Request backup_req;
-      backup_req.db_name = testdb_1;
+      backup_req.db_name = testdb;
       backup_req.s3_bucket = FLAGS_s3_bucket;
-      backup_req.s3_backup_dir = FLAGS_s3_backup_prefix + testdb_1;
+      backup_req.s3_backup_dir = FLAGS_s3_backup_prefix + testdb;
       BackupDBToS3Response backup_resp;
-      LOG(INFO) << "Backup db: " << testdb_1 << " to "
+      LOG(INFO) << "Backup db: " << testdb << " to "
                 << backup_req.s3_backup_dir;
       EXPECT_NO_THROW(backup_resp =
                           client_->future_backupDBToS3(backup_req).get());
 
       CloseDBRequest close_req;
-      close_req.db_name = testdb_1;
+      close_req.db_name = testdb;
       auto close_resp = client_->future_closeDB(close_req).get();
 
-      EXPECT_TRUE(handler_->clearMetaData(testdb_1));
-      auto empty_meta = handler_->getMetaData(testdb_1);
-      verifyMeta(empty_meta, testdb_1, false, "", "");
+      EXPECT_TRUE(handler_->clearMetaData(testdb));
+      auto empty_meta = handler_->getMetaData(testdb);
+      verifyMeta(empty_meta, testdb, false, "", "");
 
-      LOG(INFO) << "Restore db: " << testdb_1;
+      LOG(INFO) << "Restore db: " << testdb;
       RestoreDBFromS3Request restore_req;
-      restore_req.db_name = testdb_1;
+      restore_req.db_name = testdb;
       restore_req.s3_bucket = FLAGS_s3_bucket;
-      restore_req.s3_backup_dir = FLAGS_s3_backup_prefix + testdb_1;
+      restore_req.s3_backup_dir = FLAGS_s3_backup_prefix + testdb;
       restore_req.upstream_ip = localIP();
       restore_req.upstream_port = 8090;
       RestoreDBFromS3Response restore_resp;
       EXPECT_NO_THROW(restore_resp =
                           client_->future_restoreDBFromS3(restore_req).get());
       // the restoreDBHelper will write from an empty_meta
-      auto meta_after_restore = handler_->getMetaData(testdb_1);
-      verifyMeta(meta_after_restore, testdb_1, true, "", "");
+      auto meta_after_restore = handler_->getMetaData(testdb);
+      verifyMeta(meta_after_restore, testdb, true, "", "");
 
       // Verify: clearDB with reopen will have a DBMetaData with init val
-      EXPECT_TRUE(handler_->clearMetaData(testdb_1));
-      ClearDBRequest clear_req;
-      clear_req.db_name = testdb_1;
-      auto clear_resp = client_->future_clearDB(clear_req).get();
-      auto meta_after_clearreopen = handler_->getMetaData(testdb_1);
-      verifyMeta(meta_after_clearreopen, testdb_1, true, "", "");
+      EXPECT_TRUE(handler_->clearMetaData(testdb));
+      clearDB(testdb, true, false);
+      auto meta_after_clearreopen = handler_->getMetaData(testdb);
+      verifyMeta(meta_after_clearreopen, testdb, true, "", "");
 
       // Verify: addS3SstFilesToDB with updated meta
       string sst_file1 = "/tmp/file1.sst";
       list<pair<string, string>> sst1_content = {{"1", "1"}, {"2", "2"}};
       createSstWithContent(sst_file1, sst1_content);
-
-      std::shared_ptr<common::S3Util> s3_util =
-          common::S3Util::BuildS3Util(50, FLAGS_s3_bucket);
-      auto copy_resp = s3_util->putObject(
-          FLAGS_s3_backup_prefix + "tempsst/file1.sst", sst_file1);
-      ASSERT_TRUE(copy_resp.Error().empty())
-          << "Error happened when uploading files to S3: " + copy_resp.Error();
+      string s3_fullpath_sst1 = FLAGS_s3_backup_prefix + "tempsst/file1.sst";
+      putObjectFromLocalToS3(sst_file1, FLAGS_s3_bucket, s3_fullpath_sst1);
 
       AddS3SstFilesToDBRequest adds3_req;
-      adds3_req.db_name = testdb_1;
+      adds3_req.db_name = testdb;
       adds3_req.s3_bucket = FLAGS_s3_bucket;
       adds3_req.s3_path = FLAGS_s3_backup_prefix + "tempsst/";
       auto adds3_resp = client_->future_addS3SstFilesToDB(adds3_req).get();
-      auto meta_after_adds3 = handler_->getMetaData(testdb_1);
-      verifyMeta(meta_after_adds3, testdb_1, true, adds3_req.s3_bucket,
+      auto meta_after_adds3 = handler_->getMetaData(testdb);
+      verifyMeta(meta_after_adds3, testdb, true, adds3_req.s3_bucket,
                  adds3_req.s3_path);
     }
 
@@ -338,9 +539,9 @@ TEST_F(AdminHandlerTestBase, AdminAPIsWithWriteMeta) {
 }
 
 TEST_F(AdminHandlerTestBase, CheckDB) {
-  addDBWithRole("imp00001", "MASTER");
+  addDBWithRole("imp00001", "MASTER", false);
   auto dbs = db_manager_->getAllDBNames();
-  EXPECT_EQ(dbs.size(), (unsigned) 1);
+  EXPECT_EQ(dbs.size(), (unsigned)1);
   EXPECT_NE(std::find(dbs.begin(), dbs.end(), "imp00001"), dbs.end());
 
   CheckDBRequest req;
@@ -355,7 +556,7 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
   EXPECT_EQ(res.wal_ttl_seconds, 123);
   EXPECT_EQ(res.last_update_timestamp_ms, 0);
 
-  addDBWithRole("imp00002", "MASTER");
+  addDBWithRole("imp00002", "MASTER", false);
   dbs = db_manager_->getAllDBNames();
   EXPECT_NE(std::find(dbs.begin(), dbs.end(), "imp00002"), dbs.end());
 

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -232,7 +232,7 @@ TEST_F(ApplicationDBTestBase, GetLSMLevelInfo) {
   // Verify: DB level=7 at new create
   EXPECT_EQ(db_->rocksdb()->NumberLevels(), 7);
   // level num: 0, 1, ..., 6
-  EXPECT_EQ(db_->getHighestEmptyLevel(), 6);
+  EXPECT_EQ(db_->getHighestEmptyLevel(), (unsigned)6);
 
   string sst_file1 = "/tmp/file1.sst";
   list<pair<string, string>> sst1_content = {{"1", "1"}, {"2", "2"}};
@@ -246,7 +246,7 @@ TEST_F(ApplicationDBTestBase, GetLSMLevelInfo) {
   EXPECT_FALSE(db_->rocksdb()->GetOptions().allow_ingest_behind);
   auto s = db_->rocksdb()->IngestExternalFile({sst_file1}, ifo);
   EXPECT_FALSE(s.ok());
-  EXPECT_EQ(db_->getHighestEmptyLevel(), 6);
+  EXPECT_EQ(db_->getHighestEmptyLevel(), (unsigned)6);
 
   auto options = getDefaultOptions();
   options.allow_ingest_behind = true;
@@ -257,19 +257,19 @@ TEST_F(ApplicationDBTestBase, GetLSMLevelInfo) {
   s = db_->rocksdb()->IngestExternalFile({sst_file1}, ifo);
   EXPECT_TRUE(s.ok());
   // level6 is occupied by ingested data
-  EXPECT_EQ(db_->getHighestEmptyLevel(), 5);
+  EXPECT_EQ(db_->getHighestEmptyLevel(), (unsigned)5);
 
   // compact DB
   rocksdb::CompactRangeOptions compact_options;
   compact_options.change_level = false;
   // if change_level is false (default), compacted data will move to bottommost
   db_->rocksdb()->CompactRange(compact_options, nullptr, nullptr);
-  EXPECT_EQ(db_->getHighestEmptyLevel(), 5);
+  EXPECT_EQ(db_->getHighestEmptyLevel(), (unsigned)5);
 
   compact_options.change_level = true;
   // if change_level is false (default), compacted data will move to bottommost
   db_->rocksdb()->CompactRange(compact_options, nullptr, nullptr);
-  EXPECT_EQ(db_->getHighestEmptyLevel(), 6);
+  EXPECT_EQ(db_->getHighestEmptyLevel(), (unsigned)6);
 }
 
 }  // namespace admin

--- a/rocksdb_admin/tests/test_util.h
+++ b/rocksdb_admin/tests/test_util.h
@@ -4,8 +4,9 @@
 #include <list>
 #include <string>
 
-#include "boost/filesystem.hpp"
 #include "gtest/gtest.h"
+#include "boost/filesystem.hpp"
+#include "common/s3util.h"
 #include "rocksdb/db.h"
 #include "rocksdb/sst_file_writer.h"
 
@@ -35,4 +36,14 @@ void createSstWithContent(const string& sst_filename,
 
   s = sst_file_writer.Finish();
   EXPECT_TRUE(s.ok());
+}
+
+void putObjectFromLocalToS3(const string& local_absolute_path,
+                            const string& s3_bucket,
+                            const string& s3_fullpath) {
+  std::shared_ptr<common::S3Util> s3_util =
+      common::S3Util::BuildS3Util(50, s3_bucket);
+  auto copy_resp = s3_util->putObject(s3_fullpath, local_absolute_path);
+  ASSERT_TRUE(copy_resp.Error().empty())
+      << "Error happened when uploading files to S3: " + copy_resp.Error();
 }


### PR DESCRIPTION
API: addS3SstFilesToDB already execute ingesting sst files to DB. By default, it is ingest ahead and used for boostrap DBs for OnlineOffline/Bootstrap statemodel. 
Here, we extend this API to ingest sst files behind when request.ingest_behine=true.
This is useful when we backfill data to existing DB, we will ingest sst files behind existing data. 