### PR TITLE
Only change the local reference to last known published value, if publish is actually successful

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ZkBasedPerResourceShardMapPublisher.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/publisher/ZkBasedPerResourceShardMapPublisher.java
@@ -201,7 +201,6 @@ public class ZkBasedPerResourceShardMapPublisher implements ShardMapPublisher<JS
       if (latestResourceMapStr != null && latestResourceMapStr.equals(currentResourceMapStr)) {
         return;
       }
-      latestResourceToConfigMap.put(resourceName, currentResourceMapStr);
 
       final JSONObject topLevelJSONObject = new JSONObject();
       final JSONObject metaBlock = new JSONObject();
@@ -232,6 +231,7 @@ public class ZkBasedPerResourceShardMapPublisher implements ShardMapPublisher<JS
         } else {
           zkShardMapClient.setData().forPath(zkPath, serializedCompressedJson);
         }
+        latestResourceToConfigMap.put(resourceName, currentResourceMapStr);
       } catch (Exception e) {
         LOG.error(String.format(
             "Error publishing shard_map / resource_map to zk cluster: %s, resource: %s",


### PR DESCRIPTION
We match the resource map with last known published value... and don't publish if it is same as previous one. However, when we cache the last resource map, we don't know if later on the publish will be actually be successful. Hence we must store the reference to last known publish value, only if the last publish is actually successful.