### PR TITLE
add taskConfig to backup/dedup Task for better logging info

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
@@ -69,8 +69,6 @@ public class BackupTaskFactory implements TaskFactory {
     JobConfig jobConfig = context.getJobConfig();
     String job = jobConfig.getJobId();
 
-    LOG.error("Create task with TaskConfig: " + taskConfig.toString());
-
     long jobCreationTime = jobConfig.getStat().getCreationTime() / 1000; // milli to seconds
 
     String storePathPrefix = "";
@@ -108,19 +106,20 @@ public class BackupTaskFactory implements TaskFactory {
         String.format(
             "Create Task for cluster: %s, targetPartition: %s from job: %s to execute at "
                 + "localhost, port: %d. {resourceVersion: %d, helixJobCreationTime: %d, "
-                + "taskCreationTime: %d}",
+                + "taskCreationTime: %d, taskConfig: %s}",
             cluster, targetPartition, job, adminPort, resourceVersion, jobCreationTime,
-            System.currentTimeMillis()));
+            System.currentTimeMillis(), taskConfig.toString()));
 
     return getTask(cluster, targetPartition, backupLimitMbs, storePathPrefix, resourceVersion, job,
-        adminPort, useS3Store, s3Bucket, shareFilesWithChecksum);
+        adminPort, useS3Store, s3Bucket, shareFilesWithChecksum, taskConfig);
   }
 
   protected Task getTask(String cluster, String targetPartition, int backupLimitMbs,
                          String storePathPrefix, long resourceVersion, String job, int port,
-                         boolean useS3Store, String s3Bucket, boolean shareFilesWithChecksum) {
+                         boolean useS3Store, String s3Bucket, boolean shareFilesWithChecksum,
+                         TaskConfig taskConfig) {
     return new BackupTask(cluster, targetPartition, backupLimitMbs, storePathPrefix,
-        resourceVersion, job, port, useS3Store, s3Bucket, shareFilesWithChecksum);
+        resourceVersion, job, port, useS3Store, s3Bucket, shareFilesWithChecksum, taskConfig);
   }
 
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
@@ -51,8 +51,6 @@ public class DedupTaskFactory implements TaskFactory {
     JobConfig jobConfig = context.getJobConfig();
     String job = jobConfig.getJobId();
 
-    LOG.error("Create task with TaskConfig: " + taskConfig.toString());
-
     String srcStorePathPrefix = "";
     long resourceVersion = -1;
     String destStorePathPrefix = "";
@@ -87,21 +85,22 @@ public class DedupTaskFactory implements TaskFactory {
 
     LOG.error(String.format(
         "Create Task for cluster: %s, targetPartition: %s from job: %s to execute at localhost, "
-            + "port:"
-            + " %d. {resourceVersion: %d, helixJobCreationTime: %d, taskCreationTime: %d}", cluster,
-        targetPartition, job, adminPort, resourceVersion, jobConfig.getStat().getCreationTime(),
-        System.currentTimeMillis()));
+            + "port: %d. {resourceVersion: %d, helixJobCreationTime: %d, taskCreationTime: %d, "
+            + "taskConfig: %s}", cluster, targetPartition, job, adminPort, resourceVersion,
+        jobConfig.getStat().getCreationTime(), System.currentTimeMillis(), taskConfig.toString()));
 
     return getTask(srcStorePathPrefix, resourceVersion, targetPartition, cluster, job, adminPort,
-        destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum);
+        destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum,
+        taskConfig);
   }
 
   protected DedupTask getTask(String srcStorePathPrefix, long resourceVersion, String partitionName,
                               String cluster, String job, int port, String destStorePathPrefix,
                               boolean useS3Store, String s3Bucket, int backupLimitMbs,
-                              boolean shareFilesWithChecksum) {
+                              boolean shareFilesWithChecksum, TaskConfig taskConfig) {
     return new DedupTask(srcStorePathPrefix, resourceVersion, partitionName, cluster, job, port,
-        destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum);
+        destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum,
+        taskConfig);
   }
 
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/IngestTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/IngestTask.java
@@ -107,8 +107,7 @@ public class IngestTask extends UserContentStore implements Task {
 
             LOG.error(String.format(
                 "IngestTask run to ingest partition: %s from partitionStorePath: %s to instance: "
-                    + "%s, "
-                    + "role: %s. Other info {taskCluster: %s, job: %s, RpcFrom: %s_%d, "
+                    + "%s, role: %s. Other info {taskCluster: %s, job: %s, RpcFrom: %s_%d, "
                     + "taskConfig=%s}",
                 partitionName, partitionStorePath, hostPort, dbRole, taskCluster, job, host,
                 adminPort, taskConfig.toString()));
@@ -144,7 +143,7 @@ public class IngestTask extends UserContentStore implements Task {
                 + partitionName);
       }
     } catch (Exception e) {
-      String errMsg = String.format("Task ingest failed. errMsg=%s. stacktrack=%s. taskConfig=%s.",
+      String errMsg = String.format("Task ingest failed. errMsg=%s. stacktrace=%s. taskConfig=%s.",
           e.getMessage(), Arrays.toString(e.getStackTrace()), taskConfig.toString());
       LOG.error(errMsg);
       return new TaskResult(TaskResult.Status.FAILED, errMsg);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTaskFactory.java
@@ -145,15 +145,14 @@ public class RestoreTaskFactory implements TaskFactory {
             System.currentTimeMillis()));
 
     return getTask(admin, cluster, targetPartition, storePathPrefix, src_cluster, resourceVersion,
-        job,
-        adminPort, useS3Store, s3Bucket);
+        job, adminPort, useS3Store, s3Bucket, taskConfig);
   }
 
   protected Task getTask(HelixAdmin admin, String cluster, String targetPartition,
-                         String storePathPrefix,
-                         String src_cluster, long resourceVersion, String job, int port,
-                         boolean useS3Store, String s3Bucket) {
+                         String storePathPrefix, String src_cluster, long resourceVersion,
+                         String job, int port, boolean useS3Store, String s3Bucket,
+                         TaskConfig taskConfig) {
     return new RestoreTask(admin, cluster, targetPartition, storePathPrefix, src_cluster,
-        resourceVersion, job, port, useS3Store, s3Bucket);
+        resourceVersion, job, port, useS3Store, s3Bucket, taskConfig);
   }
 }

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestBackupTaskFactory.java
@@ -206,9 +206,10 @@ public class TestBackupTaskFactory extends TaskTestBase {
     @Override
     protected Task getTask(String cluster, String targetPartition, int backupLimitMbs,
                            String storePathPrefix, long resourceVersion, String job, int port,
-                           boolean useS3Store, String s3Bucket, boolean shareFilesWithChecksum) {
+                           boolean useS3Store, String s3Bucket, boolean shareFilesWithChecksum,
+                           TaskConfig taskConfig) {
       return new DummyBackupTask(cluster, targetPartition, backupLimitMbs, storePathPrefix,
-          resourceVersion, job, port, useS3Store, s3Bucket, shareFilesWithChecksum);
+          resourceVersion, job, port, useS3Store, s3Bucket, shareFilesWithChecksum, taskConfig);
     }
 
   }
