### PR TITLE
[rocksdb_replicator] Reset upstream when the replication error is SOURCE_NOT_FOUND

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -5,7 +5,9 @@ AUX_SOURCE_DIRECTORY(./ COMMON_FILES)
 
 add_library(common ${COMMON_FILES})
 
-target_link_libraries(common jemalloc glog gflags ssl wangle folly aws-cpp-sdk-core aws-cpp-sdk-s3 boost_system boost_filesystem thrift thriftcpp2 jsoncpp_lib_static zstd)
+target_link_libraries(common jemalloc jvm glog gflags ssl wangle
+        folly aws-cpp-sdk-core aws-cpp-sdk-s3 boost_system
+        boost_filesystem thrift thriftcpp2 jsoncpp_lib_static zstd)
 
 add_subdirectory(rocksdb_glogger)
 add_subdirectory(stats)

--- a/common/helix_client.cpp
+++ b/common/helix_client.cpp
@@ -16,7 +16,7 @@
 // @author bol (bol@pinterest.com)
 //
 
-#include "rocksdb_admin/helix_client.h"
+#include "common/helix_client.h"
 
 #include "jni.h"
 
@@ -26,7 +26,7 @@
 
 #include "common/network_util.h"
 
-DECLARE_int32(port);
+DEFINE_int32(port, 9090, "Port of the server");
 DEFINE_string(helix_log_config_file_path, "",
     "Participant log config file path "
     "e.g: /etc/config/helix/log4j.properties");
@@ -204,7 +204,7 @@ std::string JStringToString(JNIEnv* env, jstring jstr) {
 
 } // namespace
 
