### PR TITLE
Add admin test to verify APIs with Writemeta

### DIFF
--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -12,11 +12,14 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
-
 //
 // @author bol (bol@pinterest.com)
 //
 
+#include <algorithm>
+
+#include "boost/filesystem.hpp"
+#include "folly/SocketAddress.h"
 #include "gtest/gtest.h"
 #define private public
 #include "rocksdb_admin/admin_handler.h"
@@ -24,72 +27,184 @@
 #include "rocksdb_admin/gen-cpp2/Admin.h"
 #include "rocksdb_admin/utils.h"
 
+using admin::AddDBRequest;
+using admin::AddDBResponse;
 using admin::AdminAsyncClient;
 using admin::AdminException;
 using admin::AdminHandler;
 using admin::ApplicationDBManager;
+using admin::ChangeDBRoleAndUpstreamRequest;
+using admin::ChangeDBRoleAndUpstreamResponse;
 using admin::CheckDBRequest;
 using admin::CheckDBResponse;
 using admin::DBMetaData;
-using apache::thrift::async::TAsyncSocket;
 using apache::thrift::HeaderClientChannel;
+using apache::thrift::RpcOptions;
 using apache::thrift::ThriftServer;
+using apache::thrift::async::TAsyncSocket;
 using common::ThriftClientPool;
-using std::chrono::seconds;
+using rocksdb::Options;
 using std::make_shared;
 using std::make_tuple;
 using std::make_unique;
 using std::string;
-using std::this_thread::sleep_for;
 using std::thread;
 using std::tuple;
+using std::chrono::seconds;
+using std::this_thread::sleep_for;
+
+namespace fs = boost::filesystem;
 
 DECLARE_string(rocksdb_dir);
 
-std::unique_ptr<rocksdb::DB> GetTestDB(const std::string& dir) {
-  EXPECT_EQ(system(("rm -rf " + dir).c_str()), 0);
-
-  rocksdb::DB* db;
-  rocksdb::Options options;
+Options getOptions(const string& segment) {
+  Options options;
   options.create_if_missing = true;
   options.WAL_ttl_seconds = 123;
-  EXPECT_TRUE(rocksdb::DB::Open(options, dir, &db).ok());
-
-  return std::unique_ptr<rocksdb::DB>(db);
+  return options;
 }
 
-tuple<shared_ptr<AdminHandler>,
-      shared_ptr<ThriftServer>,
-      shared_ptr<thread>>
+tuple<shared_ptr<AdminHandler>, shared_ptr<ThriftServer>, shared_ptr<thread>,
+      ApplicationDBManager*>
 makeServer(uint16_t port) {
   auto db_manager = std::make_unique<ApplicationDBManager>();
-  auto db = GetTestDB("/tmp/handler_test");
-  EXPECT_TRUE(db_manager->addDB("imp00001", std::move(db),
-                                replicator::DBRole::MASTER, nullptr));
+  ApplicationDBManager* manager = db_manager.get();
 
-  db = GetTestDB("/tmp/handler_test_with_data");
-  EXPECT_TRUE(db_manager->addDB("imp00002", std::move(db),
-                                replicator::DBRole::MASTER, nullptr));
-
-  rocksdb::WriteBatch batch;
-  EXPECT_TRUE(batch.Delete("a").ok());
-  auto app_db = db_manager->getDB("imp00002", nullptr);
-  EXPECT_TRUE(app_db->Write(rocksdb::WriteOptions(), &batch).ok());
-
-  auto handler = make_shared<AdminHandler>(
-    std::move(db_manager), admin::RocksDBOptionsGeneratorType());
+  auto handler = make_shared<AdminHandler>(std::move(db_manager), getOptions);
 
   auto server = make_shared<ThriftServer>();
   server->setPort(port);
   server->setInterface(handler);
   auto t = make_shared<thread>([server, port] {
-      LOG(INFO) << "Start routing server on port " << port;
-      server->serve();
-      LOG(INFO) << "Exit routing server on port " << port;
-    });
-  return make_tuple(handler, server, move(t));
+    LOG(INFO) << "Start routing server on port " << port;
+    server->serve();
+    LOG(INFO) << "Exit routing server on port " << port;
+  });
+  return make_tuple(handler, server, move(t), manager);
 }
 
