### PR TITLE
enable CheckDB to get db's options

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1270,7 +1270,16 @@ void AdminHandler::async_tm_checkDB(
     }
   }
 
-  // TODO: get options as str for specified optionField
+  if (request->__isset.option_names && !request->option_names.empty()) {
+    std::map<std::string, std::string> options_map;
+    auto s = db->GetOptions(request->option_names, &options_map);
+    if (s.ok()) {
+      response.options = options_map;
+      response.__isset.options = true;
+    } else {
+      LOG(ERROR) << "Failed to GetOptions from db, " << s.ToString();
+    }
+  }
 
   if (request->__isset.include_meta) {
     auto meta = getMetaData(request->db_name);

--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -89,7 +89,14 @@ class ApplicationDB {
   rocksdb::Status CompactRange(const rocksdb::CompactRangeOptions& options,
                                const rocksdb::Slice* begin,
                                const rocksdb::Slice* end);
-  
+
+  rocksdb::Status GetOptions(std::vector<std::string>& option_names,
+                             std::map<std::string, std::string>* options_map);
+
+  rocksdb::Status GetStringFromOptions(std::string* options_str,
+                                       const rocksdb::Options& options,
+                                       const std::string& delimiter = ";  ");
+
   // get the highest empty level of default column family
   uint32_t getHighestEmptyLevel();
 

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <ctime>
+#include <map>
 #include <thread>
 
 #include "boost/filesystem.hpp"
@@ -64,6 +65,7 @@ using rocksdb::Status;
 using std::make_shared;
 using std::make_tuple;
 using std::make_unique;
+using std::map;
 using std::string;
 using std::thread;
 using std::to_string;
@@ -295,6 +297,14 @@ TEST_F(AdminHandlerTestBase, SetRocksDBOptions) {
   req.options = {{"disable_auto_compactions", "true"}};
   EXPECT_NO_THROW(resp = client_->future_setDBOptions(req).get());
   EXPECT_TRUE(app_db->rocksdb()->GetOptions().disable_auto_compactions);
+
+  CheckDBRequest check_req;
+  CheckDBResponse check_resp;
+  check_req.db_name = testdb;
+  check_req.__isset.option_names = true;
+  check_req.option_names = {"disable_auto_compactions"};
+  EXPECT_NO_THROW(check_resp = client_->future_checkDB(check_req).get());
+  EXPECT_EQ(check_resp.options["disable_auto_compactions"], "true");
 
   // Verify: set immutable db options -> !ok
   EXPECT_FALSE(app_db->rocksdb()->GetOptions().allow_ingest_behind);
@@ -580,47 +590,123 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
 
   CheckDBRequest req;
   CheckDBResponse res;
-  req.db_name = "unknown_db";
 
-  EXPECT_THROW(res = client_->future_checkDB(req).get(), AdminException);
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
 
-  req.db_name = testdb1;
-  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-  EXPECT_EQ(res.seq_num, 0);
-  EXPECT_EQ(res.wal_ttl_seconds, 123);
-  EXPECT_EQ(res.last_update_timestamp_ms, 0);
-  EXPECT_FALSE(res.__isset.db_metas);
+    req.db_name = "unknown_db";
+    EXPECT_THROW(res = client_->future_checkDB(req).get(), AdminException);
+  }
 
-  const string testdb2 = generateDBName();
-  addDBWithRole(testdb2, "MASTER");
-  dbs = db_manager_->getAllDBNames();
-  EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb2), dbs.end());
+  // Verify checkDB of newly DB with default vals
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
 
-  deleteKeyFromDB(testdb2, "a");
-  req.db_name = testdb2;
-  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-  EXPECT_EQ(res.seq_num, 1);
-  EXPECT_EQ(res.wal_ttl_seconds, 123);
-  // 1521000000 is 03/14/2018 @ 4:00am (UTC)
-  EXPECT_GT(res.last_update_timestamp_ms, 1521000000);
+    req.db_name = testdb1;
+
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    EXPECT_EQ(res.seq_num, 0);
+    EXPECT_EQ(res.wal_ttl_seconds, 123);
+    EXPECT_EQ(res.last_update_timestamp_ms, 0);
+    EXPECT_FALSE(res.__isset.db_metas);
+  }
+
+  // Verify checkDB from existed DB
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
+
+    const string testdb2 = generateDBName();
+    addDBWithRole(testdb2, "MASTER");
+    dbs = db_manager_->getAllDBNames();
+    EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb2), dbs.end());
+    deleteKeyFromDB(testdb2, "a");
+
+    req.db_name = testdb2;
+
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    EXPECT_EQ(res.seq_num, 1);
+    EXPECT_EQ(res.wal_ttl_seconds, 123);
+    // 1521000000 is 03/14/2018 @ 4:00am (UTC)
+    EXPECT_GT(res.last_update_timestamp_ms, 1521000000);
+  }
 
   // verify: checkDB get metadata
-  const string testdb3 = generateDBName();
-  addDBWithRole(testdb3, "MASTER");
-  auto meta = handler_->getMetaData(testdb3);
-  verifyMeta(meta, testdb3, true, "", "");
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
 