@@ -217,9 +218,10 @@ public class TestBackupTaskFactory extends TaskTestBase {
 
     public DummyBackupTask(String taskCluster, String partitionName, int backupLimitMbs,
                            String storePathPrefix, long resourceVersion, String job, int adminPort,
-                           boolean useS3Store, String s3Bucket, boolean shareFilesWithChecksum) {
+                           boolean useS3Store, String s3Bucket, boolean shareFilesWithChecksum,
+                           TaskConfig taskConfig) {
       super(taskCluster, partitionName, backupLimitMbs, storePathPrefix, resourceVersion, job,
-          adminPort, useS3Store, s3Bucket, shareFilesWithChecksum);
+          adminPort, useS3Store, s3Bucket, shareFilesWithChecksum, taskConfig);
     }
 
     @Override

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestDedupTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestDedupTaskFactory.java
@@ -159,10 +159,11 @@ public class TestDedupTaskFactory extends TaskTestBase {
     protected DedupTask getTask(String srcStorePathPrefix, long resourceVersion,
                                 String partitionName, String cluster, String job, int port,
                                 String destStorePathPrefix, boolean useS3Store, String s3Bucket,
-                                int backupLimitMbs, boolean shareFilesWithChecksum) {
+                                int backupLimitMbs, boolean shareFilesWithChecksum,
+                                TaskConfig taskConfig) {
       return new DummyDedupTask(srcStorePathPrefix, resourceVersion, partitionName, cluster, job,
-          port,
-          destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum);
+          port, destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum,
+          taskConfig);
     }
 
   }