+class AdminHandlerTestBase : public testing::Test {
+ public:
+  AdminHandlerTestBase() {
+    FLAGS_rocksdb_dir = testDir();
+
+    LOG(INFO) << "Test start, new remove /tmp/meta_db and " << testDir();
+    EXPECT_EQ(std::system("rm -rf /tmp/meta_db"), 0);
+    boost::system::error_code create_err;
+    boost::system::error_code remove_err;
+    fs::remove_all(testDir(), remove_err);
+    fs::create_directories(testDir(), create_err);
+    EXPECT_FALSE(remove_err || create_err);
+
+    tie(handler_, server_, thread_, db_manager_) = makeServer(8090);
+    sleep_for(seconds(1));
+
+    pool_ = make_shared<ThriftClientPool<AdminAsyncClient>>(1);
+    client_ = pool_->getClient("127.0.0.1", 8090);
+  }
+
+  ~AdminHandlerTestBase() {
+    LOG(INFO)
+        << "Test done, now stop serer and join server thread and cleanup: "
+        << testDir();
+
+    server_->stop();
+    thread_->join();
+
+    boost::system::error_code remove_err;
+    fs::remove_all(testDir(), remove_err);
+    EXPECT_FALSE(remove_err);
+  }
+
+  void addDBWithRole(const string db_name, const string db_role) {
+    AddDBRequest req;
+    req.db_name = db_name;
+    req.upstream_ip = localIP();
+    if (db_role == "SLAVE" || db_role == "FOLLOWER" || db_role == "NOOP") {
+      req.set_db_role(db_role);
+    }
+    AddDBResponse resp;
+    EXPECT_NO_THROW(resp = client_->future_addDB(req).get());
+    if (db_role == "MASTER" || db_role == "LEADER") {
+      changeDBRoleAndUpstream(db_name, db_role, localIP());
+    }
+    LOG(INFO) << "Successfully added db: " << db_name
+              << " with role: " << db_role;
+  }
+
+  void changeDBRoleAndUpstream(const string db_name, const string new_role,
+                               const string upstream_ip) {
+    if (new_role != "MASTER" && new_role != "LEADER" && new_role != "SLAVE" &&
+        new_role != "FOLLOWER") {
+      ASSERT_FALSE(true) << "Unkownn new_role: " + new_role;
+    }
+    ChangeDBRoleAndUpstreamRequest req;
+    req.db_name = db_name;
+    req.new_role = new_role;
+    req.set_upstream_ip(upstream_ip);
+    ChangeDBRoleAndUpstreamResponse resp;
+    EXPECT_NO_THROW(resp = client_->future_changeDBRoleAndUpStream(req).get());
+    LOG(INFO) << "Successfully change db role to " << new_role
+              << ", upstreamIP " << upstream_ip;
+  }
+
+  bool deleteKeyFromDB(const string db_name, const string key) {
+    rocksdb::WriteBatch batch;
+    EXPECT_TRUE(batch.Delete(key).ok());
+    auto app_db = db_manager_->getDB(db_name, nullptr);
+    EXPECT_TRUE(app_db->Write(rocksdb::WriteOptions(), &batch).ok());
+  }
+
+  const string& testDir() {
+    static const string testDir = "/tmp/admin_handler_test/";
+    return testDir;
+  }
+
+  const string& localIP() {
+    static const string localIP = "127.0.0.1";
+    return localIP;
+  }
+
+ public:
+  shared_ptr<ThriftClientPool<AdminAsyncClient>> pool_;
+  shared_ptr<AdminAsyncClient> client_;
+  shared_ptr<AdminHandler> handler_;
+  shared_ptr<ThriftServer> server_;
+  shared_ptr<thread> thread_;
+  // this is very hacky, since db_manager is a unique_ptr inside AdminHandler
+  ApplicationDBManager* db_manager_;
+};
+
+TEST_F(AdminHandlerTestBase, CheckDB) {
+  addDBWithRole("imp00001", "MASTER");
+  auto dbs = db_manager_->getAllDBNames();
+  EXPECT_EQ(dbs.size(), 1);
+  EXPECT_NE(std::find(dbs.begin(), dbs.end(), "imp00001"), dbs.end());
+
+  CheckDBRequest req;
+  CheckDBResponse res;
+  req.db_name = "unknown_db";
+
+  EXPECT_THROW(res = client_->future_checkDB(req).get(), AdminException);
+
+  req.db_name = "imp00001";
+  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+  EXPECT_EQ(res.seq_num, 0);
+  EXPECT_EQ(res.wal_ttl_seconds, 123);
+  EXPECT_EQ(res.last_update_timestamp_ms, 0);
+
+  addDBWithRole("imp00002", "MASTER");
+  dbs = db_manager_->getAllDBNames();
+  EXPECT_NE(std::find(dbs.begin(), dbs.end(), "imp00002"), dbs.end());
+
+  deleteKeyFromDB("imp00002", "a");
+  req.db_name = "imp00002";
+  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+  EXPECT_EQ(res.seq_num, 1);
+  EXPECT_EQ(res.wal_ttl_seconds, 123);
+  // 1521000000 is 03/14/2018 @ 4:00am (UTC)
+  EXPECT_GT(res.last_update_timestamp_ms, 1521000000);
+}
 
 TEST(AdminHandlerTest, MetaData) {
   EXPECT_EQ(std::system("rm -rf /tmp/meta_db"), 0);
@@ -141,7 +256,7 @@ TEST(AdminHandlerTest, MetaData) {
   EXPECT_FALSE(meta.__isset.last_kafka_msg_timestamp_ms);
 
   // Test DBMetaData inheritance from Leader to Follower
-  // Verify write empty meta is ok && get db_name("") is also ok 
+  // Verify write empty meta is ok && get db_name("") is also ok
   DBMetaData db_meta;
   meta = handler.getMetaData(db_meta.db_name);
   EXPECT_TRUE(meta.db_name.empty());
@@ -149,65 +264,28 @@ TEST(AdminHandlerTest, MetaData) {
   EXPECT_FALSE(meta.__isset.s3_path);
 
   // verify meta is written, meta from get always has s3_path/s3_bucket isset
-  EXPECT_TRUE(handler.writeMetaData(db_meta.db_name, db_meta.s3_bucket, db_meta.s3_path));
+  EXPECT_TRUE(handler.writeMetaData(db_meta.db_name, db_meta.s3_bucket,
+                                    db_meta.s3_path));
   meta = handler.getMetaData(db_meta.db_name);
   EXPECT_TRUE(meta.db_name.empty());
   EXPECT_TRUE(meta.__isset.s3_bucket);
   EXPECT_TRUE(meta.s3_bucket.empty());
   EXPECT_TRUE(meta.__isset.s3_path);
   EXPECT_TRUE(meta.s3_path.empty());
-  
+
   EXPECT_TRUE(handler.clearMetaData(db_meta.db_name));
 
   std::string meta_from_backup = "";
   EXPECT_FALSE(DecodeThriftStruct(meta_from_backup, &meta));
   EXPECT_TRUE(meta.db_name.empty());
-  
+
   // failed decode did not impact meta's old values
   meta.set_db_name(db_name);
   EXPECT_FALSE(DecodeThriftStruct(meta_from_backup, &meta));
   EXPECT_EQ(meta.db_name, db_name);
 }
 
-TEST(AdminHandlerTest, CheckDB) {
-  EXPECT_EQ(std::system("rm -rf /tmp/meta_db"), 0);
-
-  shared_ptr<AdminHandler> handler;
-  shared_ptr<ThriftServer> server;
-  shared_ptr<thread> thread;
-  tie(handler, server, thread) = makeServer(8090);
-  sleep_for(seconds(1));
-
-
-  ThriftClientPool<AdminAsyncClient> pool(1);
-  auto client = pool.getClient("127.0.0.1", 8090);
-
-  CheckDBRequest req;
-  CheckDBResponse res;
-  req.db_name = "unknown_db";
-
-  EXPECT_THROW(res = client->future_checkDB(req).get(), AdminException);
-
-  req.db_name = "imp00001";
-  EXPECT_NO_THROW(res = client->future_checkDB(req).get());
-  EXPECT_EQ(res.seq_num, 0);
-  EXPECT_EQ(res.wal_ttl_seconds, 123);
-  EXPECT_EQ(res.last_update_timestamp_ms, 0);
-
-  req.db_name = "imp00002";
-  EXPECT_NO_THROW(res = client->future_checkDB(req).get());
-  EXPECT_EQ(res.seq_num, 1);
-  EXPECT_EQ(res.wal_ttl_seconds, 123);
-  // 1521000000 is 03/14/2018 @ 4:00am (UTC)
-  EXPECT_GT(res.last_update_timestamp_ms, 1521000000);
-
-  server->stop();
-  thread->join();
-}
-
 int main(int argc, char** argv) {
-  FLAGS_rocksdb_dir = "/tmp/";
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -26,23 +26,21 @@
 #include "gflags/gflags.h"
 #include "gtest/gtest.h"
 #include "rocksdb/db.h"
-#include "rocksdb/sst_file_writer.h"
 #include "rocksdb_admin/application_db.h"
+#include "rocksdb_admin/tests/test_util.h"
 #include "rocksdb_replicator/rocksdb_replicator.h"
 
-DEFINE_bool(log_to_stdout, false, "Enable output some assisting logs to stdout");
+DEFINE_bool(log_to_stdout, false,
+            "Enable output some assisting logs to stdout");
 
 namespace admin {
 
 using boost::filesystem::remove_all;
 using rocksdb::DB;
 using rocksdb::DestroyDB;
-using rocksdb::EnvOptions;
 using rocksdb::FlushOptions;
-using rocksdb::Logger;
 using rocksdb::Options;
 using rocksdb::Slice;
-using rocksdb::SstFileWriter;
 using rocksdb::WriteOptions;
 using std::cout;
 using std::endl;
@@ -58,7 +56,7 @@ using std::chrono::seconds;
 using std::this_thread::sleep_for;
 
 class ApplicationDBTestBase : public testing::Test {
-public:
+ public:
   ApplicationDBTestBase() {
     static thread_local unsigned int seed = time(nullptr);
     db_name_ = "test_db_" + to_string(rand_r(&seed));
@@ -71,27 +69,10 @@ public:
 
   ~ApplicationDBTestBase(){};
 
-  void createSstWithContent(const string& sst_filename, list<pair<string, string>>& key_vals) {
-    EXPECT_NO_THROW(remove_all(sst_filename));
-
-    Options options;
-    SstFileWriter sst_file_writer(EnvOptions(), options, options.comparator);
-    auto s = sst_file_writer.Open(sst_filename);
-    ASSERT_TRUE(s.ok()) << s.ToString();
-
-    list<pair<string, string>>::iterator it;
-    for (it = key_vals.begin(); it != key_vals.end(); ++it) {
-      s = sst_file_writer.Put(it->first, it->second);
-      ASSERT_TRUE(s.ok()) << s.ToString();
-    }
-
-    s = sst_file_writer.Finish();
-    ASSERT_TRUE(s.ok()) << s.ToString();
-  }
-
   int numTableFilesAtLevel(int level) {
     std::string p;
-    db_->rocksdb()->GetProperty("rocksdb.num-files-at-level" + std::to_string(level), &p);
+    db_->rocksdb()->GetProperty(
+        "rocksdb.num-files-at-level" + std::to_string(level), &p);
     return atoi(p.c_str());
   }
 
@@ -117,8 +98,8 @@ public:
     auto status = DB::Open(options, db_path_, &db);
     ASSERT_TRUE(status.ok()) << status.ToString();
     ASSERT_TRUE(db != nullptr);
-    db_ = make_unique<ApplicationDB>(
-        db_name_, shared_ptr<DB>(db), replicator::DBRole::SLAVE, nullptr);
+    db_ = make_unique<ApplicationDB>(db_name_, shared_ptr<DB>(db),
+                                     replicator::DBRole::SLAVE, nullptr);
   }
 
   void DestroyAndReopen(const Options& options) {
@@ -147,7 +128,7 @@ public:
     return options;
   }
 
-public:
+ public:
   unique_ptr<ApplicationDB> db_;
   string db_name_;
   string db_path_;
@@ -188,12 +169,13 @@ TEST_F(ApplicationDBTestBase, SetOptionsDisableEnableAutoCompaction) {
   if (FLAGS_log_to_stdout) {
     cout << "Level Stats Right After Flush 1st sst: \n" << levelStats() << endl;
   }
-  // After flush 1st sst into L0, an auto compaction will be triggered. Ideally, we should wait the
-  // for compaction complete. But, the API is not avail. Thus, here we wait for 1s for compaction
-  // finish
+  // After flush 1st sst into L0, an auto compaction will be triggered. Ideally,
+  // we should wait the for compaction complete. But, the API is not avail.
+  // Thus, here we wait for 1s for compaction finish
   sleep_for(seconds(1));
   if (FLAGS_log_to_stdout) {
-    cout << "Level Stats After Wait(1s) for Compaction: \n" << levelStats() << endl;
+    cout << "Level Stats After Wait(1s) for Compaction: \n"
+         << levelStats() << endl;
   }
   EXPECT_EQ(numTableFilesAtLevel(0), 0);
   EXPECT_EQ(numTableFilesAtLevel(1), 1);
@@ -206,7 +188,8 @@ TEST_F(ApplicationDBTestBase, SetOptionsDisableEnableAutoCompaction) {
   db_->rocksdb()->Flush(FlushOptions());
   sleep_for(seconds(1));  // wait for 1s for compaction finish if exist
   if (FLAGS_log_to_stdout) {
-    cout << "Level Stats after flush a 2nd sst, with auto compaction disabled: \n"
+    cout << "Level Stats after flush a 2nd sst, with auto compaction disabled: "
+            "\n"
          << levelStats() << endl;
   }
   EXPECT_EQ(numTableFilesAtLevel(0), 1);
@@ -217,7 +200,8 @@ TEST_F(ApplicationDBTestBase, SetOptionsDisableEnableAutoCompaction) {
   db_->rocksdb()->Flush(FlushOptions());
   sleep_for(seconds(1));  // wait for 1s for compaction finish if exist
   if (FLAGS_log_to_stdout) {
-    cout << "Level Stats after flush a 3rd sst, with auto compaction disabled: \n"
+    cout << "Level Stats after flush a 3rd sst, with auto compaction disabled: "
+            "\n"
          << levelStats() << endl;
   }
   EXPECT_EQ(numTableFilesAtLevel(0), 2);
@@ -226,18 +210,21 @@ TEST_F(ApplicationDBTestBase, SetOptionsDisableEnableAutoCompaction) {
   EXPECT_EQ(numCompactPending(), 1);
 
   // Verify the compaction continue after enable auto compaction again.
-  // in db.h, it claims that EnableAutoCompaction will first set options and then schedule
-  // a flush/compaction; but, the impl only has the 1st step of setting options.
+  // in db.h, it claims that EnableAutoCompaction will first set options and
+  // then schedule a flush/compaction; but, the impl only has the 1st step of
+  // setting options.
   // (https://github.com/facebook/rocksdb/blob/cf160b98e1a9bd7b45f115337a923e6b6da7d9c2/db/db_impl/db_impl_compaction_flush.cc#L2142).
   // db_->rocksdb()->EnableAutoCompaction({db_->rocksdb()->DefaultColumnFamily()});
   // from our test, SetOptions deliver expected result.
   db_->rocksdb()->SetOptions({{"disable_auto_compactions", "false"}});
   sleep_for(seconds(1));  // wait for 1s for compaction finish if exist
   if (FLAGS_log_to_stdout) {
-    cout << "Level Stats after enable auto compaction again \n" << levelStats() << endl;
+    cout << "Level Stats after enable auto compaction again \n"
+         << levelStats() << endl;
   }
   EXPECT_EQ(numTableFilesAtLevel(0), 0);
-  EXPECT_EQ(numTableFilesAtLevel(1), 2);  // the two sst at L0 will merge into 1 at L1
+  // the two sst at L0 will merge into 1 at L1
+  EXPECT_EQ(numTableFilesAtLevel(1), 2);
   EXPECT_EQ(numCompactPending(), 0);
 }
 
@@ -269,7 +256,8 @@ TEST_F(ApplicationDBTestBase, GetLSMLevelInfo) {
   EXPECT_TRUE(db_->rocksdb()->GetOptions().allow_ingest_behind);
   s = db_->rocksdb()->IngestExternalFile({sst_file1}, ifo);
   EXPECT_TRUE(s.ok());
-  EXPECT_EQ(db_->getHighestEmptyLevel(), 5);  // level6 is occupied by ingested data
+  // level6 is occupied by ingested data
+  EXPECT_EQ(db_->getHighestEmptyLevel(), 5);
 
   // compact DB
   rocksdb::CompactRangeOptions compact_options;

--- a/rocksdb_admin/tests/test_util.h
+++ b/rocksdb_admin/tests/test_util.h
@@ -1,0 +1,38 @@
+
+
+#include <stdlib.h>
+#include <list>
+#include <string>
+
+#include "boost/filesystem.hpp"
+#include "gtest/gtest.h"
+#include "rocksdb/db.h"
+#include "rocksdb/sst_file_writer.h"
+
+using boost::filesystem::remove_all;
+using rocksdb::EnvOptions;
+using rocksdb::Logger;
+using rocksdb::Options;
+using rocksdb::SstFileWriter;
+using std::list;
+using std::pair;
+using std::string;
+
+void createSstWithContent(const string& sst_filename,
+                          list<pair<string, string>>& key_vals) {
+  EXPECT_NO_THROW(remove_all(sst_filename));
+
+  Options options;
+  SstFileWriter sst_file_writer(EnvOptions(), options, options.comparator);
+  auto s = sst_file_writer.Open(sst_filename);
+  EXPECT_TRUE(s.ok());
+
+  list<pair<string, string>>::iterator it;
+  for (it = key_vals.begin(); it != key_vals.end(); ++it) {
+    s = sst_file_writer.Put(it->first, it->second);
+    EXPECT_TRUE(s.ok());
+  }
+
+  s = sst_file_writer.Finish();
+  EXPECT_TRUE(s.ok());
+}


### PR DESCRIPTION
This change add Unit/Integration tests for several Admin Handler APIS: AddDB, closeDB, backupToS3, restoreFromS3, addS3SstFilesToDB, and verify all the MetaData is written to meta_db in the expected way. 

- This pull request refactor the sst creation function into a test_util.h from #463 
- this  pull request also test/verify all the changes in #467 