### PR TITLE
add ingestTask(factory) to support ingest data with helix task framework

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -26,6 +26,7 @@ import com.pinterest.rocksplicator.monitoring.mbeans.RocksplicatorMonitor;
 import com.pinterest.rocksplicator.publisher.ShardMapPublisherBuilder;
 import com.pinterest.rocksplicator.task.BackupTaskFactory;
 import com.pinterest.rocksplicator.task.DedupTaskFactory;
+import com.pinterest.rocksplicator.task.IngestTaskFactory;
 import com.pinterest.rocksplicator.task.RestoreTaskFactory;
 
 import org.apache.commons.cli.CommandLine;
@@ -370,6 +371,8 @@ public class Participant {
           .put("Backup", new BackupTaskFactory(clusterName, port, useS3Backup, s3BucketName));
       taskFactoryRegistry
           .put("Restore", new RestoreTaskFactory(clusterName, port, useS3Backup, s3BucketName));
+      taskFactoryRegistry.put(
+          "Ingest", new IngestTaskFactory(clusterName, instanceName.split("_")[0], port, s3Bucket));
     } else if (stateModelType.equals("LeaderFollower;Task")) {
       stateModelType = "LeaderFollower";
       stateModelFactory = new LeaderFollowerStateModelFactory(instanceName.split("_")[0],
@@ -380,6 +383,8 @@ public class Participant {
           .put("Backup", new BackupTaskFactory(clusterName, port, useS3Backup, s3BucketName));
       taskFactoryRegistry
           .put("Restore", new RestoreTaskFactory(clusterName, port, useS3Backup, s3BucketName));
+      taskFactoryRegistry.put(
+          "Ingest", new IngestTaskFactory(clusterName, instanceName.split("_")[0], port, s3Bucket));
     } else if (stateModelType.equals("Task")) {
       taskFactoryRegistry
           .put("Dedup", new DedupTaskFactory(clusterName, port, useS3Backup, s3BucketName));

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/IngestTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/IngestTask.java
@@ -1,0 +1,180 @@
+/// Copyright 2017 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author kangnanli (kangnanli@pinterest.com)
+//
+package com.pinterest.rocksplicator.task;
+
+import com.pinterest.rocksplicator.Utils;
+
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.UserContentStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ingest sst files from cloud to a local DB (ingest ahead or behind). Currently, only support
+ * ingest from S3 (could extend to support HDFS)
+ */
+public class IngestTask extends UserContentStore implements Task {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IngestTask.class);
+
+  private HelixAdmin admin;
+  private final String taskCluster;
+  private final String partitionName;
+  private final String job;
+  private final boolean ingest_behind;
+  private final String host;
+  private final int adminPort;
+  private final int downloadLimitMbs;
+  private final String partitionStorePath;
+  private final String s3Bucket;
+  private final TaskConfig taskConfig;
+
+  public IngestTask(HelixAdmin admin, String taskCluster, String partitionName, String job,
+                    boolean ingest_behind, String host, int adminPort, int downloadLimitMbs,
+                    String s3Bucket,
+                    String partitionStorePath, TaskConfig taskConfig) {
+    this.admin = admin;
+    this.taskCluster = taskCluster;
+    this.partitionName = partitionName;
+    this.job = job;
+    this.ingest_behind = ingest_behind;
+    this.host = host;
+    this.adminPort = adminPort;
+    this.downloadLimitMbs = downloadLimitMbs;
+    this.s3Bucket = s3Bucket;
+    this.partitionStorePath = partitionStorePath;
+    this.taskConfig = taskConfig;
+  }
+
+  /**
+   * Execute the task.
+   *
+   * @return A {@link TaskResult} object indicating the status of the task and any additional
+   *         context information that can be interpreted by the specific {@link Task}
+   *         implementation.
+   */
+  @Override
+  public TaskResult run() {
+    String dbName = Utils.getDbName(partitionName);
+    if (partitionStorePath.isEmpty()) {
+      String errMsg = String.format(
+          "Cancel the task, partitionStorePath is not provided from job command config map. "
+              + "taskConfig=%s",
+          taskConfig.toString());
+      LOG.error(errMsg);
+      return new TaskResult(TaskResult.Status.CANCELED, errMsg);
+    }
+
+    try {
+      String resourceName = dbName.substring(0, dbName.length() - 5);
+      ExternalView view = admin.getResourceExternalView(taskCluster, resourceName);
+      Map<String, String> stateMap = view.getStateMap(partitionName);
+      List<String> errMsgs = new ArrayList<>();
+      if (stateMap.size() != 0) {
+        if (stateMap.containsValue("SLAVE") || stateMap.containsValue("MASTER")
+            || stateMap.containsValue("FOLLOWER") || stateMap.containsValue("LEADER")) {
+          int numReplica = stateMap.size();
+          int numSuccIngestReplica = 0;
+          for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
+            String hostPort = instanceNameAndRole.getKey();
+            String dbRole = instanceNameAndRole.getValue();
+            String dbHost = hostPort.split("_")[0];
+            int dbPort = Integer.parseInt(hostPort.split("_")[1]);
+
+            LOG.error(String.format(
+                "IngestTask run to ingest partition: %s from partitionStorePath: %s to instance: "
+                    + "%s, "
+                    + "role: %s. Other info {taskCluster: %s, job: %s, RpcFrom: %s_%d, "
+                    + "taskConfig=%s}",
+                partitionName, partitionStorePath, hostPort, dbRole, taskCluster, job, host,
+                adminPort, taskConfig.toString()));
+
+            try {
+              executeIngest(dbHost, dbPort, dbName, ingest_behind, downloadLimitMbs, s3Bucket,
+                  partitionStorePath);
+              numSuccIngestReplica++;
+            } catch (Exception e) {
+              String errMsg =
+                  String.format("Ingestion failed on %s. errMsg=%s.", host, e.getMessage());
+              errMsgs.add(errMsg);
+              LOG.error(
+                  String.format("%s. stacktrack=%s", errMsg, Arrays.toString(e.getStackTrace())));
+            }
+          }
+          if (numSuccIngestReplica != numReplica) {
+            throw new RuntimeException(String.format(
+                "Not all replica successfully execute ingestion, %s out of %s return success. "
+                    + "errMsgs=[%s]",
+                numSuccIngestReplica, numReplica, String.join(", ", errMsgs)));
+          } else {
+            LOG.info("Successfully ingest to all replicas of " + partitionName);
+          }
+        } else {
+          throw new RuntimeException(
+              "Skip ingest due to no Master/Slave or Leader/Follower replica found for partition: "
+                  + partitionName);
+        }
+      } else {
+        throw new RuntimeException(
+            "Skip ingest due to empty stateMap got from resource externalView for partition: "
+                + partitionName);
+      }
+    } catch (Exception e) {
+      String errMsg = String.format("Task ingest failed. errMsg=%s. stacktrack=%s. taskConfig=%s.",
+          e.getMessage(), Arrays.toString(e.getStackTrace()), taskConfig.toString());
+      LOG.error(errMsg);
+      return new TaskResult(TaskResult.Status.FAILED, errMsg);
+    }
+
+    return new TaskResult(TaskResult.Status.COMPLETED, "IngestTask is completed!");
+  }
+
+  protected void executeIngest(String host, int port, String dbName, boolean ingest_behind,
+                               int downloadLimitMbs, String s3Bucket, String partitionStorePath)
+      throws RuntimeException {
+    try {
+      Utils.ingestFromS3(
+          host, port, dbName, ingest_behind, downloadLimitMbs, s3Bucket, partitionStorePath);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Signals the task to stop execution. The task implementation should carry out any clean up
+   * actions that may be required and return from the {@link #run()} method.
+   *
+   * with default TaskStateModel, "cancel()" invoked by
+   * {@link org.apache.helix.task.TaskRunner #cancel()} during state transitions:
+   * running->stopped /task_aborted /dropped /init, and during
+   * {@link org.apache.helix.task.TaskStateModel #reset()}
+   */
+  @Override
+  public void cancel() {
+    LOG.error(String.format("IngestTask cancelled. taskConfig=%s", taskConfig.toString()));
+  }
+}

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/IngestTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/IngestTaskFactory.java
@@ -1,0 +1,136 @@
+/// Copyright 2017 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author kangnanli (kangnanli@pinterest.com)
+//
+package com.pinterest.rocksplicator.task;
+
+import com.pinterest.rocksplicator.Utils;
+
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskCallbackContext;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * An implementation of {@link TaskFactory} that create Tasks upon ingest-job launching.
+ *
+ * This class takes in {@param adminPort}, {@param cluster}, from
+ * {@link com.pinterest.rocksplicator.Participant} to create tasks to backup local db to cloud.
+ **
+ * Upon Task creation, configs inherited from job configs JobCommandConfigMap: INGEST_BEHIND,
+ * whether instruct to ingest data ahead or behind existing data; RESOURCE_STORE_PATH, the s3 path
+ * for the whole version of the segment data, e.g. "<cluster>/<seg>/1596739476/", which will further
+ * append the suffix for the specific partition to buidl the <s3_path> for the partition ingestion
+ * request, e.g. "<cluster>/<seg>/1596739476/part-%05d-"; (optional) DOWNLOAD_LIMIT_MBS, specify
+ * download limit by mbs.
+ */
+public class IngestTaskFactory implements TaskFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IngestTaskFactory.class);
+
+  private final String cluster;
+  private final String host;
+  private final int adminPort;
+  private String s3Bucket;
+
+  private static final int DEFAULT_DOWNLOAD_LIMIT_MBS = 64;
+
+  public IngestTaskFactory(String cluster, String host, int adminPort, String s3Bucket) {
+    this.cluster = cluster;
+    this.host = host;
+    this.adminPort = adminPort;
+    this.s3Bucket = s3Bucket;
+  }
+
+  /**
+   * Returns a {@link Task} instance.
+   *
+   * @param context Contextual information for the task, including task and job configurations
+   */
+  @Override
+  public Task createNewTask(TaskCallbackContext context) {
+    HelixAdmin admin = context.getManager().getClusterManagmentTool();
+
+    TaskConfig taskConfig = context.getTaskConfig();
+    JobConfig jobConfig = context.getJobConfig();
+    String job = jobConfig.getJobId();
+
+    String targetPartition = taskConfig.getTargetPartition();
+    boolean ingest_behind = true;
+    String resourceStorePath = null;
+    int downloadLimitMbs = DEFAULT_DOWNLOAD_LIMIT_MBS;
+
+    try {
+      Map<String, String> jobCmdMap = jobConfig.getJobCommandConfigMap();
+      if (jobCmdMap != null && !jobCmdMap.isEmpty()) {
+        if (jobCmdMap.containsKey("INGEST_BEHIND")) {
+          ingest_behind = Boolean.parseBoolean(jobCmdMap.get("INGEST_BEHIND"));
+        }
+        if (jobCmdMap.containsKey("S3_BUCKET")) {
+          // by default, use the S3Bucket of the FLAGS_s3_bucket_backup
+          s3Bucket = jobCmdMap.get("S3_BUCKET");
+        }
+        if (jobCmdMap.containsKey("RESOURCE_STORE_PATH")) {
+          resourceStorePath = jobCmdMap.get("RESOURCE_STORE_PATH");
+        }
+        if (jobCmdMap.containsKey("DOWNLOAD_LIMIT_MBS")) {
+          downloadLimitMbs = Integer.parseInt(jobCmdMap.get("DOWNLOAD_LIMIT_MBS"));
+        }
+      }
+
+      if (targetPartition == null || resourceStorePath == null) {
+        throw new RuntimeException(String.format(
+            "Failed to get required configs from job/task config, targetPartition: %s, "
+                + "resourceStorePath: %s",
+            targetPartition, resourceStorePath));
+      }
+    } catch (NumberFormatException e) {
+      LOG.error(String.format(
+          "Failed to parse configs from job/task configs, use defaults downloadLimitMbs: %d. "
+              + "errMsg=%s. stacktrace=%s",
+          DEFAULT_DOWNLOAD_LIMIT_MBS, e.getMessage(), Arrays.toString(e.getStackTrace())));
+    } catch (Exception e) {
+      LOG.error(String.format("Failed to createNewTask. taskConfig=%s. errMsg=%s. stacktrace=%s",
+          taskConfig.toString(), e.getMessage(), Arrays.toString(e.getStackTrace())));
+      return null;
+    }
+
+    LOG.error(
+        String.format("Create Task for cluster: %s, targetPartition: %s from job: %s to execute at "
+                + "host: %s, port: %d. {taskCreationTime: %d, taskConfig: %s}",
+            cluster, targetPartition, job, host, adminPort, System.currentTimeMillis(),
+            taskConfig.toString()));
+
+    return getTask(admin, cluster, targetPartition, job, ingest_behind, host, adminPort,
+        downloadLimitMbs, s3Bucket, resourceStorePath + Utils.getS3PartPrefix(targetPartition),
+        taskConfig);
+  }
+
+  protected Task getTask(HelixAdmin admin, String cluster, String targetPartition, String job,
+                         boolean ingest_behind, String host, int port, int downloadLimitMbs,
+                         String s3Bucket,
+                         String partitionStorePath, TaskConfig taskConfig) {
+    return new IngestTask(admin, cluster, targetPartition, job, ingest_behind, host, port,
+        downloadLimitMbs, s3Bucket, partitionStorePath, taskConfig);
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestIngestTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestIngestTaskFactory.java
@@ -1,0 +1,300 @@
+package com.pinterest.rocksplicator.task;
+
+import com.pinterest.rocksplicator.Utils;
+
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.TestHelper;
+import org.apache.helix.integration.manager.MockParticipantManager;
+import org.apache.helix.integration.task.TaskTestBase;
+import org.apache.helix.participant.StateMachineEngine;
+import org.apache.helix.task.JobConfig;
+import org.apache.helix.task.JobContext;
+import org.apache.helix.task.Task;
+import org.apache.helix.task.TaskConfig;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskFactory;
+import org.apache.helix.task.TaskResult;
+import org.apache.helix.task.TaskState;
+import org.apache.helix.task.TaskStateModelFactory;
+import org.apache.helix.task.TaskUtil;
+import org.apache.helix.task.Workflow;
+import org.apache.helix.task.WorkflowConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestIngestTaskFactory extends TaskTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestIngestTaskFactory.class);
+
+  // default test resource used by TaskSynchronizedTestBase
+  private static final String TEST_RESOURCE = "TestDB";
+  private static final String JOB_COMMAND = "DummyCommand";
+  private static final int NUM_JOB = 1;
+  private static final int NUM_TASK_PER_JOB = 1;
+  private static final int NUM_TASK = NUM_JOB * NUM_TASK_PER_JOB;
+  private Map<String, String> _jobCommandMap;
+
+  private static final String fakeS3Bucket = "pinterest-fake-bucket";
+  private static final String fakeRequestS3Bucket = "pinterest-fake-req-bucket";
+
+  private final CountDownLatch allTasksReady = new CountDownLatch(NUM_TASK);
+  private final CountDownLatch adminReady = new CountDownLatch(1);
+
+  // local variables to store job/task execution context for verification use only
+  private Set<String> instanceNames;
+  private Set<String> ingestedPartitions;
+  // how many times "executeIngest" called
+  private AtomicInteger numExecuteIngest = new AtomicInteger(0);
+
+  @Override
+  protected void startParticipant(String zkAddr, int i) {
+    final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
+    instanceNames.add(instanceName);
+    Map<String, TaskFactory> taskFactoryReg = new HashMap<String, TaskFactory>();
+    taskFactoryReg.put("Ingest",
+        new DummyIngestTaskFactory(CLUSTER_NAME, instanceName.split("_")[0],
+            Integer.parseInt(instanceName.split("_")[1]), fakeS3Bucket));
+    this._participants[i] = new MockParticipantManager(zkAddr, this.CLUSTER_NAME, instanceName);
+    StateMachineEngine stateMachine = this._participants[i].getStateMachineEngine();
+    stateMachine.registerStateModelFactory(
+        "Task", new TaskStateModelFactory(this._participants[i], taskFactoryReg));
+    this._participants[i].syncStart();
+  }
+
+  @BeforeClass
+  public void beforeClass() throws Exception {
+    // this will setup a cluster with 5 hosts; a resource "TestDB" with 20 partitions, 3 RF.
+    _jobCommandMap = new HashMap<>();
+    instanceNames = new HashSet<>();
+    ingestedPartitions = new HashSet<>();
+    numExecuteIngest.set(0);
+    super.beforeClass();
+  }
+
+  @BeforeMethod
+  public void setUp(Method m) throws Exception {
+    String workflowName = m.getName();
+    Workflow.Builder workflowBuilder = new Workflow.Builder(workflowName);
+    WorkflowConfig.Builder configBuilder = new WorkflowConfig.Builder(workflowName);
+    configBuilder.setAllowOverlapJobAssignment(true);
+    workflowBuilder.setWorkflowConfig(configBuilder.build());
+
+    // Create 2 jobs with 2 Backup Tasks each
+    for (int i = 0; i < NUM_JOB; i++) {
+      String jobName = "JOB" + i;
+
+      _jobCommandMap.put("S3_BUCKET", fakeRequestS3Bucket);
+      _jobCommandMap.put("RESOURCE_STORE_PATH", "/test_cloud/");
+      _jobCommandMap.put("INGEST_BEHIND", "true");
+      _jobCommandMap.put("DOWNLOAD_LIMIT_MBS", "30");
+
+      List<TaskConfig> taskConfigs = new ArrayList<>();
+      for (int j = 0; j < NUM_TASK_PER_JOB; ++j) {
+        Map<String, String> taskConfigMap = new HashMap<>();
+        taskConfigMap.put("TASK_TARGET_PARTITION", String.format("%s_%d", TEST_RESOURCE, j));
+        ingestedPartitions.add(String.format("%s_%d", TEST_RESOURCE, j));
+        taskConfigs.add(new TaskConfig("Ingest", taskConfigMap));
+      }
+
+      JobConfig.Builder jobConfigBulider = new JobConfig.Builder()
+          .setCommand(JOB_COMMAND)
+          .addTaskConfigs(taskConfigs)
+          .setJobCommandConfigMap(_jobCommandMap);
+      workflowBuilder.addJob(jobName, jobConfigBulider);
+    }
+
+    // Start the workflow and wait for all tasks started
+    _driver.start(workflowBuilder.build());
+    allTasksReady.await();
+
+    adminReady.countDown();
+    _driver.pollForWorkflowState(workflowName, TaskState.COMPLETED);
+  }
+
+  @AfterMethod
+  public void cleanUp(Method m) throws Exception {
+    _jobCommandMap.clear();
+    instanceNames.clear();
+    ingestedPartitions.clear();
+    numExecuteIngest.set(0);
+  }
+
+  @Test
+  public void testIngestTaskFactoryCreateNewTaskWithPassedConfigs() throws Exception {
+    String workflowName = TestHelper.getTestMethodName();
+
+    Assert.assertEquals(_driver.getWorkflowConfig(workflowName).getWorkflowId(), workflowName);
+
+    for (int i = 0; i < NUM_JOB; i++) {
+      String jobName = "JOB" + i;
+      String namespacedJobName = TaskUtil.getNamespacedJobName(workflowName, jobName);
+      JobConfig jobConfig = _driver.getJobConfig(namespacedJobName);
+
+      // Verify Job confgis: when task cmd is provided; job_cmd remained as dummy, but, in reality,
+      // task_cmd is executed
+      Assert.assertEquals(jobConfig.getCommand(), JOB_COMMAND);
+      Assert.assertEquals(jobConfig.getJobCommandConfigMap(), _jobCommandMap);
+
+      // Verify task context
+      // each task send out 3 rpcs to the 3 replica of the same partition
+      Assert.assertEquals(numExecuteIngest.get(), NUM_TASK * 3);
+
+      Set<String> taskTargetParts = new HashSet<>();
+      for (Map.Entry<String, TaskConfig> entry : jobConfig.getTaskConfigMap().entrySet()) {
+        String taskId = entry.getKey();
+        TaskConfig taskConfig = entry.getValue();
+        int taskPartitionId = getTaskPartitionIdFromTaskConfig(_driver, namespacedJobName, taskId);
+
+        Assert.assertEquals(taskConfig.getCommand(), "Ingest");
+        Assert.assertEquals(taskConfig.getId(), taskId);
+        taskTargetParts.add(taskConfig.getTargetPartition());
+
+        Assert.assertEquals(
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("taskCluster"),
+            CLUSTER_NAME);
+        Assert.assertEquals(
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("s3Bucket"),
+            fakeRequestS3Bucket);
+        Assert.assertTrue(instanceNames.contains(
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("instance")));
+        Assert.assertEquals(
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("dbName"),
+            Utils.getDbName(taskConfig.getTargetPartition()));
+        Assert.assertEquals(
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("ingest_behind"),
+            jobConfig.getJobCommandConfigMap().get("INGEST_BEHIND"));
+        Assert.assertEquals(
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("downloadLimitMbs"),
+            jobConfig.getJobCommandConfigMap().get("DOWNLOAD_LIMIT_MBS"));
+        Assert.assertEquals(
+            _driver.getTaskUserContentMap(workflowName, jobName, String.valueOf(taskPartitionId))
+                .get("partitionStorePath"),
+            jobConfig.getJobCommandConfigMap().get("RESOURCE_STORE_PATH")
+                + Utils.getS3PartPrefix(taskConfig.getTargetPartition()));
+      }
+
+      Assert.assertEquals(taskTargetParts, ingestedPartitions);
+    }
+  }
+
+  // helper funct to get the <taskParititionId>, e.g. 0, 1, ..., from taskId, e.g.
+  // 428b8f5a-fd5a-4c44-ab7e-a353980941dd
+  int getTaskPartitionIdFromTaskConfig(TaskDriver driver, String namespacedJobName, String taskId) {
+    JobContext jobContext = _driver.getJobContext(namespacedJobName);
+    Map<String, Integer> taskIdPartitionMap = jobContext.getTaskIdPartitionMap();
+    return taskIdPartitionMap.get(taskId);
+  }
+
+  //*****************************************************
+  // dummy TaskFactory, Task to limit testing scope
+  //
+  // Varied behavior based on specific testing class:
+  // - populate Task level userStore
+  //****************************************************/
+
+  private class DummyIngestTaskFactory extends IngestTaskFactory {
+
+    public DummyIngestTaskFactory(String cluster, String host, int adminPort, String s3Bucket) {
+      super(cluster, host, adminPort, s3Bucket);
+    }
+
+    @Override
+    protected Task getTask(HelixAdmin admin, String cluster, String targetPartition, String job,
+                           boolean ingest_behind, String host, int port, int downloadLimitMbs,
+                           String s3Bucket,
+                           String partitionStorePath, TaskConfig taskConfig) {
+      return new TestIngestTaskFactory.DummyIngestTask(admin, cluster, targetPartition, job,
+          ingest_behind, host, port, downloadLimitMbs, s3Bucket, partitionStorePath, taskConfig);
+    }
+  }
+
+  private class DummyIngestTask extends IngestTask {
+
+    public DummyIngestTask(HelixAdmin admin, String taskCluster, String partitionName, String job,
+                           boolean ingest_behind, String host, int adminPort, int downloadLimitMbs,
+                           String s3Bucket,
+                           String partitionStorePath, TaskConfig taskConfig) {
+      super(admin, taskCluster, partitionName, job, ingest_behind, host, adminPort,
+          downloadLimitMbs, s3Bucket, partitionStorePath, taskConfig);
+    }
+
+    @Override
+    public TaskResult run() {
+      allTasksReady.countDown();
+      try {
+        adminReady.await();
+      } catch (Exception e) {
+        return new TaskResult(TaskResult.Status.FATAL_FAILED, e.getMessage());
+      }
+
+      try {
+        String taskCluster = readPrivateSuperClassStringField("taskCluster");
+        String bucket = readPrivateSuperClassStringField("s3Bucket");
+        putUserContent("taskCluster", taskCluster, Scope.TASK);
+        putUserContent("s3Bucket", bucket, Scope.TASK);
+      } catch (Exception e) {
+        LOG.error(
+            "Failed to read super class's private filed or fail to pur userStore" + e.getMessage());
+      }
+
+      try {
+        super.run();
+      } catch (Exception e) {
+        LOG.error("Failed to execute IngestTask run" + e.getMessage());
+      }
+
+      return new TaskResult(TaskResult.Status.COMPLETED, "");
+    }
+
+    @Override
+    protected void executeIngest(String host, int port, String dbName, boolean ingest_behind,
+                                 int downloadLimitMbs, String s3Bucket, String partitionStorePath)
+        throws RuntimeException {
+      numExecuteIngest.incrementAndGet();
+      try {
+        putUserContent("instance", String.format("%s_%d", host, port), Scope.TASK);
+        putUserContent("dbName", dbName, Scope.TASK);
+        putUserContent("ingest_behind", String.valueOf(ingest_behind), Scope.TASK);
+        putUserContent("downloadLimitMbs", String.valueOf(downloadLimitMbs), Scope.TASK);
+        putUserContent("partitionStorePath", partitionStorePath, Scope.TASK);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public void cancel() {}
+
+    // helper function for testing
+    // java refection: http://tutorials.jenkov.com/java-reflection/private-fields-and-methods.html
+
+    private String readPrivateSuperClassStringField(String fieldName) throws Exception {
+      Class<?> clazz = getClass().getSuperclass();
+      Field field = clazz.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return (String) field.get(this);
+    }
+  }
+}

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestRestoreTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestRestoreTaskFactory.java
@@ -54,7 +54,7 @@ public class TestRestoreTaskFactory extends TaskTestBase {
   @Override
   protected void startParticipant(String zkAddr, int i) {
     final String instanceName = PARTICIPANT_PREFIX + "_" + (_startPort + i);
-    Map<String, TaskFactory> taskFactoryReg = new HashMap();
+    Map<String, TaskFactory> taskFactoryReg = new HashMap<>();
     taskFactoryReg.put("Restore", new TestRestoreTaskFactory.DummyRestoreTaskFactory(CLUSTER_NAME,
         Integer.parseInt(instanceName.split("_")[1]), true, fakeS3Bucket));
     this._participants[i] = new MockParticipantManager(zkAddr, this.CLUSTER_NAME, instanceName);

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1524,6 +1524,12 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     LOG(INFO) << "Already hosting " << meta.s3_bucket << "/" << meta.s3_path;
     callback->result(AddS3SstFilesToDBResponse());
     return;
+  } else {
+    LOG(INFO) << folly::stringPrintf(
+        "Current meta, s3_bucket: %s, s3_path: %s. Update with, s3_bucket: %s, "
+        "s3_path: %s",
+        meta.s3_bucket.c_str(), meta.s3_path.c_str(),
+        request->s3_bucket.c_str(), request->s3_path.c_str());
   }
 
   bool ingest_behind = request->__isset.ingest_behind && request->ingest_behind;


### PR DESCRIPTION
This change added ingestTask(Factory) into rocksplicator, specifically, it adds 3 files:
- ingestTaskFactory, which create ingestTask based on helixJobConfigs, which is created through helixRest api to helix-zoookeeper. The helixJobConfigs contain info: which s3_path of the ingested data, whether ingest_behind, ... 
- ingestTask, which is the unit to execute the ingestion. It get the externalView of the resource, since 1 partition will have 1 task, then each Task manage the ingestion to all the replicas of the same partition (ie. 3 replicas). The actual execution will be cpp code `AddS3SstfilesToDB`.
- TestIingestTaskFactory, test logic inside above two files. 

others are formatter change due to clang-format. We will introduce a checkfile later to unify the style. 