### PR TITLE
add optional to retrieve dbmeta and dboptions from CheckDB

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -26,6 +26,7 @@
 #include <thread>
 #include <unordered_set>
 #include <vector>
+#include <map>
 
 #include "boost/filesystem.hpp"
 #include "common/identical_name_thread_factory.h"
@@ -1267,6 +1268,18 @@ void AdminHandler::async_tm_checkDB(
         response.set_last_update_timestamp_ms(extractor.ms);
       }
     }
+  }
+
+  // TODO: get options as str for specified optionField
+
+  if (request->__isset.include_meta) {
+    auto meta = getMetaData(request->db_name);
+    std::map<std::string, std::string> metas;
+    metas["s3_bucket"] = meta.s3_bucket;
+    metas["s3_path"] = meta.s3_path;
+    metas["last_kafka_msg_timestamp_ms"] = std::to_string(meta.last_kafka_msg_timestamp_ms);
+    response.db_metas = metas;
+    response.__isset.db_metas = true;
   }
 
   callback->result(response);

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -136,6 +136,10 @@ struct CloseDBResponse {
 struct CheckDBRequest {
   # the DB to check
   1: required string db_name,
+  # retrieve DB's option values for specified option names
+  2: optional list<string> option_names,
+  # if true, get the DBMetaData of the db
+  3: optional bool include_meta,
 }
 
 struct CheckDBResponse {
@@ -147,6 +151,8 @@ struct CheckDBResponse {
   3: optional i64 last_update_timestamp_ms = 0,
   # if the DB is Master
   4: optional bool is_master = false,
+  5: optional map<string, string> options,
+  6: optional map<string, string> db_metas,
 }
 
 struct ChangeDBRoleAndUpstreamRequest {

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -572,10 +572,11 @@ TEST_F(AdminHandlerTestBase, AdminAPIsWithWriteMeta) {
 }
 
 TEST_F(AdminHandlerTestBase, CheckDB) {
-  addDBWithRole("imp00001", "MASTER");
+  const string testdb1 = generateDBName();
+  addDBWithRole(testdb1, "MASTER");
   auto dbs = db_manager_->getAllDBNames();
   EXPECT_EQ(dbs.size(), (unsigned)1);
-  EXPECT_NE(std::find(dbs.begin(), dbs.end(), "imp00001"), dbs.end());
+  EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb1), dbs.end());
 
   CheckDBRequest req;
   CheckDBResponse res;
@@ -583,23 +584,43 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
 
   EXPECT_THROW(res = client_->future_checkDB(req).get(), AdminException);
 
-  req.db_name = "imp00001";
+  req.db_name = testdb1;
   EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
   EXPECT_EQ(res.seq_num, 0);
   EXPECT_EQ(res.wal_ttl_seconds, 123);
   EXPECT_EQ(res.last_update_timestamp_ms, 0);
+  EXPECT_FALSE(res.__isset.db_metas);
 
-  addDBWithRole("imp00002", "MASTER");
+  const string testdb2 = generateDBName();
+  addDBWithRole(testdb2, "MASTER");
   dbs = db_manager_->getAllDBNames();
-  EXPECT_NE(std::find(dbs.begin(), dbs.end(), "imp00002"), dbs.end());
+  EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb2), dbs.end());
 
-  deleteKeyFromDB("imp00002", "a");
-  req.db_name = "imp00002";
+  deleteKeyFromDB(testdb2, "a");
+  req.db_name = testdb2;
   EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
   EXPECT_EQ(res.seq_num, 1);
   EXPECT_EQ(res.wal_ttl_seconds, 123);
   // 1521000000 is 03/14/2018 @ 4:00am (UTC)
   EXPECT_GT(res.last_update_timestamp_ms, 1521000000);
+
+  // verify: checkDB get metadata
+  const string testdb3 = generateDBName();
+  addDBWithRole(testdb3, "MASTER");
+  auto meta = handler_->getMetaData(testdb3);
+  verifyMeta(meta, testdb3, true, "", "");
+
+  // write fake DBMetadata for <testdb3>
+  handler_->writeMetaData(testdb3, "fakes3bucket", "fakes3path");
+  meta = handler_->getMetaData(testdb3);
+  verifyMeta(meta, testdb3, true, "fakes3bucket", "fakes3path");
+
+  req.db_name = testdb3;
+  req.set_include_meta(true);
+  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+  EXPECT_TRUE(res.__isset.db_metas);
+  EXPECT_EQ(res.db_metas["s3_bucket"], "fakes3bucket");
+  EXPECT_EQ(res.db_metas["s3_path"], "fakes3path");
 }
 
 TEST(AdminHandlerTest, MetaData) {


### PR DESCRIPTION
Two changes to CheckDBRequest:
- We can expose the DBMetadata from CheckDB request. 
- - usage: know which data version is serving by retrieve its DBMetadata
- Also, enable retrieve specified DBOptions field. 
- - usage: know the DB options.allow_ingest_behind before even ingest the data to avoid ingest to DB does not support ingest behind. 
