### PR TITLE
Enable Embedded Spectator to publish zk data and Participant to download zk data to local file

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmapagent/ClusterShardMapAgent.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmapagent/ClusterShardMapAgent.java
@@ -23,10 +23,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import com.pinterest.rocksplicator.codecs.CodecException;
 import com.pinterest.rocksplicator.codecs.ZkGZIPCompressedShardMapCodec;
-<<<<<<< HEAD
 import com.pinterest.rocksplicator.codecs.ZkShardMapCodec;
-=======
->>>>>>> master
 import com.pinterest.rocksplicator.utils.ZkPathUtils;
 
 import org.apache.curator.framework.CuratorFramework;

--- a/rocksdb_admin/helix_client.cpp
+++ b/rocksdb_admin/helix_client.cpp
@@ -53,6 +53,10 @@ DEFINE_string(shard_map_zk_connect_string,
   "",
   "[Optional]: zk server storing shard_map for individual clusters");
 
+DEFINE_string(shard_map_zk_download_dir,
+  "",
+  "[Optional]: if need to download shard_map from zk. shard_map_zk_connect_string option also must be given");
+
 namespace {
 
 JNIEnv* createVM(const std::string& class_path) {
@@ -159,6 +163,10 @@ void invokeClass(JNIEnv* env,
   if (!FLAGS_shard_map_zk_connect_string.empty()) {
     arguments.push_back(std::string("--shardMapZkSvr"));
     arguments.push_back(std::string(FLAGS_shard_map_zk_connect_string));
+  }
+  if (!FLAGS_shard_map_zk_download_dir.empty()) {
+    arguments.push_back(std::string("--shardMapDownloadDir"));
+    arguments.push_back(std::string(FLAGS_shard_map_zk_download_dir));
   }
   if (FLAGS_use_s3_backup) {
     arguments.push_back(std::string("--s3Bucket"));

--- a/rocksdb_admin/helix_client.cpp
+++ b/rocksdb_admin/helix_client.cpp
@@ -49,6 +49,10 @@ DEFINE_string(handoff_client_event_history_json_shard_map_path,
   "",
   "[Optional]: path of shard_map generated from spectator in json format");
 
+DEFINE_string(shard_map_zk_connect_string,
+  "",
+  "[Optional]: zk server storing shard_map for individual clusters");
+
 namespace {
 
 JNIEnv* createVM(const std::string& class_path) {
@@ -152,6 +156,10 @@ void invokeClass(JNIEnv* env,
   arguments.push_back(std::string(domain));
   arguments.push_back(std::string("--configPostUrl"));
   arguments.push_back(std::string(config_post_url));
+  if (!FLAGS_shard_map_zk_connect_string.empty()) {
+    arguments.push_back(std::string("--shardMapZkSvr"));
+    arguments.push_back(std::string(FLAGS_shard_map_zk_connect_string));
+  }
   if (FLAGS_use_s3_backup) {
     arguments.push_back(std::string("--s3Bucket"));
     arguments.push_back(std::string(FLAGS_s3_bucket_backup));


### PR DESCRIPTION
This won't work in following scenario

If the Application  api is directly inheriting from Rockdb_Admin api, and it supports routing layer within participant cluster, then the startup sequence for the application will be

1. Create a Router (this requires shardMap)
2. Create serviceHandler (requires router)
3. Create Server routing calls to ServiceHandler (we may potentially start getting requests here)
4. Start JVM Participant which will then download the shardMap as first step, which was required in step no. 1.

Ideal scene would have been, that application service api not extend from rocksdb_admin service api and create separate servers for both..

1. Create RocksdbAdmin handler
2. Start RocksdbAdmin server routing rocksdb_admin api calls to RockdbAdmin handler (now we are ready to serve admin requests)
3. Start JVM Participant, which starts with downloading the shardMap and joins helix cluster as participant and start performing state transitions in background.
4. Wait for shardMap to be downloaded
5. Create Router (we now have shardMap)
6. Create ServiceHandler for application api
7. Create Application Server routing api calls to ServiceHandler (now we are ready to receive api calls for application)

Unfortunately... the design pattern for existing application already do not confirm to proper startup sequence.. 

Hence it is not possible to embedd zk data download logic in the embedded jvm.. Other option is to deploy the zk-shardmap download agent as a side-car with the participant cluster as well.