-namespace admin {
+namespace common {
 
 void JoinCluster(const std::string& zk_connect_str,
                  const std::string& cluster,
@@ -306,4 +306,4 @@ std::string GetLeaderInstanceId(
     return JStringToString(env, jstr);
 }
 
-}  // namespace admin
+}  // namespace common

--- a/common/helix_client.h
+++ b/common/helix_client.h
@@ -20,7 +20,7 @@
 
 #include <string>
 
-namespace admin {
+namespace common {
 
 /*
  * Join a Helix managed cluster.
@@ -57,4 +57,4 @@ std::string GetLeaderInstanceId(
   const std::string& resource,
   const std::string& partition);
 
-}  // namespace admin
+}  // namespace common

--- a/common/segment_utils.cpp
+++ b/common/segment_utils.cpp
@@ -13,7 +13,7 @@
 /// limitations under the License.
 
 
-#include "rocksdb_admin/utils.h"
+#include "common/segment_utils.h"
 
 #include <string>
 
@@ -21,7 +21,7 @@
 
 const uint32_t kShardLength = 5;
 
-namespace admin {
+namespace common {
 
 std::string SegmentToDbName(const std::string& segment,
                             const int shard_id) {
@@ -47,4 +47,8 @@ int ExtractShardId(const std::string& db_name) {
   }
 }
 
-}  // namespace admin
+std::string DbNameToHelixPartitionName(const std::string& db_name) {
+  return DbNameToSegment(db_name) + '_' + std::to_string(ExtractShardId(db_name));
+}
+
+}  // namespace common

--- a/common/segment_utils.h
+++ b/common/segment_utils.h
@@ -1,0 +1,39 @@
+/// Copyright 2016 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+namespace common {
+/*
+ * Convert a segment name to a db name
+ */
+std::string SegmentToDbName(const std::string& segment, const int shard_id);
+/*
+ * Convert a db name to segment name
+ */
+std::string DbNameToSegment(const std::string& db_name);
+
+/*
+ * Extract the shard id from a db name
+ */
+int ExtractShardId(const std::string& db_name);
+
+/*
+ * Convert a db name (test00100) to helix partition name (test_100)
+ */
+std::string DbNameToHelixPartitionName(const std::string& db_name);
+
+}  // namespace common

--- a/common/tests/segment_utils_test.cpp
+++ b/common/tests/segment_utils_test.cpp
@@ -13,32 +13,43 @@
 /// limitations under the License.
 
 
-#include "rocksdb_admin/utils.h"
+#include "common/segment_utils.h"
 
 #include "gtest/gtest.h"
 
 TEST(SegmentToDbNameTest, Basics) {
-  EXPECT_EQ(admin::SegmentToDbName("seg", 1), "seg00001");
-  EXPECT_EQ(admin::SegmentToDbName("seg", 12345), "seg12345");
+  EXPECT_EQ(common::SegmentToDbName("seg", 1), "seg00001");
+  EXPECT_EQ(common::SegmentToDbName("seg", 12345), "seg12345");
 }
 
 TEST(DbNameToSegmentTest, Basics) {
-  EXPECT_EQ(admin::DbNameToSegment("seg00001"), "seg");
-  EXPECT_EQ(admin::DbNameToSegment("seg12345"), "seg");
-  EXPECT_EQ(admin::DbNameToSegment("seg12"), "seg12");
+  EXPECT_EQ(common::DbNameToSegment("seg00001"), "seg");
+  EXPECT_EQ(common::DbNameToSegment("seg12345"), "seg");
+  EXPECT_EQ(common::DbNameToSegment("seg12"), "seg12");
 }
 
 TEST(ExtractShardIDTest, Basics) {
   std::string db_name;
 
   db_name = "test_db00000";
-  EXPECT_EQ(admin::ExtractShardId(db_name), 0);
+  EXPECT_EQ(common::ExtractShardId(db_name), 0);
 
   db_name = "test_db00030";
-  EXPECT_EQ(admin::ExtractShardId(db_name), 30);
+  EXPECT_EQ(common::ExtractShardId(db_name), 30);
 
   db_name = "test_db";
-  EXPECT_EQ(admin::ExtractShardId(db_name), -1);
+  EXPECT_EQ(common::ExtractShardId(db_name), -1);
+}
+
+TEST(DbNameToHelixPartitionNameTest, Basics) {
+  std::string db_name;
+
+  db_name = "test_db00000";
+  EXPECT_EQ(common::DbNameToHelixPartitionName(db_name), "test_db_0");
+
+  db_name = "test_db00030";
+  EXPECT_EQ(common::DbNameToHelixPartitionName(db_name), "test_db_30");
+
 }
 
 int main(int argc, char** argv) {

--- a/examples/counter_service/counter.cpp
+++ b/examples/counter_service/counter.cpp
@@ -32,7 +32,7 @@
 #include "common/stats/stats.h"
 #include "common/stats/status_server.h"
 #include "gflags/gflags.h"
-#include "rocksdb_admin/helix_client.h"
+#include "common/helix_client.h"
 #include "thrift/lib/cpp2/server/ThriftServer.h"
 
 
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
       // e.g., "az=us-east-1a,pg=placement_group1"
       auto domain = "az=" + az + ",pg=" + (pg.empty() ? az : pg);
       LOG(INFO) << "Joining Helix cluster with domain " << domain;
-      admin::JoinCluster(FLAGS_helix_zk_connect_str,
+      common::JoinCluster(FLAGS_helix_zk_connect_str,
                          FLAGS_helix_cluster_name,
                          FLAGS_read_only_mode ? "OnlineOffline" : "MasterSlave",
                          domain,

--- a/rocksdb_admin/CMakeLists.txt
+++ b/rocksdb_admin/CMakeLists.txt
@@ -22,7 +22,7 @@ AUX_SOURCE_DIRECTORY(./ SRC_FILES)
 add_library(rocksdb_admin ${GEN_FILES} ${SRC_FILES})
 target_link_libraries(rocksdb_admin thrift thriftcpp2 rocksdb rocksdb_replicator
         rocksdb_admin_detail folly glog pthread boost_filesystem rocksdb_glogger
-        common jvm kafka_consumer rdkafka++ )
+        common kafka_consumer rdkafka++ )
 
 add_subdirectory(tests)
 add_subdirectory(detail)

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -35,6 +35,7 @@
 #include "common/network_util.h"
 #include "common/rocksdb_env_s3.h"
 #include "common/rocksdb_glogger/rocksdb_glogger.h"
+#include "common/segment_utils.h"
 #include "common/stats/stats.h"
 #include "common/thrift_router.h"
 #include "common/timer.h"
@@ -69,7 +70,7 @@ DEFINE_string(rocksdb_dir, "/tmp/",
 DEFINE_int32(num_hdfs_access_threads, 8,
              "The number of threads for backup or restore to/from HDFS");
 
-DEFINE_int32(port, 9090, "Port of the server");
+DECLARE_int32(port);
 
 DEFINE_string(shard_config_path, "",
              "Local path of file storing shard mapping for Aperture");
@@ -268,7 +269,7 @@ std::unique_ptr<::admin::ApplicationDBManager> CreateDBBasedOnConfig(
         continue;
       }
 
-      auto db_name = admin::SegmentToDbName(segment.first.c_str(), shard_id);
+      auto db_name = common::SegmentToDbName(segment.first.c_str(), shard_id);
       auto options = rocksdb_options(segment.first);
       auto db_future = GetRocksdbFuture(FLAGS_rocksdb_dir + db_name, options);
       std::unique_ptr<folly::SocketAddress> upstream_addr(nullptr);
@@ -579,7 +580,7 @@ void AdminHandler::async_tm_addDB(
     return;
   }
 
-  auto segment = admin::DbNameToSegment(request->db_name);
+  auto segment = common::DbNameToSegment(request->db_name);
   auto db_path = FLAGS_rocksdb_dir + request->db_name;
   rocksdb::Status status;
   if (request->overwrite) {
@@ -754,7 +755,7 @@ bool AdminHandler::restoreDBHelper(const std::string& db_name,
   }
 
   rocksdb::DB* rocksdb_db;
-  auto segment = admin::DbNameToSegment(db_name);
+  auto segment = common::DbNameToSegment(db_name);
   status = rocksdb::DB::Open(rocksdb_options_(segment), db_path, &rocksdb_db);
   if (!status.ok()) {
     e->errorCode = AdminErrorCode::DB_ERROR;
@@ -1181,7 +1182,7 @@ void AdminHandler::async_tm_restoreDBFromS3(
 
 
     rocksdb::DB* restore_db;
-    auto segment = admin::DbNameToSegment(request->db_name);
+    auto segment = common::DbNameToSegment(request->db_name);
     auto status = rocksdb::DB::Open(rocksdb_options_(segment), formatted_local_path, &restore_db);
     if (!status.ok()) {
       OKOrSetException(status, AdminErrorCode::DB_ERROR, &callback);
@@ -1365,7 +1366,7 @@ void AdminHandler::async_tm_clearDB(
 
   removeDB(request->db_name, nullptr);
 
-  auto options = rocksdb_options_(admin::DbNameToSegment(request->db_name));
+  auto options = rocksdb_options_(common::DbNameToSegment(request->db_name));
   auto db_path = FLAGS_rocksdb_dir + request->db_name;
   LOG(INFO) << "Clearing DB: " << request->db_name;
   clearMetaData(request->db_name);
@@ -1564,7 +1565,7 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
 
   clearMetaData(request->db_name);
 
-  auto segment = admin::DbNameToSegment(request->db_name);
+  auto segment = common::DbNameToSegment(request->db_name);
   bool allow_overlapping_keys =
       allow_overlapping_keys_segments_.find(segment) !=
       allow_overlapping_keys_segments_.end();
@@ -1693,8 +1694,8 @@ void AdminHandler::async_tm_startMessageIngestion(
   }
 
   // Kafka partition to consume is the shard id in rocksdb.
-  const auto segment = DbNameToSegment(db_name);
-  const auto partition_id = ExtractShardId(db_name);
+  const auto segment = common::DbNameToSegment(db_name);
+  const auto partition_id = common::ExtractShardId(db_name);
 
   if (partition_id == -1) {
     e.message = "Invalid db_name: " + db_name;

--- a/rocksdb_admin/utils.h
+++ b/rocksdb_admin/utils.h
@@ -22,20 +22,6 @@
 
 namespace admin {
 
-/*
- * Convert a segment name to a db name
- */
-std::string SegmentToDbName(const std::string& segment, const int shard_id);
-/*
- * Convert a db name to segment name
- */
-std::string DbNameToSegment(const std::string& db_name);
-
-/*
- * Extract the shard id from a db name
- */
-int ExtractShardId(const std::string& db_name);
-
 template <typename T>
 bool DecodeThriftStruct(const std::string& data, T* obj) {
   auto ex = folly::try_and_catch<std::exception>([data, obj]() {

--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -34,6 +34,10 @@ const std::string kReplicatorWriteBytes = "replicator_write_bytes";
 const std::string kReplicatorConnectionErrors = "replicator_connection_errors";
 const std::string kReplicatorRemoteApplicationExceptions =
   "replicator_remote_app_exceptions";
+const std::string kReplicatorRemoteApplicationExceptionsNotFound =
+  "replicator_remote_app_exceptions_source_not_found";
+const std::string kReplicatorLeaderReset =
+  "replicator_remote_app_leader_reset";
 const std::string kReplicatorGetUpdatesSinceErrors =
   "replicator_get_update_since_errors";
 const std::string kReplicatorGetUpdatesSinceMs =

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -32,7 +32,8 @@ extern const std::string kReplicatorGetUpdatesSinceErrors;
 extern const std::string kReplicatorGetUpdatesSinceMs;
 extern const std::string kReplicatorWriteMs;
 extern const std::string kReplicatorLeaderSequenceNumbersBehind;
-
+extern const std::string kReplicatorLeaderReset;
+extern const std::string kReplicatorRemoteApplicationExceptionsNotFound;
 
 // add value to metric_name. If db_name is not empty, add value to the per db
 // metric also

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -113,6 +113,7 @@ class RocksDBReplicator {
                  = nullptr);
 
     void pullFromUpstream();
+    void resetUpstream();
     using CallbackType =
       apache::thrift::HandlerCallback<std::unique_ptr<ReplicateResponse>>;
     void handleReplicateRequest(std::unique_ptr<CallbackType> callback,
@@ -127,7 +128,7 @@ class RocksDBReplicator {
     std::shared_ptr<rocksdb::DB> db_;
     folly::Executor* const executor_;
     const DBRole role_;
-    const folly::SocketAddress upstream_addr_;
+    folly::SocketAddress upstream_addr_;
     common::ThriftClientPool<ReplicatorAsyncClient>* const client_pool_;
     std::shared_ptr<ReplicatorAsyncClient> client_;
     detail::NonBlockingConditionVariable cond_var_;

--- a/rocksdb_replicator/thrift/replicator.thrift
+++ b/rocksdb_replicator/thrift/replicator.thrift
@@ -60,6 +60,10 @@ enum ErrorCode {
   OTHER = 0,
   SOURCE_NOT_FOUND = 1, # could not find the upstream db
   SOURCE_READ_ERROR = 2,
+  # upstream db was recently removed. This is an optimization to reduce reads from
+  # helix, and there is no harm if the upstream fails to distinguish between
+  # SOURCE_REMOVED and SOURCE_NOT_FOUND
+  SOURCE_REMOVED = 3,
 }
 
 exception ReplicateException {


### PR DESCRIPTION
…RCE_NOT_FOUND

This is the last diff in the task to fix replication errors on
followers. In this diff, we use the previously implemeneted function to
get the latest upstream for a follower.

Some specifics:
1. Since we do not want to overload the ZX server for external views,
only a small (right now 10) percentage of errors are querying helix.
In the rocksdb_replicator, there is already a delay in the next pull if
there is a replication error (default delay of 5 seconds). So the risk
of overloading ZK is low.
2. Add new a type of replication error: SOURCE_REMOVED. Prior to this
change, if a leader instance was aware that it was no longer hosting a
DB, it would return the same SOURCE_NOT_FOUND error. We want to
differentiate this case to further reduce load on ZK: SOURCE_REMOVED
errors are not eligible for upstream resets since a new leader might not
have been elected yet. We will rely on SOURCE_NOT_FOUND errors for
querying ZK.
3. Adding new gflags for zookeeper server string helix cluster name.
Instead of passing down the flags through a series of constructors, I'm
creating two gflags to set these values. In the service code, I will set
the values from glfags of the service. So, users of the service will be
agnostic of the new gflags.