### PR TITLE
enable CheckDB to return DB properties

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1291,6 +1291,20 @@ void AdminHandler::async_tm_checkDB(
     response.__isset.db_metas = true;
   }
 
+  if (request->__isset.property_names && !request->property_names.empty()) {
+    std::map<std::string, std::string> properties;
+    for (const auto& p : request->property_names) {
+      std::string p_val;
+      if (db->GetProperty(p, &p_val)) {
+        properties[p] = p_val;
+      } else {
+        LOG(ERROR) << "Failed to getProperty for " << p;
+      }
+    }
+    response.properties = properties;
+    response.__isset.properties = true;
+  }
+
   callback->result(response);
 }
 
@@ -1549,7 +1563,7 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
       callback.release()->exceptionInThread(std::move(e));
       return;
     }
-    if (db->getHighestEmptyLevel() != db->rocksdb()->NumberLevels() - 1) {
+    if (!db->DBLmaxEmpty()) {
       // note: default num levels for DB is 7 (0, 1, ..., 6)
       std::string errMsg = "The Lmax of DB is not empty, skip ingestion to " + request->db_name;
       e.message = errMsg;

--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -12,7 +12,6 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
-
 #pragma once
 
 #include <string>
@@ -29,6 +28,15 @@ namespace admin {
 // along with basic data operations(read/write)
 class ApplicationDB {
  public:
+
+  struct Properties {
+    // "applicationdb.num-levels" - return string of the configured level of DB
+    static const std::string kNumLevels;
+    // "applicationdb.highest-empty-level" - return string of the highest empty
+    // level number
+    static const std::string kHighestEmptyLevel;
+  };
+
   // Create a ApplicationDB instance
   // db_name:       (IN) name of this db instance
   // db:            (IN) shared pointer of rocksdb instance
@@ -97,8 +105,9 @@ class ApplicationDB {
                                        const rocksdb::Options& options,
                                        const std::string& delimiter = ";  ");
 
-  // get the highest empty level of default column family
-  uint32_t getHighestEmptyLevel();
+  bool GetProperty(const rocksdb::Slice& property, std::string* value);
+
+  bool DBLmaxEmpty();
 
   // Whether this db instance is slave
   bool IsSlave() const { return role_ == replicator::DBRole::SLAVE; }
@@ -120,6 +129,9 @@ class ApplicationDB {
   ~ApplicationDB();
 
  private:
+  // get the highest empty level of default column family
+  uint32_t getHighestEmptyLevel();
+
   const std::string db_name_;
   std::shared_ptr<rocksdb::DB> db_;
 

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -140,6 +140,8 @@ struct CheckDBRequest {
   2: optional list<string> option_names,
   # if true, get the DBMetaData of the db
   3: optional bool include_meta,
+  # get DB's properties
+  4: optional list<string> property_names,
 }
 
 struct CheckDBResponse {
@@ -153,6 +155,7 @@ struct CheckDBResponse {
   4: optional bool is_master = false,
   5: optional map<string, string> options,
   6: optional map<string, string> db_metas,
+  7: optional map<string, string> properties,
 }
 
 struct ChangeDBRoleAndUpstreamRequest {

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -24,7 +24,9 @@
 #include "boost/filesystem.hpp"
 #include "folly/SocketAddress.h"
 #include "gtest/gtest.h"
+#include "rocksdb/options.h"
 #include "rocksdb/status.h"
+#include "rocksdb_admin/application_db.h"
 #define private public
 #include "rocksdb_admin/admin_handler.h"
 #undef private
@@ -59,6 +61,7 @@ using apache::thrift::RpcOptions;
 using apache::thrift::ThriftServer;
 using apache::thrift::async::TAsyncSocket;
 using common::ThriftClientPool;
+using rocksdb::FlushOptions;
 using rocksdb::Options;
 using rocksdb::ReadOptions;
 using rocksdb::Status;
@@ -212,6 +215,12 @@ class AdminHandlerTestBase : public testing::Test {
     batch.Put(key, val);
     auto app_db = db_manager_->getDB(db_name, nullptr);
     EXPECT_TRUE(app_db->Write(rocksdb::WriteOptions(), &batch).ok());
+  }
+
+  void flushDB(const string db_name) {
+    auto app_db = db_manager_->getDB(db_name, nullptr);
+    auto s = app_db->rocksdb()->Flush(FlushOptions());
+    EXPECT_TRUE(s.ok());
   }
 
   void clearDB(const string db_name) {
@@ -403,7 +412,7 @@ TEST_F(AdminHandlerTestBase, AddS3SstFilesToDBTest) {
 
       // 4th ingest, ingest behind from ssDir1 after clearDB with reopen with
       // allow_ingest_behind -> ok
-      // Then, ingest behind from sstDir2 will violate Lmax.empty() -> exception
+      // Then, ingest behind from sstDir2 will violate Lmax.empty()->exception
       {
         FLAGS_test_db_create_with_allow_ingest_behind = true;
         // by default, not allow overlap, so always will recreate DB
@@ -615,6 +624,7 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
     EXPECT_EQ(res.wal_ttl_seconds, 123);
     EXPECT_EQ(res.last_update_timestamp_ms, 0);
     EXPECT_FALSE(res.__isset.db_metas);
+    EXPECT_FALSE(res.__isset.properties);
   }
 
   // Verify checkDB from existed DB
@@ -706,6 +716,46 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
       EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
       EXPECT_EQ(res.options["allow_ingest_behind"], "true");
     }
+  }
+
+  const string app_p_not_define = "applicationdb.not-defined-property";
+  const string rocksdb_p_not_define = "rocksdb.not-defined-property";
+  const string p_not_define = "not-defined-property";
+  const string num_files_at_l0 =
+      rocksdb::DB::Properties::kNumFilesAtLevelPrefix + "0";
+  vector<string> property_names{{ApplicationDB::Properties::kNumLevels,
+                                 ApplicationDB::Properties::kHighestEmptyLevel,
+                                 app_p_not_define, num_files_at_l0,
+                                 rocksdb_p_not_define, p_not_define}};
+  // Verify: checkDB get properties
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
+
+    const string testdbP = generateDBName();
+    addDBWithRole(testdbP, "MASTER");
+
+    req.db_name = testdbP;
+    req.property_names = property_names;
+    req.__isset.property_names = true;
+
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    EXPECT_TRUE(res.__isset.properties);
+    EXPECT_EQ(res.properties[ApplicationDB::Properties::kNumLevels], "7");
+    EXPECT_EQ(res.properties[ApplicationDB::Properties::kHighestEmptyLevel],
+              "6");
+    EXPECT_EQ(res.properties.find(app_p_not_define), res.properties.end());
+    EXPECT_EQ(res.properties[num_files_at_l0], "0");
+    EXPECT_EQ(res.properties.find(rocksdb_p_not_define), res.properties.end());
+    EXPECT_EQ(res.properties.find(p_not_define), res.properties.end());
+
+    writeToDB(testdbP, "1", "1");
+    flushDB(testdbP);
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    EXPECT_EQ(res.seq_num, 1);
+    EXPECT_EQ(res.properties[num_files_at_l0], "1");
   }
 }
 

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -29,7 +29,9 @@
 #include "gtest/gtest.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
+#define private public
 #include "rocksdb_admin/application_db.h"
+#undef private
 #include "rocksdb_admin/tests/test_util.h"
 #include "rocksdb_replicator/rocksdb_replicator.h"
 
@@ -76,19 +78,19 @@ class ApplicationDBTestBase : public testing::Test {
   int numTableFilesAtLevel(int level) {
     std::string p;
     db_->rocksdb()->GetProperty(
-        "rocksdb.num-files-at-level" + std::to_string(level), &p);
+        DB::Properties::kNumFilesAtLevelPrefix + std::to_string(level), &p);
     return atoi(p.c_str());
   }
 
   int numCompactPending() {
     uint64_t p;
-    db_->rocksdb()->GetIntProperty("rocksdb.compaction-pending", &p);
+    db_->rocksdb()->GetIntProperty(DB::Properties::kCompactionPending, &p);
     return static_cast<int>(p);
   }
 
   string levelStats() {
     std::string p;
-    db_->rocksdb()->GetProperty("rocksdb.levelstats", &p);
+    db_->rocksdb()->GetProperty(DB::Properties::kLevelStats, &p);
     return p;
   }
 
@@ -264,6 +266,15 @@ TEST_F(ApplicationDBTestBase, SetOptionsDisableEnableAutoCompaction) {
   // the two sst at L0 will merge into 1 at L1
   EXPECT_EQ(numTableFilesAtLevel(1), 2);
   EXPECT_EQ(numCompactPending(), 0);
+}
+
+TEST_F(ApplicationDBTestBase, GetProperty) {
+  string p_val;
+  EXPECT_TRUE(db_->GetProperty(ApplicationDB::Properties::kNumLevels, &p_val));
+  EXPECT_EQ(atoi(p_val.c_str()), 7);
+  EXPECT_TRUE(db_->GetProperty(ApplicationDB::Properties::kHighestEmptyLevel, &p_val));
+  EXPECT_EQ(atoi(p_val.c_str()), 6);
+  EXPECT_TRUE(db_->DBLmaxEmpty());
 }
 
 TEST_F(ApplicationDBTestBase, GetLSMLevelInfo) {


### PR DESCRIPTION
Expose application/rocksdb properties through CheckDB. 
For example, through CheckDB, we could check whether DB's Lmax is empty or not; check how many sst files exist in the DB, etc.