### PR TITLE
Share a single zkConnection across multiple clusters to save connections to zookeeper cluster

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/ClientShardMapAgent.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/ClientShardMapAgent.java
@@ -32,6 +32,9 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.BoundedExponentialBackoffRetry;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
@@ -42,6 +45,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 /**
@@ -71,6 +76,7 @@ public class ClientShardMapAgent {
   private static final String clustersArg = "clusters";
   private static final String clustersFileArg = "clustersFile";
   private static final String shardMapDownloadDirArg = "shardMapDownloadDir";
+  private static final String disableSharingZkClientArg = "disableSharingZkClient";
 
   private static Options constructCommandLineOptions() {
     Option shardMapZkSvrOption =
@@ -104,11 +110,20 @@ public class ClientShardMapAgent {
     shardMapDownloadDirOption.setRequired(true);
     shardMapDownloadDirOption.setArgName(shardMapDownloadDirArg);
 
+    Option disableSharingZkClientOption = OptionBuilder
+        .withLongOpt(disableSharingZkClientArg)
+        .withDescription("Explicitly disable sharing zk connection for watching multiple clusters")
+        .create();
+    disableSharingZkClientOption.setArgs(0);
+    disableSharingZkClientOption.setRequired(false);
+    disableSharingZkClientOption.setArgName(disableSharingZkClientArg);
+
     Options options = new Options();
     options.addOption(shardMapZkSvrOption)
         .addOption(clustersOption)
         .addOption(clustersFileOption)
-        .addOption(shardMapDownloadDirOption);
+        .addOption(shardMapDownloadDirOption)
+        .addOption(disableSharingZkClientOption);
 
     return options;
   }
@@ -130,6 +145,7 @@ public class ClientShardMapAgent {
     final String shardMapDownloadDir = cmd.getOptionValue(shardMapDownloadDirArg);
     final String csClusters = cmd.getOptionValue(clustersArg, "");
     final String clustersFile = cmd.getOptionValue(clustersFileArg, "");
+    final boolean disableSharingZkClient = cmd.hasOption(disableSharingZkClientArg);
 
     Preconditions.checkArgument(!(csClusters.isEmpty() && clustersFile.isEmpty()));
 
@@ -164,8 +180,26 @@ public class ClientShardMapAgent {
       };
     }
 
+    final AtomicReference<CuratorFramework> zkShardMapClientRef = new AtomicReference<>(null);
+    if (!disableSharingZkClient) {
+      CuratorFramework zkShardMapClient = CuratorFrameworkFactory
+          .newClient(zkConnectString,
+              new BoundedExponentialBackoffRetry(
+                  250, 10000, 60));
+
+      zkShardMapClient.start();
+      try {
+        zkShardMapClient.blockUntilConnected(120, TimeUnit.SECONDS);
+        zkShardMapClientRef.set(zkShardMapClient);
+      } catch (InterruptedException e) {
+        zkShardMapClient.close();
+        throw new RuntimeException();
+      }
+    }
+
     ClusterShardMapAgentManager handler =
-        new ClusterShardMapAgentManager(zkConnectString, shardMapDownloadDir, clustersSupplier);
+        new ClusterShardMapAgentManager(zkConnectString, zkShardMapClientRef.get(),
+            shardMapDownloadDir, clustersSupplier);
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
@@ -174,6 +208,9 @@ public class ClientShardMapAgent {
           handler.close();
         } catch (IOException e) {
           e.printStackTrace();
+        }
+        if (zkShardMapClientRef.get() != null) {
+          zkShardMapClientRef.get().close();
         }
       }
     });

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Spectator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Spectator.java
@@ -91,35 +91,6 @@ public class Spectator {
 
   private ConfigGenerator configGenerator = null;
 
-  public Spectator(String zkConnectString, String clusterName, String instanceName,
-                   String httpPostUri, String shardMapZkSvr, String shardMapDownloadDir,
-                   LeaderEventsLogger spectatorLeaderEventsLogger) throws Exception {
-    this.clusterName = clusterName;
-    this.instanceName = instanceName;
-    this.httpPostUri = httpPostUri;
-    this.shardMapZkSvr = shardMapZkSvr;
-    this.shardMapDownloadDir = shardMapDownloadDir;
-
-    this.helixManager =
-        HelixManagerFactory
-            .getZKHelixManager(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectString);
-    this.monitor = new RocksplicatorMonitor(clusterName, instanceName);
-    this.spectatorLeaderEventsLogger = spectatorLeaderEventsLogger;
-
-    helixManager.connect();
-
-    Runtime.getRuntime().addShutdownHook(new Thread() {
-      @Override
-      public void run() {
-        try {
-          stopListeners();
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-      }
-    });
-  }
-
   private static Options constructCommandLineOptions() {
     Option zkServerOption =
         OptionBuilder.withLongOpt(zkServer).withDescription("Provide zookeeper addresses").create();
@@ -325,8 +296,33 @@ public class Spectator {
     LOG.error("Returning from main");
   }
 
-  private static String getClusterLockPath(String cluster) {
-    return "/rocksplicator/" + cluster + "/spectator/lock";
+  public Spectator(String zkConnectString, String clusterName, String instanceName,
+                   String httpPostUri, String shardMapZkSvr, String shardMapDownloadDir,
+                   LeaderEventsLogger spectatorLeaderEventsLogger) throws Exception {
+    this.clusterName = clusterName;
+    this.instanceName = instanceName;
+    this.httpPostUri = httpPostUri;
+    this.shardMapZkSvr = shardMapZkSvr;
+    this.shardMapDownloadDir = shardMapDownloadDir;
+
+    this.helixManager =
+        HelixManagerFactory
+            .getZKHelixManager(clusterName, instanceName, InstanceType.SPECTATOR, zkConnectString);
+    this.monitor = new RocksplicatorMonitor(clusterName, instanceName);
+    this.spectatorLeaderEventsLogger = spectatorLeaderEventsLogger;
+
+    helixManager.connect();
+
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        try {
+          stopListeners();
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+    });
   }
 
   private void startListener() throws Exception {
@@ -357,7 +353,8 @@ public class Spectator {
        * start downloading shard_map for this cluster.
        */
       if (!(shardMapZkSvr.isEmpty() || shardMapDownloadDir.isEmpty())) {
-        ClusterShardMapAgent clusterShardMapAgent =
+        ClusterShardMapAgent
+            clusterShardMapAgent =
             new ClusterShardMapAgent(shardMapZkSvr, null, clusterName, shardMapDownloadDir);
         clusterShardMapAgent.startNotification();
         Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -421,5 +418,9 @@ public class Spectator {
       }
       staticClientLeaderEventsLogger = null;
     }
