### PR TITLE
Revert all latest changes rely on checkdb and only keep thrift changes

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
@@ -90,7 +90,6 @@ import java.util.concurrent.TimeUnit;
 public class LeaderFollowerStateModelFactory extends StateModelFactory<StateModel> {
 
   private static final Logger LOG = LoggerFactory.getLogger(LeaderFollowerStateModelFactory.class);
-  private static final String LOCAL_HOST_IP = "127.0.0.1";
 
   private final String host;
   private final int adminPort;
@@ -238,7 +237,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
           LOG.error("Found another host " + hostWithHighestSeq + " with higher seq num: " +
               String.valueOf(highestSeq) + " for " + dbName);
           Utils.changeDBRoleAndUpStream(
-              LOCAL_HOST_IP, adminPort, dbName, "FOLLOWER", hostWithHighestSeq, adminPort);
+              "localhost", adminPort, dbName, "FOLLOWER", hostWithHighestSeq, adminPort);
 
           // wait for up to 10 mins
           for (int i = 0; i < 600; ++i) {
@@ -262,7 +261,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
         }
 
         // changeDBRoleAndUpStream(me, "Leader")
-        Utils.changeDBRoleAndUpStream(LOCAL_HOST_IP, adminPort, dbName, "LEADER",
+        Utils.changeDBRoleAndUpStream("localhost", adminPort, dbName, "LEADER",
             "", adminPort);
 
         // Get the latest external view and state map
@@ -315,8 +314,8 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
       Utils.logTransitionMessage(message);
 
       try (Locker locker = new Locker(partitionMutex)) {
-        Utils.changeDBRoleAndUpStream(LOCAL_HOST_IP, adminPort, Utils.getDbName(partitionName),
-            "FOLLOWER", LOCAL_HOST_IP, adminPort);
+        Utils.changeDBRoleAndUpStream("localhost", adminPort, Utils.getDbName(partitionName),
+            "FOLLOWER", "127.0.0.1", adminPort);
         leaderEventsCollector.addEvent(LeaderEventType.PARTICIPANT_LEADER_DOWN_SUCCESS, null);
       } catch (RuntimeException e) {
         leaderEventsCollector.addEvent(LeaderEventType.PARTICIPANT_LEADER_DOWN_FAILURE, null);
@@ -386,26 +385,17 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
               upstream = instanceNameAndRole.getKey();
             }
           }
-          String upstreamHost = (upstream == null ? LOCAL_HOST_IP : upstream.split("_")[0]);
+          String upstreamHost = (upstream == null ? "127.0.0.1" : upstream.split("_")[0]);
           snapshotHost = upstreamHost;
           int upstreamPort =
               (upstream == null ? adminPort : Integer.parseInt(upstream.split("_")[1]));
           snapshotPort = upstreamPort;
 
           // check if the local replica needs rebuild
-          CheckDBResponse
-              localStatus =
-              Utils.checkRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, true, null);
-          CheckDBResponse upstreamStatus = null;
-          if (!upstreamHost.equals(LOCAL_HOST_IP) && !upstreamHost.equals(this.host)) {
-            upstreamStatus =
-                Utils.checkRemoteOrLocalDB(upstreamHost, upstreamPort, dbName, true, null);
-          }
+          CheckDBResponse localStatus = Utils.checkLocalDB(dbName, adminPort);
 
           boolean needRebuild = true;