-  // write fake DBMetadata for <testdb3>
-  handler_->writeMetaData(testdb3, "fakes3bucket", "fakes3path");
-  meta = handler_->getMetaData(testdb3);
-  verifyMeta(meta, testdb3, true, "fakes3bucket", "fakes3path");
+    const string testdb3 = generateDBName();
+    addDBWithRole(testdb3, "MASTER");
+    auto meta = handler_->getMetaData(testdb3);
+    verifyMeta(meta, testdb3, true, "", "");
 
-  req.db_name = testdb3;
-  req.set_include_meta(true);
-  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-  EXPECT_TRUE(res.__isset.db_metas);
-  EXPECT_EQ(res.db_metas["s3_bucket"], "fakes3bucket");
-  EXPECT_EQ(res.db_metas["s3_path"], "fakes3path");
+    // write fake DBMetadata for <testdb3>
+    handler_->writeMetaData(testdb3, "fakes3bucket", "fakes3path");
+    meta = handler_->getMetaData(testdb3);
+    verifyMeta(meta, testdb3, true, "fakes3bucket", "fakes3path");
+
+    req.db_name = testdb3;
+    req.set_include_meta(true);
+
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    EXPECT_TRUE(res.__isset.db_metas);
+    EXPECT_EQ(res.db_metas["s3_bucket"], "fakes3bucket");
+    EXPECT_EQ(res.db_metas["s3_path"], "fakes3path");
+  }
+
+  // verify CheckDB get options
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
+
+    map<string, string> option_with_expvals{
+        {"WAL_ttl_seconds", "123"},
+        {"allow_ingest_behind", "false"},
+        {"disable_auto_compactions", "false"}};
+    vector<string> option_names{"unknown_option_name"};
+    for (const auto& map_entry : option_with_expvals) {
+      option_names.push_back(map_entry.first);
+    }
+
+    req.db_name = testdb1;
+    req.option_names = option_names;
+    req.__isset.option_names = true;
+
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    for (const auto& option_name : option_names) {
+      if (option_name == "unknown_option_name") {
+        EXPECT_EQ(res.options.find(option_name), res.options.end());
+      } else {
+        EXPECT_EQ(res.options[option_name], option_with_expvals[option_name]);
+      }
+    }
+
+    // get DB options when created with allow_ingest_behind
+    {
+      FLAGS_test_db_create_with_allow_ingest_behind = true;
+      SCOPE_EXIT { FLAGS_test_db_create_with_allow_ingest_behind = false; };
+      const string testdbOptions2 = generateDBName();
+      addDBWithRole(testdbOptions2, "MASTER");
+
+      req.db_name = testdbOptions2;
+
+      EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+      EXPECT_EQ(res.options["allow_ingest_behind"], "true");
+    }
+  }
 }
 
 TEST(AdminHandlerTest, MetaData) {

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -20,11 +20,14 @@
 #include <ctime>
 #include <iostream>
 #include <thread>
+#include <unordered_map>
+#include <map>
 #include <vector>
 
 #include "boost/filesystem.hpp"
 #include "gflags/gflags.h"
 #include "gtest/gtest.h"
+#include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
 #include "rocksdb_admin/application_db.h"
 #include "rocksdb_admin/tests/test_util.h"
@@ -51,6 +54,7 @@ using std::shared_ptr;
 using std::string;
 using std::to_string;
 using std::unique_ptr;
+using std::unordered_map;
 using std::vector;
 using std::chrono::seconds;
 using std::this_thread::sleep_for;
@@ -134,6 +138,33 @@ class ApplicationDBTestBase : public testing::Test {
   string db_path_;
   Options last_options_;
 };
+
+TEST_F(ApplicationDBTestBase, GetOptionsAsStrMap) {
+  unordered_map<string, string> option_with_expvals{
+      {"create_if_missing", "true"},
+      {"error_if_exists", "true"},
+      {"WAL_size_limit_MB", "100"},
+      {"allow_ingest_behind", "false"},
+      {"bottommost_compression", "kDisableCompressionOption"},
+      {"compaction_style", "kCompactionStyleLevel"},
+      {"disable_auto_compactions", "false"}};
+
+  vector<string> option_names{"unknown_option_name"};
+  for (const auto& map_entry : option_with_expvals) {
+    option_names.push_back(map_entry.first);
+  }
+
+  map<string, string> resp_options;
+  EXPECT_TRUE(db_->GetOptions(option_names, &resp_options).ok());
+
+  for (const auto& option_name : option_names) {
+    if (option_name == "unknown_option_name") {
+      EXPECT_EQ(resp_options.find(option_name), resp_options.end());
+    } else {
+      EXPECT_EQ(resp_options[option_name], option_with_expvals[option_name]);
+    }
+  }
+}
 
 TEST_F(ApplicationDBTestBase, SetImmutableOptionsFail) {
   EXPECT_FALSE(last_options_.allow_ingest_behind);


### PR DESCRIPTION
This is helpful, e.g. we want to get the db options.allow_ingest_behind to tell whether a DB support ingest behind. 