+  }
+
+  private static String getClusterLockPath(String cluster) {
+    return "/rocksplicator/" + cluster + "/spectator/lock";
   }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmapagent/ClusterShardMapAgent.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmapagent/ClusterShardMapAgent.java
@@ -69,28 +69,39 @@ public class ClusterShardMapAgent implements Closeable {
   private final String clusterName;
   private final String zkConnectString;
   private final CuratorFramework zkShardMapClient;
+  private final boolean zkClientIsOwned;
   private final PathChildrenCache pathChildrenCache;
   private final ConcurrentHashMap<String, JSONObject> shardMapsByResources;
   private final ZkShardMapCodec zkShardMapCompressedCodec;
   private final ScheduledExecutorService dumperExecutorService;
   private final AtomicInteger numPendingNotifications;
 
-  public ClusterShardMapAgent(String zkConnectString, String clusterName, String shardMapDir) {
+  public ClusterShardMapAgent(
+      String zkConnectString,
+      CuratorFramework zkSharedShardMapClient,
+      String clusterName,
+      String shardMapDir) {
     this.clusterName = clusterName;
     this.shardMapDir = shardMapDir;
     this.tempShardMapDir = shardMapDir + "/" + ".temp";
     this.zkConnectString = zkConnectString;
 
-    this.zkShardMapClient = CuratorFrameworkFactory
-        .newClient(this.zkConnectString,
-            new BoundedExponentialBackoffRetry(
-                100, 10000, 10));
+    if (zkSharedShardMapClient != null) {
+      this.zkClientIsOwned = false;
+      this.zkShardMapClient = zkSharedShardMapClient;
+    } else {
+      this.zkClientIsOwned = true;
+      this.zkShardMapClient = CuratorFrameworkFactory
+          .newClient(this.zkConnectString,
+              new BoundedExponentialBackoffRetry(
+                  250, 10000, 60));
 
-    this.zkShardMapClient.start();
-    try {
-      this.zkShardMapClient.blockUntilConnected(60, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      throw new RuntimeException();
+      this.zkShardMapClient.start();
+      try {
+        this.zkShardMapClient.blockUntilConnected(60, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        throw new RuntimeException();
+      }
     }
     this.shardMapsByResources = new ConcurrentHashMap<>();
     this.zkShardMapCompressedCodec = new ZkGZIPCompressedShardMapCodec();
@@ -296,6 +307,8 @@ public class ClusterShardMapAgent implements Closeable {
     }
 
     this.pathChildrenCache.close();
-    this.zkShardMapClient.close();
+    if (zkClientIsOwned && zkShardMapClient != null) {
+      this.zkShardMapClient.close();
+    }
   }
 }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmapagent/ClusterShardMapAgentManager.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmapagent/ClusterShardMapAgentManager.java
@@ -18,6 +18,7 @@
 
 package com.pinterest.rocksplicator.shardmapagent;
 
+import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,15 +38,19 @@ public class ClusterShardMapAgentManager implements Closeable {
 
   private final String shardMapDir;
   private final String zkShardMapSvr;
+  private final CuratorFramework zkShardMapClient;
   private final Supplier<Set<String>> clustersSupplier;
   private final ConcurrentHashMap<String, ClusterShardMapAgent> clusterAgents;
   private final ScheduledExecutorService scheduledExecutorService;
 
+
   public ClusterShardMapAgentManager(
       final String zkShardMapSvr,
+      final CuratorFramework zkShardMapClient,
       final String shardMapDir,
       final Supplier<Set<String>> clustersSupplier) {
     this.zkShardMapSvr = zkShardMapSvr;
+    this.zkShardMapClient = zkShardMapClient;
     this.shardMapDir = shardMapDir;
     this.clustersSupplier = clustersSupplier;
     this.clusterAgents = new ConcurrentHashMap<>();

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmapagent/ClusterShardMapAgentManager.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/shardmapagent/ClusterShardMapAgentManager.java
@@ -96,7 +96,8 @@ public class ClusterShardMapAgentManager implements Closeable {
         try {
           LOG.error(String.format("Start Watching cluster: %s", cluster));
           ClusterShardMapAgent agent =
-              new ClusterShardMapAgent(this.zkShardMapSvr, cluster, shardMapDir);
+              new ClusterShardMapAgent(this.zkShardMapSvr, this.zkShardMapClient, cluster,
+                  shardMapDir);
           clusterAgents.put(cluster, agent);
           clusterAgents.get(cluster).startNotification();
         } catch (Exception e) {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/spectator/ConfigGeneratorClusterSpectatorImpl.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/spectator/ConfigGeneratorClusterSpectatorImpl.java
@@ -169,8 +169,13 @@ public class ConfigGeneratorClusterSpectatorImpl implements ClusterSpectator {
     if (this.clusterShardMapAgent == null) {
       if (shardMapZkSvr != null && !shardMapZkSvr.isEmpty()) {
         if (shardMapDownloadDir != null && !shardMapDownloadDir.isEmpty()) {
+          /**
+           * There is no need to share the zk client, as number of spectator instances is expected
+           * to be really small and total number of zk clients created will be linear to number of
+           * participant clusters being watched in total by all spectator instances...
+           */
           this.clusterShardMapAgent =
-              new ClusterShardMapAgent(shardMapZkSvr, clusterName, shardMapDownloadDir);
+              new ClusterShardMapAgent(shardMapZkSvr, null, clusterName, shardMapDownloadDir);
           this.clusterShardMapAgent.startNotification();
           LOGGER.info(
               String.format("Successfully started ShardMapAgent for cluster=%s", clusterName));

--- a/cluster_management/src/test/java/com/pinterest/rocksplicator/shardmapagent/ClusterShardMapAgentTest.java
+++ b/cluster_management/src/test/java/com/pinterest/rocksplicator/shardmapagent/ClusterShardMapAgentTest.java
@@ -85,7 +85,8 @@ public class ClusterShardMapAgentTest {
      * Now enable downloading of the data to local file.
      */
     ClusterShardMapAgent clusterShardMapAgent =
-        new ClusterShardMapAgent(zkTestServer.getConnectString(), CLUSTER_NAME, "target/shardmap");
+        new ClusterShardMapAgent(zkTestServer.getConnectString(), null, CLUSTER_NAME,
+            "target/shardmap");
 
     clusterShardMapAgent.startNotification();
 


### PR DESCRIPTION
In case of some clients that need routing informations for multiple stateful clusters, it needs to watch multiple clusters to the shardmap zk. Earlier we used one zk client per cluster. However all cluster information are available on same zk cluster. Means we can potentially share the same connection across each of the cluster specific agents (as all agents for all clusters are running in the same jvm)

Verified the result by running a local clientshardagent and download multiple cluster's shardmap. It works in both cases. When explicitly disabled... it will fallback to old behaviour of creating one zk client per cluster it needs to watch.