-          if (upstreamStatus != null && !upstreamStatus.db_metas.equals(localStatus.db_metas)) {
-            LOG.error("upstreamStatus exist and differ from localStatus, rebuild.");
-          } else if (liveHostAndRole.isEmpty()) {
+          if (liveHostAndRole.isEmpty()) {
             LOG.error("No other live replicas, skip rebuild " + dbName);
             needRebuild = false;
           } else if (System.currentTimeMillis() <
@@ -423,7 +413,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
 
           // if rebuild is not needed, setup upstream and return
           if (!needRebuild) {
-            Utils.changeDBRoleAndUpStream(LOCAL_HOST_IP, adminPort, dbName, "FOLLOWER",
+            Utils.changeDBRoleAndUpStream("localhost", adminPort, dbName, "FOLLOWER",
                 upstreamHost, upstreamPort);
             Utils.logTransitionCompletionMessage(message);
             return;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
@@ -88,7 +88,6 @@ import java.util.concurrent.TimeUnit;
 public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> {
 
   private static final Logger LOG = LoggerFactory.getLogger(MasterSlaveStateModelFactory.class);
-  private static final String LOCAL_HOST_IP = "127.0.0.1";
 
   private final String host;
   private final int adminPort;
@@ -235,7 +234,7 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
           LOG.error("Found another host " + hostWithHighestSeq + " with higher seq num: " +
               String.valueOf(highestSeq) + " for " + dbName);
           Utils.changeDBRoleAndUpStream(
-              LOCAL_HOST_IP, adminPort, dbName, "SLAVE", hostWithHighestSeq, adminPort);
+              "localhost", adminPort, dbName, "SLAVE", hostWithHighestSeq, adminPort);
 
           // wait for up to 10 mins
           for (int i = 0; i < 600; ++i) {
@@ -259,7 +258,7 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
         }
 
         // changeDBRoleAndUpStream(me, "Master")
-        Utils.changeDBRoleAndUpStream(LOCAL_HOST_IP, adminPort, dbName, "MASTER",
+        Utils.changeDBRoleAndUpStream("localhost", adminPort, dbName, "MASTER",
             "", adminPort);
 
         // Get the latest external view and state map
@@ -312,8 +311,8 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
       Utils.logTransitionMessage(message);
 
       try (Locker locker = new Locker(partitionMutex)) {
-        Utils.changeDBRoleAndUpStream(LOCAL_HOST_IP, adminPort, Utils.getDbName(partitionName),
-            "SLAVE", LOCAL_HOST_IP, adminPort);
+        Utils.changeDBRoleAndUpStream("localhost", adminPort, Utils.getDbName(partitionName),
+            "SLAVE", "127.0.0.1", adminPort);
         leaderEventsCollector.addEvent(LeaderEventType.PARTICIPANT_LEADER_DOWN_SUCCESS, null);
       } catch (RuntimeException e) {
         leaderEventsCollector.addEvent(LeaderEventType.PARTICIPANT_LEADER_DOWN_FAILURE, null);
@@ -383,26 +382,17 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
               upstream = instanceNameAndRole.getKey();
             }
           }
-          String upstreamHost = (upstream == null ? LOCAL_HOST_IP : upstream.split("_")[0]);
+          String upstreamHost = (upstream == null ? "127.0.0.1" : upstream.split("_")[0]);
           snapshotHost = upstreamHost;
           int upstreamPort =
               (upstream == null ? adminPort : Integer.parseInt(upstream.split("_")[1]));
           snapshotPort = upstreamPort;
 
           // check if the local replica needs rebuild
-          CheckDBResponse
-              localStatus =
-              Utils.checkRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, true, null);
-          CheckDBResponse upstreamStatus = null;
-          if (!upstreamHost.equals(LOCAL_HOST_IP) && !upstreamHost.equals(this.host)) {
-            upstreamStatus =
-                Utils.checkRemoteOrLocalDB(upstreamHost, upstreamPort, dbName, true, null);
-          }
+          CheckDBResponse localStatus = Utils.checkLocalDB(dbName, adminPort);
 
           boolean needRebuild = true;
-          if (upstreamStatus != null && !upstreamStatus.db_metas.equals(localStatus.db_metas)) {
-            LOG.error("upstreamStatus exist and differ from localStatus, rebuild.");
-          } else if (liveHostAndRole.isEmpty()) {
+          if (liveHostAndRole.isEmpty()) {
             LOG.error("No other live replicas, skip rebuild " + dbName);
             needRebuild = false;
           } else if (System.currentTimeMillis() <
@@ -420,7 +410,7 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
 
           // if rebuild is not needed, setup upstream and return
           if (!needRebuild) {
-            Utils.changeDBRoleAndUpStream(LOCAL_HOST_IP, adminPort, dbName, "SLAVE",
+            Utils.changeDBRoleAndUpStream("localhost", adminPort, dbName, "SLAVE",
                 upstreamHost, upstreamPort);
             Utils.logTransitionCompletionMessage(message);
             return;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -47,14 +47,12 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class Utils {
 
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
-  private static final String LOCAL_HOST_IP = "127.0.0.1";
 
   /**
    * Build a thrift client to local adminPort
@@ -63,7 +61,7 @@ public class Utils {
    * @throws TTransportException
    */
   public static Admin.Client getLocalAdminClient(int adminPort) throws TTransportException {
-    return getAdminClient(LOCAL_HOST_IP, adminPort);
+    return getAdminClient("localhost", adminPort);
   }
 
   /**
@@ -118,7 +116,7 @@ public class Utils {
    */
   public static void closeDB(String dbName, int adminPort) {
     try {
-      closeRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName);
+      closeRemoteOrLocalDB("localhost", adminPort, dbName);
     } catch (RuntimeException e) {
       LOG.error("closeDB failed with exception", e);
     }
@@ -159,7 +157,7 @@ public class Utils {
     try {
       try {
         client = getLocalAdminClient(adminPort);
-        req = new AddDBRequest(dbName, LOCAL_HOST_IP);
+        req = new AddDBRequest(dbName, "127.0.0.1");
         req.setDb_role(dbRole);
         client.addDB(req);
       } catch (AdminException e) {
@@ -220,7 +218,7 @@ public class Utils {
   public static long getLocalLatestSequenceNumber(String dbName, int adminPort)
       throws RuntimeException {
     LOG.error("Get local seq number");
-    long seqNum = getLatestSequenceNumber(dbName, LOCAL_HOST_IP, adminPort);
+    long seqNum = getLatestSequenceNumber(dbName, "localhost", adminPort);
     if (seqNum == -1) {
       throw new RuntimeException("Failed to fetch local sequence number for DB: " + dbName);
     }
@@ -277,35 +275,23 @@ public class Utils {
   }
 
   /**
-   * Check the status of a local DB.
-   * This method is deprecated, please use @checkRemoteOrLocalDB
+   * Check the status of a local DB
    * @param dbName
    * @param adminPort
    * @return the DB status
    * @throws RuntimeException
    */
-  @Deprecated
   public static CheckDBResponse checkLocalDB(String dbName, int adminPort) throws RuntimeException {
-    return checkRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, false, null);
-  }
-
-  public static CheckDBResponse checkRemoteOrLocalDB(String host, int adminPort, String dbName,
-                                                     boolean includeMeta,
-                                                     List<String> optionNames) {
     try {
-      Admin.Client client = getAdminClient(host, adminPort);
+      Admin.Client client = getLocalAdminClient(adminPort);
 
       CheckDBRequest req = new CheckDBRequest(dbName);
-      req.setInclude_meta(includeMeta);
-      req.setOption_names(optionNames);
-
       return client.checkDB(req);
     } catch (TException e) {
       LOG.error("Failed to check DB: ", e);
       throw new RuntimeException(e);
     }
   }
-
 
   /**
    * Backup the DB on the host
@@ -357,7 +343,7 @@ public class Utils {
   public static void restoreLocalDB(int adminPort, String dbName, String hdfsPath,
                                     String upsreamHost, int upstreamPort)
       throws RuntimeException {
-    restoreRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, hdfsPath, upsreamHost, upstreamPort);
+    restoreRemoteOrLocalDB("localhost", adminPort, dbName, hdfsPath, upsreamHost, upstreamPort);
   }
 
   public static void restoreRemoteOrLocalDB(String host, int adminPort, String dbName,
@@ -446,7 +432,7 @@ public class Utils {
   public static void restoreLocalDBFromS3(int adminPort, String dbName, String s3Bucket,
                                           String s3Path, String upsreamHost, int upstreamPort)
       throws RuntimeException {
-    restoreRemoteOrLocalDBFromS3(LOCAL_HOST_IP, adminPort, dbName, s3Bucket, s3Path, upsreamHost,
+    restoreRemoteOrLocalDBFromS3("localhost", adminPort, dbName, s3Bucket, s3Path, upsreamHost,
         upstreamPort);
   }
 

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1278,16 +1278,7 @@ void AdminHandler::async_tm_checkDB(
     }
   }
 
-  if (request->__isset.option_names && !request->option_names.empty()) {
-    std::map<std::string, std::string> options_map;
-    auto s = db->GetOptions(request->option_names, &options_map);
-    if (s.ok()) {
-      response.options = options_map;
-      response.__isset.options = true;
-    } else {
-      LOG(ERROR) << "Failed to GetOptions from db, " << s.ToString();
-    }
-  }
+  // TODO: get options as str for specified optionField
 
   if (request->__isset.include_meta) {
     auto meta = getMetaData(request->db_name);

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -26,7 +26,6 @@
 #include <thread>
 #include <unordered_set>
 #include <vector>
-#include <map>
 
 #include "boost/filesystem.hpp"
 #include "common/identical_name_thread_factory.h"
@@ -1276,18 +1275,6 @@ void AdminHandler::async_tm_checkDB(
         response.set_last_update_timestamp_ms(extractor.ms);
       }
     }
-  }
-
-  // TODO: get options as str for specified optionField
-
-  if (request->__isset.include_meta) {
-    auto meta = getMetaData(request->db_name);
-    std::map<std::string, std::string> metas;
-    metas["s3_bucket"] = meta.s3_bucket;
-    metas["s3_path"] = meta.s3_path;
-    metas["last_kafka_msg_timestamp_ms"] = std::to_string(meta.last_kafka_msg_timestamp_ms);
-    response.db_metas = metas;
-    response.__isset.db_metas = true;
   }
 
   callback->result(response);

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1299,20 +1299,6 @@ void AdminHandler::async_tm_checkDB(
     response.__isset.db_metas = true;
   }
 
-  if (request->__isset.property_names && !request->property_names.empty()) {
-    std::map<std::string, std::string> properties;
-    for (const auto& p : request->property_names) {
-      std::string p_val;
-      if (db->GetProperty(p, &p_val)) {
-        properties[p] = p_val;
-      } else {
-        LOG(ERROR) << "Failed to getProperty for " << p;
-      }
-    }
-    response.properties = properties;
-    response.__isset.properties = true;
-  }
-
   callback->result(response);
 }
 
@@ -1571,7 +1557,7 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
       callback.release()->exceptionInThread(std::move(e));
       return;
     }
-    if (!db->DBLmaxEmpty()) {
+    if (db->getHighestEmptyLevel() != db->rocksdb()->NumberLevels() - 1) {
       // note: default num levels for DB is 7 (0, 1, ..., 6)
       std::string errMsg = "The Lmax of DB is not empty, skip ingestion to " + request->db_name;
       e.message = errMsg;

--- a/rocksdb_admin/application_db.cpp
+++ b/rocksdb_admin/application_db.cpp
@@ -17,7 +17,6 @@
 
 #include <string>
 
-#include "rocksdb/convenience.h"
 #include "common/stats/stats.h"
 #include "common/timer.h"
 
@@ -134,43 +133,6 @@ rocksdb::Status ApplicationDB::CompactRange(
   common::Stats::get()->Incr(kRocksdbCompaction);
   common::Timer timer(kRocksdbCompactionMs);
   return db_->CompactRange(options, begin, end);
-}
-
-rocksdb::Status ApplicationDB::GetOptions(
-    std::vector<std::string>& option_names,
-    std::map<std::string, std::string>* options_map) {
-  rocksdb::Options options = db_->GetOptions();
-  std::string opts_str;
-  std::unordered_map<std::string, std::string> opts_map;
-  auto get_s = GetStringFromOptions(&opts_str, options);
-  auto to_map_s = rocksdb::StringToMap(opts_str, &opts_map);
-  if (!get_s.ok() || !to_map_s.ok()) {
-    return !get_s.ok() ? get_s : to_map_s;
-  }
-  for (const auto& option_name : option_names) {
-    if (opts_map.find(option_name) != opts_map.end()) {
-      (*options_map)[option_name] = opts_map[option_name];
-    } else {
-      LOG(ERROR) << "Option name not found, " << option_name;
-    }
-  }
-  return rocksdb::Status();
-}
-
-rocksdb::Status ApplicationDB::GetStringFromOptions(
-    std::string* options_str, const rocksdb::Options& options,
-    const std::string& delimiter) {
-  std::string dboptions_str;
-  std::string cfoptions_str;
-  auto db_s =
-      rocksdb::GetStringFromDBOptions(&dboptions_str, options, delimiter);
-  auto cf_s = rocksdb::GetStringFromColumnFamilyOptions(&cfoptions_str, options,
-                                                        delimiter);
-  if (!db_s.ok() || !cf_s.ok()) {
-    return !db_s.ok() ? db_s : cf_s;
-  }
-  *options_str = dboptions_str + delimiter + cfoptions_str;
-  return rocksdb::Status();
 }
 
 uint32_t ApplicationDB::getHighestEmptyLevel() {

--- a/rocksdb_admin/application_db.cpp
+++ b/rocksdb_admin/application_db.cpp
@@ -12,6 +12,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
+
 #include "rocksdb_admin/application_db.h"
 
 #include <string>
@@ -40,13 +41,6 @@ const std::string kRocksdbCompactionMs = "rocksdb_compact_range_ms";
 }  // anonymous namespace
 
 namespace admin {
-
-static const std::string rocksdb_prefix = "rocksdb.";
-static const std::string applicationdb_prefix = "applicationdb.";
-const std::string ApplicationDB::Properties::kNumLevels =
-    applicationdb_prefix + "num-levels";
-const std::string ApplicationDB::Properties::kHighestEmptyLevel =
-    applicationdb_prefix + "highest-empty-level";
 
 ApplicationDB::ApplicationDB(
     const std::string& db_name,
@@ -177,47 +171,6 @@ rocksdb::Status ApplicationDB::GetStringFromOptions(
   }
   *options_str = dboptions_str + delimiter + cfoptions_str;
   return rocksdb::Status();
-}
-
-bool ApplicationDB::GetProperty(const rocksdb::Slice& property,
-                                std::string* value) {
-  if (property.starts_with(applicationdb_prefix)) {
-    if (property == Properties::kHighestEmptyLevel) {
-      *value = std::to_string(getHighestEmptyLevel());
-      return true;
-    } else if (property == Properties::kNumLevels) {
-      *value = std::to_string(db_->NumberLevels());
-      return true;
-    } else {
-      LOG(ERROR) << "ApplicationDb property not defined, "
-                 << property.ToString();
-      return false;
-    }
-  } else if (property.starts_with(rocksdb_prefix)) {
-    return db_->GetProperty(property, value);
-  } else {
-    LOG(ERROR) << "Property not defined, " << property.ToString();
-    return false;
-  }
-}
-
-bool ApplicationDB::DBLmaxEmpty() {
-  std::string num_levels;
-  std::string highest_empty_level;
-  auto ex = folly::try_and_catch<std::exception>(
-      [&num_levels, &highest_empty_level, this]() {
-        if (this->GetProperty(Properties::kNumLevels, &num_levels) &&
-            this->GetProperty(Properties::kHighestEmptyLevel,
-                              &highest_empty_level) &&
-            std::atoi(num_levels.c_str()) - 1 !=
-                std::atoi(highest_empty_level.c_str())) {
-          LOG(INFO) << "DBLmax not empty, num_levels: " << num_levels
-                    << ", highest_empty_level: " << highest_empty_level;
-          return false;
-        }
-      });
-  ex.with_exception([](std::exception& e) { LOG(ERROR) << e.what(); });
-  return true;
 }
 
 uint32_t ApplicationDB::getHighestEmptyLevel() {

--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -89,14 +89,7 @@ class ApplicationDB {
   rocksdb::Status CompactRange(const rocksdb::CompactRangeOptions& options,
                                const rocksdb::Slice* begin,
                                const rocksdb::Slice* end);
-
-  rocksdb::Status GetOptions(std::vector<std::string>& option_names,
-                             std::map<std::string, std::string>* options_map);
-
-  rocksdb::Status GetStringFromOptions(std::string* options_str,
-                                       const rocksdb::Options& options,
-                                       const std::string& delimiter = ";  ");
-
+  
   // get the highest empty level of default column family
   uint32_t getHighestEmptyLevel();
 

--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -12,6 +12,7 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
+
 #pragma once
 
 #include <string>
@@ -28,15 +29,6 @@ namespace admin {
 // along with basic data operations(read/write)
 class ApplicationDB {
  public:
-
-  struct Properties {
-    // "applicationdb.num-levels" - return string of the configured level of DB
-    static const std::string kNumLevels;
-    // "applicationdb.highest-empty-level" - return string of the highest empty
-    // level number
-    static const std::string kHighestEmptyLevel;
-  };
-
   // Create a ApplicationDB instance
   // db_name:       (IN) name of this db instance
   // db:            (IN) shared pointer of rocksdb instance
@@ -105,9 +97,8 @@ class ApplicationDB {
                                        const rocksdb::Options& options,
                                        const std::string& delimiter = ";  ");
 
-  bool GetProperty(const rocksdb::Slice& property, std::string* value);
-
-  bool DBLmaxEmpty();
+  // get the highest empty level of default column family
+  uint32_t getHighestEmptyLevel();
 
   // Whether this db instance is slave
   bool IsSlave() const { return role_ == replicator::DBRole::SLAVE; }
@@ -129,9 +120,6 @@ class ApplicationDB {
   ~ApplicationDB();
 
  private:
-  // get the highest empty level of default column family
-  uint32_t getHighestEmptyLevel();
-
   const std::string db_name_;
   std::shared_ptr<rocksdb::DB> db_;
 

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -136,10 +136,6 @@ struct CloseDBResponse {
 struct CheckDBRequest {
   # the DB to check
   1: required string db_name,
-  # retrieve DB's option values for specified option names
-  2: optional list<string> option_names,
-  # if true, get the DBMetaData of the db
-  3: optional bool include_meta,
 }
 
 struct CheckDBResponse {
@@ -151,8 +147,6 @@ struct CheckDBResponse {
   3: optional i64 last_update_timestamp_ms = 0,
   # if the DB is Master
   4: optional bool is_master = false,
-  5: optional map<string, string> options,
-  6: optional map<string, string> db_metas,
 }
 
 struct ChangeDBRoleAndUpstreamRequest {

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -136,6 +136,12 @@ struct CloseDBResponse {
 struct CheckDBRequest {
   # the DB to check
   1: required string db_name,
+  # retrieve DB's option values for specified option names
+  2: optional list<string> option_names,
+  # if true, get the DBMetaData of the db
+  3: optional bool include_meta,
+  # get DB's properties
+  4: optional list<string> property_names,
 }
 
 struct CheckDBResponse {
@@ -147,6 +153,9 @@ struct CheckDBResponse {
   3: optional i64 last_update_timestamp_ms = 0,
   # if the DB is Master
   4: optional bool is_master = false,
+  5: optional map<string, string> options,
+  6: optional map<string, string> db_metas,
+  7: optional map<string, string> properties,
 }
 
 struct ChangeDBRoleAndUpstreamRequest {

--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -140,8 +140,6 @@ struct CheckDBRequest {
   2: optional list<string> option_names,
   # if true, get the DBMetaData of the db
   3: optional bool include_meta,
-  # get DB's properties
-  4: optional list<string> property_names,
 }
 
 struct CheckDBResponse {
@@ -155,7 +153,6 @@ struct CheckDBResponse {
   4: optional bool is_master = false,
   5: optional map<string, string> options,
   6: optional map<string, string> db_metas,
-  7: optional map<string, string> properties,
 }
 
 struct ChangeDBRoleAndUpstreamRequest {

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <ctime>
-#include <map>
 #include <thread>
 
 #include "boost/filesystem.hpp"
@@ -65,7 +64,6 @@ using rocksdb::Status;
 using std::make_shared;
 using std::make_tuple;
 using std::make_unique;
-using std::map;
 using std::string;
 using std::thread;
 using std::to_string;
@@ -297,14 +295,6 @@ TEST_F(AdminHandlerTestBase, SetRocksDBOptions) {
   req.options = {{"disable_auto_compactions", "true"}};
   EXPECT_NO_THROW(resp = client_->future_setDBOptions(req).get());
   EXPECT_TRUE(app_db->rocksdb()->GetOptions().disable_auto_compactions);
-
-  CheckDBRequest check_req;
-  CheckDBResponse check_resp;
-  check_req.db_name = testdb;
-  check_req.__isset.option_names = true;
-  check_req.option_names = {"disable_auto_compactions"};
-  EXPECT_NO_THROW(check_resp = client_->future_checkDB(check_req).get());
-  EXPECT_EQ(check_resp.options["disable_auto_compactions"], "true");
 
   // Verify: set immutable db options -> !ok
   EXPECT_FALSE(app_db->rocksdb()->GetOptions().allow_ingest_behind);
@@ -590,123 +580,47 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
 
   CheckDBRequest req;
   CheckDBResponse res;
+  req.db_name = "unknown_db";
 
-  {
-    SCOPE_EXIT {
-      req.__clear();
-      res.__clear();
-    };
+  EXPECT_THROW(res = client_->future_checkDB(req).get(), AdminException);
 
-    req.db_name = "unknown_db";
-    EXPECT_THROW(res = client_->future_checkDB(req).get(), AdminException);
-  }
+  req.db_name = testdb1;
+  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+  EXPECT_EQ(res.seq_num, 0);
+  EXPECT_EQ(res.wal_ttl_seconds, 123);
+  EXPECT_EQ(res.last_update_timestamp_ms, 0);
+  EXPECT_FALSE(res.__isset.db_metas);
 
-  // Verify checkDB of newly DB with default vals
-  {
-    SCOPE_EXIT {
-      req.__clear();
-      res.__clear();
-    };
+  const string testdb2 = generateDBName();
+  addDBWithRole(testdb2, "MASTER");
+  dbs = db_manager_->getAllDBNames();
+  EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb2), dbs.end());
 
-    req.db_name = testdb1;
-
-    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-    EXPECT_EQ(res.seq_num, 0);
-    EXPECT_EQ(res.wal_ttl_seconds, 123);
-    EXPECT_EQ(res.last_update_timestamp_ms, 0);
-    EXPECT_FALSE(res.__isset.db_metas);
-  }
-
-  // Verify checkDB from existed DB
-  {
-    SCOPE_EXIT {
-      req.__clear();
-      res.__clear();
-    };
-
-    const string testdb2 = generateDBName();
-    addDBWithRole(testdb2, "MASTER");
-    dbs = db_manager_->getAllDBNames();
-    EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb2), dbs.end());
-    deleteKeyFromDB(testdb2, "a");
-
-    req.db_name = testdb2;
-
-    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-    EXPECT_EQ(res.seq_num, 1);
-    EXPECT_EQ(res.wal_ttl_seconds, 123);
-    // 1521000000 is 03/14/2018 @ 4:00am (UTC)
-    EXPECT_GT(res.last_update_timestamp_ms, 1521000000);
-  }
+  deleteKeyFromDB(testdb2, "a");
+  req.db_name = testdb2;
+  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+  EXPECT_EQ(res.seq_num, 1);
+  EXPECT_EQ(res.wal_ttl_seconds, 123);
+  // 1521000000 is 03/14/2018 @ 4:00am (UTC)
+  EXPECT_GT(res.last_update_timestamp_ms, 1521000000);
 
   // verify: checkDB get metadata
-  {
-    SCOPE_EXIT {
-      req.__clear();
-      res.__clear();
-    };
+  const string testdb3 = generateDBName();
+  addDBWithRole(testdb3, "MASTER");
+  auto meta = handler_->getMetaData(testdb3);
+  verifyMeta(meta, testdb3, true, "", "");
 
-    const string testdb3 = generateDBName();
-    addDBWithRole(testdb3, "MASTER");
-    auto meta = handler_->getMetaData(testdb3);
-    verifyMeta(meta, testdb3, true, "", "");
+  // write fake DBMetadata for <testdb3>
+  handler_->writeMetaData(testdb3, "fakes3bucket", "fakes3path");
+  meta = handler_->getMetaData(testdb3);
+  verifyMeta(meta, testdb3, true, "fakes3bucket", "fakes3path");
 
-    // write fake DBMetadata for <testdb3>
-    handler_->writeMetaData(testdb3, "fakes3bucket", "fakes3path");
-    meta = handler_->getMetaData(testdb3);
-    verifyMeta(meta, testdb3, true, "fakes3bucket", "fakes3path");
-
-    req.db_name = testdb3;
-    req.set_include_meta(true);
-
-    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-    EXPECT_TRUE(res.__isset.db_metas);
-    EXPECT_EQ(res.db_metas["s3_bucket"], "fakes3bucket");
-    EXPECT_EQ(res.db_metas["s3_path"], "fakes3path");
-  }
-
-  // verify CheckDB get options
-  {
-    SCOPE_EXIT {
-      req.__clear();
-      res.__clear();
-    };
-
-    map<string, string> option_with_expvals{
-        {"WAL_ttl_seconds", "123"},
-        {"allow_ingest_behind", "false"},
-        {"disable_auto_compactions", "false"}};
-    vector<string> option_names{"unknown_option_name"};
-    for (const auto& map_entry : option_with_expvals) {
-      option_names.push_back(map_entry.first);
-    }
-
-    req.db_name = testdb1;
-    req.option_names = option_names;
-    req.__isset.option_names = true;
-
-    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-    for (const auto& option_name : option_names) {
-      if (option_name == "unknown_option_name") {
-        EXPECT_EQ(res.options.find(option_name), res.options.end());
-      } else {
-        EXPECT_EQ(res.options[option_name], option_with_expvals[option_name]);
-      }
-    }
-
-    // get DB options when created with allow_ingest_behind
-    {
-      FLAGS_test_db_create_with_allow_ingest_behind = true;
-      SCOPE_EXIT { FLAGS_test_db_create_with_allow_ingest_behind = false; };
-      const string testdbOptions2 = generateDBName();
-      addDBWithRole(testdbOptions2, "MASTER");
-
-      req.db_name = testdbOptions2;
-
-      EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-      EXPECT_EQ(res.options["allow_ingest_behind"], "true");
-    }
-  }
+  req.db_name = testdb3;
+  req.set_include_meta(true);
+  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+  EXPECT_TRUE(res.__isset.db_metas);
+  EXPECT_EQ(res.db_metas["s3_bucket"], "fakes3bucket");
+  EXPECT_EQ(res.db_metas["s3_path"], "fakes3path");
 }
 
 TEST(AdminHandlerTest, MetaData) {

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -572,11 +572,10 @@ TEST_F(AdminHandlerTestBase, AdminAPIsWithWriteMeta) {
 }
 
 TEST_F(AdminHandlerTestBase, CheckDB) {
-  const string testdb1 = generateDBName();
-  addDBWithRole(testdb1, "MASTER");
+  addDBWithRole("imp00001", "MASTER");
   auto dbs = db_manager_->getAllDBNames();
   EXPECT_EQ(dbs.size(), (unsigned)1);
-  EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb1), dbs.end());
+  EXPECT_NE(std::find(dbs.begin(), dbs.end(), "imp00001"), dbs.end());
 
   CheckDBRequest req;
   CheckDBResponse res;
@@ -584,43 +583,23 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
 
   EXPECT_THROW(res = client_->future_checkDB(req).get(), AdminException);
 
-  req.db_name = testdb1;
+  req.db_name = "imp00001";
   EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
   EXPECT_EQ(res.seq_num, 0);
   EXPECT_EQ(res.wal_ttl_seconds, 123);
   EXPECT_EQ(res.last_update_timestamp_ms, 0);
-  EXPECT_FALSE(res.__isset.db_metas);
 
-  const string testdb2 = generateDBName();
-  addDBWithRole(testdb2, "MASTER");
+  addDBWithRole("imp00002", "MASTER");
   dbs = db_manager_->getAllDBNames();
-  EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb2), dbs.end());
+  EXPECT_NE(std::find(dbs.begin(), dbs.end(), "imp00002"), dbs.end());
 
-  deleteKeyFromDB(testdb2, "a");
-  req.db_name = testdb2;
+  deleteKeyFromDB("imp00002", "a");
+  req.db_name = "imp00002";
   EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
   EXPECT_EQ(res.seq_num, 1);
   EXPECT_EQ(res.wal_ttl_seconds, 123);
   // 1521000000 is 03/14/2018 @ 4:00am (UTC)
   EXPECT_GT(res.last_update_timestamp_ms, 1521000000);
-
-  // verify: checkDB get metadata
-  const string testdb3 = generateDBName();
-  addDBWithRole(testdb3, "MASTER");
-  auto meta = handler_->getMetaData(testdb3);
-  verifyMeta(meta, testdb3, true, "", "");
-
-  // write fake DBMetadata for <testdb3>
-  handler_->writeMetaData(testdb3, "fakes3bucket", "fakes3path");
-  meta = handler_->getMetaData(testdb3);
-  verifyMeta(meta, testdb3, true, "fakes3bucket", "fakes3path");
-
-  req.db_name = testdb3;
-  req.set_include_meta(true);
-  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-  EXPECT_TRUE(res.__isset.db_metas);
-  EXPECT_EQ(res.db_metas["s3_bucket"], "fakes3bucket");
-  EXPECT_EQ(res.db_metas["s3_path"], "fakes3path");
 }
 
 TEST(AdminHandlerTest, MetaData) {

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -20,14 +20,11 @@
 #include <ctime>
 #include <iostream>
 #include <thread>
-#include <unordered_map>
-#include <map>
 #include <vector>
 
 #include "boost/filesystem.hpp"
 #include "gflags/gflags.h"
 #include "gtest/gtest.h"
-#include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
 #include "rocksdb_admin/application_db.h"
 #include "rocksdb_admin/tests/test_util.h"
@@ -54,7 +51,6 @@ using std::shared_ptr;
 using std::string;
 using std::to_string;
 using std::unique_ptr;
-using std::unordered_map;
 using std::vector;
 using std::chrono::seconds;
 using std::this_thread::sleep_for;
@@ -138,33 +134,6 @@ class ApplicationDBTestBase : public testing::Test {
   string db_path_;
   Options last_options_;
 };
-
-TEST_F(ApplicationDBTestBase, GetOptionsAsStrMap) {
-  unordered_map<string, string> option_with_expvals{
-      {"create_if_missing", "true"},
-      {"error_if_exists", "true"},
-      {"WAL_size_limit_MB", "100"},
-      {"allow_ingest_behind", "false"},
-      {"bottommost_compression", "kDisableCompressionOption"},
-      {"compaction_style", "kCompactionStyleLevel"},
-      {"disable_auto_compactions", "false"}};
-
-  vector<string> option_names{"unknown_option_name"};
-  for (const auto& map_entry : option_with_expvals) {
-    option_names.push_back(map_entry.first);
-  }
-
-  map<string, string> resp_options;
-  EXPECT_TRUE(db_->GetOptions(option_names, &resp_options).ok());
-
-  for (const auto& option_name : option_names) {
-    if (option_name == "unknown_option_name") {
-      EXPECT_EQ(resp_options.find(option_name), resp_options.end());
-    } else {
-      EXPECT_EQ(resp_options[option_name], option_with_expvals[option_name]);
-    }
-  }
-}
 
 TEST_F(ApplicationDBTestBase, SetImmutableOptionsFail) {
   EXPECT_FALSE(last_options_.allow_ingest_behind);

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -29,9 +29,7 @@
 #include "gtest/gtest.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
-#define private public
 #include "rocksdb_admin/application_db.h"
-#undef private
 #include "rocksdb_admin/tests/test_util.h"
 #include "rocksdb_replicator/rocksdb_replicator.h"
 
@@ -78,19 +76,19 @@ class ApplicationDBTestBase : public testing::Test {
   int numTableFilesAtLevel(int level) {
     std::string p;
     db_->rocksdb()->GetProperty(
-        DB::Properties::kNumFilesAtLevelPrefix + std::to_string(level), &p);
+        "rocksdb.num-files-at-level" + std::to_string(level), &p);
     return atoi(p.c_str());
   }
 
   int numCompactPending() {
     uint64_t p;
-    db_->rocksdb()->GetIntProperty(DB::Properties::kCompactionPending, &p);
+    db_->rocksdb()->GetIntProperty("rocksdb.compaction-pending", &p);
     return static_cast<int>(p);
   }
 
   string levelStats() {
     std::string p;
-    db_->rocksdb()->GetProperty(DB::Properties::kLevelStats, &p);
+    db_->rocksdb()->GetProperty("rocksdb.levelstats", &p);
     return p;
   }
 
@@ -266,15 +264,6 @@ TEST_F(ApplicationDBTestBase, SetOptionsDisableEnableAutoCompaction) {
   // the two sst at L0 will merge into 1 at L1
   EXPECT_EQ(numTableFilesAtLevel(1), 2);
   EXPECT_EQ(numCompactPending(), 0);
-}
-
-TEST_F(ApplicationDBTestBase, GetProperty) {
-  string p_val;
-  EXPECT_TRUE(db_->GetProperty(ApplicationDB::Properties::kNumLevels, &p_val));
-  EXPECT_EQ(atoi(p_val.c_str()), 7);
-  EXPECT_TRUE(db_->GetProperty(ApplicationDB::Properties::kHighestEmptyLevel, &p_val));
-  EXPECT_EQ(atoi(p_val.c_str()), 6);
-  EXPECT_TRUE(db_->DBLmaxEmpty());
 }
 
 TEST_F(ApplicationDBTestBase, GetLSMLevelInfo) {


### PR DESCRIPTION
We are using the thrift change data in a peer-to-peer way, which introduce various compatibility issue. 
For example, in a cluster, during deploy, old hosts might still serving build without the thrift change, while new hosts are serving build with the thrift change, then, the old->new read, or new->old read on the thrift change will break. 

We will have to revert all business logic using the thrift change, but only keep the thrift change itself. 
Then, we will rollout thrift change to all clusters, then, add business logic to use the thrift change. 