@@ -172,9 +173,11 @@ public class TestDedupTaskFactory extends TaskTestBase {
     public DummyDedupTask(String srcStorePathPrefix, long resourceVersion,
                           String partitionName, String taskCluster, String job, int adminPort,
                           String destStorePathPrefix, boolean useS3Store, String s3Bucket,
-                          int backupLimitMbs, boolean shareFilesWithChecksum) {
+                          int backupLimitMbs, boolean shareFilesWithChecksum,
+                          TaskConfig taskConfig) {
       super(srcStorePathPrefix, resourceVersion, partitionName, taskCluster, job, adminPort,
-          destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum);
+          destStorePathPrefix, useS3Store, s3Bucket, backupLimitMbs, shareFilesWithChecksum,
+          taskConfig);
     }
 
     @Override

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestRestoreTaskFactory.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/task/TestRestoreTaskFactory.java
@@ -177,9 +177,11 @@ public class TestRestoreTaskFactory extends TaskTestBase {
     @Override
     protected Task getTask(HelixAdmin admin, String cluster, String targetPartition,
                            String storePathPrefix, String src_cluster, long resourceVersion,
-                           String job, int port, boolean useS3Store, String s3Bucket) {
+                           String job, int port, boolean useS3Store, String s3Bucket,
+                           TaskConfig taskConfig) {
       return new TestRestoreTaskFactory.DummyRestoreTask(admin, cluster, targetPartition,
-          storePathPrefix, src_cluster, resourceVersion, job, port, useS3Store, s3Bucket);
+          storePathPrefix, src_cluster, resourceVersion, job, port, useS3Store, s3Bucket,
+          taskConfig);
     }
   }
 
@@ -187,9 +189,10 @@ public class TestRestoreTaskFactory extends TaskTestBase {
 
     public DummyRestoreTask(HelixAdmin admin, String taskCluster, String partitionName,
                             String storePathPrefix, String src_cluster, long resourceVersion,
-                            String job, int adminPort, boolean useS3Store, String s3Bucket) {
+                            String job, int adminPort, boolean useS3Store, String s3Bucket,
+                            TaskConfig taskConfig) {
       super(admin, taskCluster, partitionName, storePathPrefix, src_cluster, resourceVersion, job,
-          adminPort, useS3Store, s3Bucket);
+          adminPort, useS3Store, s3Bucket, taskConfig);
     }
 
     @Override


### PR DESCRIPTION
Previously, when task failed, the info to helixUI (backup/dedup Task) is too little without any debug info. 
In this pull request, I specifically added the exception message and stacktrace into the info, which will looks like what in `ingestTask`
![Screen Shot 2021-03-11 at 2 56 58 PM](https://user-images.githubusercontent.com/24217293/110866634-49295a80-827a-11eb-8966-835fc4e593dd.png)

a few other logging improvement with `taskConfig` info. 
