### PR TITLE
Revert "reverts for non p2p changes 482, 485, 486"

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1295,7 +1295,8 @@ void AdminHandler::async_tm_checkDB(
     std::map<std::string, std::string> metas;
     metas["s3_bucket"] = meta.s3_bucket;
     metas["s3_path"] = meta.s3_path;
-    metas["last_kafka_msg_timestamp_ms"] = std::to_string(meta.last_kafka_msg_timestamp_ms);
+    metas["last_kafka_msg_timestamp_ms"] =
+        std::to_string(meta.last_kafka_msg_timestamp_ms);
     response.db_metas = metas;
     response.__isset.db_metas = true;
   }
@@ -1568,13 +1569,15 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
   if (ingest_behind) {
     if (!db->rocksdb()->GetDBOptions().allow_ingest_behind) {
       e.message = request->db_name + " DBOptions.allow_ingest_behind false";
-      LOG(ERROR) << "DBOptions.allow_ingest_behind false, can't ingest behind " << request->db_name;
+      LOG(ERROR) << "DBOptions.allow_ingest_behind false, can't ingest behind "
+                 << request->db_name;
       callback.release()->exceptionInThread(std::move(e));
       return;
     }
     if (!db->DBLmaxEmpty()) {
       // note: default num levels for DB is 7 (0, 1, ..., 6)
-      std::string errMsg = "The Lmax of DB is not empty, skip ingestion to " + request->db_name;
+      std::string errMsg =
+          "The Lmax of DB is not empty, skip ingestion to " + request->db_name;
       e.message = errMsg;
       callback.release()->exceptionInThread(std::move(e));
       LOG(ERROR) << errMsg;

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1279,7 +1279,16 @@ void AdminHandler::async_tm_checkDB(
     }
   }
 
-  // TODO: get options as str for specified optionField
+  if (request->__isset.option_names && !request->option_names.empty()) {
+    std::map<std::string, std::string> options_map;
+    auto s = db->GetOptions(request->option_names, &options_map);
+    if (s.ok()) {
+      response.options = options_map;
+      response.__isset.options = true;
+    } else {
+      LOG(ERROR) << "Failed to GetOptions from db, " << s.ToString();
+    }
+  }
 
   if (request->__isset.include_meta) {
     auto meta = getMetaData(request->db_name);

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -26,6 +26,7 @@
 #include <thread>
 #include <unordered_set>
 #include <vector>
+#include <map>
 
 #include "boost/filesystem.hpp"
 #include "common/identical_name_thread_factory.h"
@@ -1276,6 +1277,18 @@ void AdminHandler::async_tm_checkDB(
         response.set_last_update_timestamp_ms(extractor.ms);
       }
     }
+  }
+
+  // TODO: get options as str for specified optionField
+
+  if (request->__isset.include_meta) {
+    auto meta = getMetaData(request->db_name);
+    std::map<std::string, std::string> metas;
+    metas["s3_bucket"] = meta.s3_bucket;
+    metas["s3_path"] = meta.s3_path;
+    metas["last_kafka_msg_timestamp_ms"] = std::to_string(meta.last_kafka_msg_timestamp_ms);
+    response.db_metas = metas;
+    response.__isset.db_metas = true;
   }
 
   callback->result(response);

--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -12,7 +12,6 @@
 /// See the License for the specific language governing permissions and
 /// limitations under the License.
 
-
 #pragma once
 
 #include <string>
@@ -29,6 +28,15 @@ namespace admin {
 // along with basic data operations(read/write)
 class ApplicationDB {
  public:
+
+  struct Properties {
+    // "applicationdb.num-levels" - return string of the configured level of DB
+    static const std::string kNumLevels;
+    // "applicationdb.highest-empty-level" - return string of the highest empty
+    // level number
+    static const std::string kHighestEmptyLevel;
+  };
+
   // Create a ApplicationDB instance
   // db_name:       (IN) name of this db instance
   // db:            (IN) shared pointer of rocksdb instance
@@ -97,8 +105,9 @@ class ApplicationDB {
                                        const rocksdb::Options& options,
                                        const std::string& delimiter = ";  ");
 
-  // get the highest empty level of default column family
-  uint32_t getHighestEmptyLevel();
+  bool GetProperty(const rocksdb::Slice& property, std::string* value);
+
+  bool DBLmaxEmpty();
 
   // Whether this db instance is slave
   bool IsSlave() const { return role_ == replicator::DBRole::SLAVE; }
@@ -120,6 +129,9 @@ class ApplicationDB {
   ~ApplicationDB();
 
  private:
+  // get the highest empty level of default column family
+  uint32_t getHighestEmptyLevel();
+
   const std::string db_name_;
   std::shared_ptr<rocksdb::DB> db_;
 

--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -89,7 +89,14 @@ class ApplicationDB {
   rocksdb::Status CompactRange(const rocksdb::CompactRangeOptions& options,
                                const rocksdb::Slice* begin,
                                const rocksdb::Slice* end);
-  
+
+  rocksdb::Status GetOptions(std::vector<std::string>& option_names,
+                             std::map<std::string, std::string>* options_map);
+
+  rocksdb::Status GetStringFromOptions(std::string* options_str,
+                                       const rocksdb::Options& options,
+                                       const std::string& delimiter = ";  ");
+
   // get the highest empty level of default column family
   uint32_t getHighestEmptyLevel();
 

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -572,10 +572,11 @@ TEST_F(AdminHandlerTestBase, AdminAPIsWithWriteMeta) {
 }
 
 TEST_F(AdminHandlerTestBase, CheckDB) {
-  addDBWithRole("imp00001", "MASTER");
+  const string testdb1 = generateDBName();
+  addDBWithRole(testdb1, "MASTER");
   auto dbs = db_manager_->getAllDBNames();
   EXPECT_EQ(dbs.size(), (unsigned)1);
-  EXPECT_NE(std::find(dbs.begin(), dbs.end(), "imp00001"), dbs.end());
+  EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb1), dbs.end());
 
   CheckDBRequest req;
   CheckDBResponse res;
@@ -583,23 +584,43 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
 
   EXPECT_THROW(res = client_->future_checkDB(req).get(), AdminException);
 
-  req.db_name = "imp00001";
+  req.db_name = testdb1;
   EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
   EXPECT_EQ(res.seq_num, 0);
   EXPECT_EQ(res.wal_ttl_seconds, 123);
   EXPECT_EQ(res.last_update_timestamp_ms, 0);
+  EXPECT_FALSE(res.__isset.db_metas);
 
-  addDBWithRole("imp00002", "MASTER");
+  const string testdb2 = generateDBName();
+  addDBWithRole(testdb2, "MASTER");
   dbs = db_manager_->getAllDBNames();
-  EXPECT_NE(std::find(dbs.begin(), dbs.end(), "imp00002"), dbs.end());
+  EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb2), dbs.end());
 
-  deleteKeyFromDB("imp00002", "a");
-  req.db_name = "imp00002";
+  deleteKeyFromDB(testdb2, "a");
+  req.db_name = testdb2;
   EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
   EXPECT_EQ(res.seq_num, 1);
   EXPECT_EQ(res.wal_ttl_seconds, 123);
   // 1521000000 is 03/14/2018 @ 4:00am (UTC)
   EXPECT_GT(res.last_update_timestamp_ms, 1521000000);
+
+  // verify: checkDB get metadata
+  const string testdb3 = generateDBName();
+  addDBWithRole(testdb3, "MASTER");
+  auto meta = handler_->getMetaData(testdb3);
+  verifyMeta(meta, testdb3, true, "", "");
+
+  // write fake DBMetadata for <testdb3>
+  handler_->writeMetaData(testdb3, "fakes3bucket", "fakes3path");
+  meta = handler_->getMetaData(testdb3);
+  verifyMeta(meta, testdb3, true, "fakes3bucket", "fakes3path");
+
+  req.db_name = testdb3;
+  req.set_include_meta(true);
+  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+  EXPECT_TRUE(res.__isset.db_metas);
+  EXPECT_EQ(res.db_metas["s3_bucket"], "fakes3bucket");
+  EXPECT_EQ(res.db_metas["s3_path"], "fakes3path");
 }
 
 TEST(AdminHandlerTest, MetaData) {

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <ctime>
+#include <map>
 #include <thread>
 
 #include "boost/filesystem.hpp"
@@ -64,6 +65,7 @@ using rocksdb::Status;
 using std::make_shared;
 using std::make_tuple;
 using std::make_unique;
+using std::map;
 using std::string;
 using std::thread;
 using std::to_string;
@@ -295,6 +297,14 @@ TEST_F(AdminHandlerTestBase, SetRocksDBOptions) {
   req.options = {{"disable_auto_compactions", "true"}};
   EXPECT_NO_THROW(resp = client_->future_setDBOptions(req).get());
   EXPECT_TRUE(app_db->rocksdb()->GetOptions().disable_auto_compactions);
+
+  CheckDBRequest check_req;
+  CheckDBResponse check_resp;
+  check_req.db_name = testdb;
+  check_req.__isset.option_names = true;
+  check_req.option_names = {"disable_auto_compactions"};
+  EXPECT_NO_THROW(check_resp = client_->future_checkDB(check_req).get());
+  EXPECT_EQ(check_resp.options["disable_auto_compactions"], "true");
 
   // Verify: set immutable db options -> !ok
   EXPECT_FALSE(app_db->rocksdb()->GetOptions().allow_ingest_behind);
@@ -580,47 +590,123 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
 
   CheckDBRequest req;
   CheckDBResponse res;
-  req.db_name = "unknown_db";
 
-  EXPECT_THROW(res = client_->future_checkDB(req).get(), AdminException);
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
 
-  req.db_name = testdb1;
-  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-  EXPECT_EQ(res.seq_num, 0);
-  EXPECT_EQ(res.wal_ttl_seconds, 123);
-  EXPECT_EQ(res.last_update_timestamp_ms, 0);
-  EXPECT_FALSE(res.__isset.db_metas);
+    req.db_name = "unknown_db";
+    EXPECT_THROW(res = client_->future_checkDB(req).get(), AdminException);
+  }
 
-  const string testdb2 = generateDBName();
-  addDBWithRole(testdb2, "MASTER");
-  dbs = db_manager_->getAllDBNames();
-  EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb2), dbs.end());
+  // Verify checkDB of newly DB with default vals
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
 
-  deleteKeyFromDB(testdb2, "a");
-  req.db_name = testdb2;
-  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-  EXPECT_EQ(res.seq_num, 1);
-  EXPECT_EQ(res.wal_ttl_seconds, 123);
-  // 1521000000 is 03/14/2018 @ 4:00am (UTC)
-  EXPECT_GT(res.last_update_timestamp_ms, 1521000000);
+    req.db_name = testdb1;
+
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    EXPECT_EQ(res.seq_num, 0);
+    EXPECT_EQ(res.wal_ttl_seconds, 123);
+    EXPECT_EQ(res.last_update_timestamp_ms, 0);
+    EXPECT_FALSE(res.__isset.db_metas);
+  }
+
+  // Verify checkDB from existed DB
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
+
+    const string testdb2 = generateDBName();
+    addDBWithRole(testdb2, "MASTER");
+    dbs = db_manager_->getAllDBNames();
+    EXPECT_NE(std::find(dbs.begin(), dbs.end(), testdb2), dbs.end());
+    deleteKeyFromDB(testdb2, "a");
+
+    req.db_name = testdb2;
+
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    EXPECT_EQ(res.seq_num, 1);
+    EXPECT_EQ(res.wal_ttl_seconds, 123);
+    // 1521000000 is 03/14/2018 @ 4:00am (UTC)
+    EXPECT_GT(res.last_update_timestamp_ms, 1521000000);
+  }
 
   // verify: checkDB get metadata
-  const string testdb3 = generateDBName();
-  addDBWithRole(testdb3, "MASTER");
-  auto meta = handler_->getMetaData(testdb3);
-  verifyMeta(meta, testdb3, true, "", "");
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
 
-  // write fake DBMetadata for <testdb3>
-  handler_->writeMetaData(testdb3, "fakes3bucket", "fakes3path");
-  meta = handler_->getMetaData(testdb3);
-  verifyMeta(meta, testdb3, true, "fakes3bucket", "fakes3path");
+    const string testdb3 = generateDBName();
+    addDBWithRole(testdb3, "MASTER");
+    auto meta = handler_->getMetaData(testdb3);
+    verifyMeta(meta, testdb3, true, "", "");
 
-  req.db_name = testdb3;
-  req.set_include_meta(true);
-  EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
-  EXPECT_TRUE(res.__isset.db_metas);
-  EXPECT_EQ(res.db_metas["s3_bucket"], "fakes3bucket");
-  EXPECT_EQ(res.db_metas["s3_path"], "fakes3path");
+    // write fake DBMetadata for <testdb3>
+    handler_->writeMetaData(testdb3, "fakes3bucket", "fakes3path");
+    meta = handler_->getMetaData(testdb3);
+    verifyMeta(meta, testdb3, true, "fakes3bucket", "fakes3path");
+
+    req.db_name = testdb3;
+    req.set_include_meta(true);
+
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    EXPECT_TRUE(res.__isset.db_metas);
+    EXPECT_EQ(res.db_metas["s3_bucket"], "fakes3bucket");
+    EXPECT_EQ(res.db_metas["s3_path"], "fakes3path");
+  }
+
+  // verify CheckDB get options
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
+
+    map<string, string> option_with_expvals{
+        {"WAL_ttl_seconds", "123"},
+        {"allow_ingest_behind", "false"},
+        {"disable_auto_compactions", "false"}};
+    vector<string> option_names{"unknown_option_name"};
+    for (const auto& map_entry : option_with_expvals) {
+      option_names.push_back(map_entry.first);
+    }
+
+    req.db_name = testdb1;
+    req.option_names = option_names;
+    req.__isset.option_names = true;
+
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    for (const auto& option_name : option_names) {
+      if (option_name == "unknown_option_name") {
+        EXPECT_EQ(res.options.find(option_name), res.options.end());
+      } else {
+        EXPECT_EQ(res.options[option_name], option_with_expvals[option_name]);
+      }
+    }
+
+    // get DB options when created with allow_ingest_behind
+    {
+      FLAGS_test_db_create_with_allow_ingest_behind = true;
+      SCOPE_EXIT { FLAGS_test_db_create_with_allow_ingest_behind = false; };
+      const string testdbOptions2 = generateDBName();
+      addDBWithRole(testdbOptions2, "MASTER");
+
+      req.db_name = testdbOptions2;
+
+      EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+      EXPECT_EQ(res.options["allow_ingest_behind"], "true");
+    }
+  }
 }
 
 TEST(AdminHandlerTest, MetaData) {

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -24,7 +24,9 @@
 #include "boost/filesystem.hpp"
 #include "folly/SocketAddress.h"
 #include "gtest/gtest.h"
+#include "rocksdb/options.h"
 #include "rocksdb/status.h"
+#include "rocksdb_admin/application_db.h"
 #define private public
 #include "rocksdb_admin/admin_handler.h"
 #undef private
@@ -59,6 +61,7 @@ using apache::thrift::RpcOptions;
 using apache::thrift::ThriftServer;
 using apache::thrift::async::TAsyncSocket;
 using common::ThriftClientPool;
+using rocksdb::FlushOptions;
 using rocksdb::Options;
 using rocksdb::ReadOptions;
 using rocksdb::Status;
@@ -212,6 +215,12 @@ class AdminHandlerTestBase : public testing::Test {
     batch.Put(key, val);
     auto app_db = db_manager_->getDB(db_name, nullptr);
     EXPECT_TRUE(app_db->Write(rocksdb::WriteOptions(), &batch).ok());
+  }
+
+  void flushDB(const string db_name) {
+    auto app_db = db_manager_->getDB(db_name, nullptr);
+    auto s = app_db->rocksdb()->Flush(FlushOptions());
+    EXPECT_TRUE(s.ok());
   }
 
   void clearDB(const string db_name) {
@@ -403,7 +412,7 @@ TEST_F(AdminHandlerTestBase, AddS3SstFilesToDBTest) {
 
       // 4th ingest, ingest behind from ssDir1 after clearDB with reopen with
       // allow_ingest_behind -> ok
-      // Then, ingest behind from sstDir2 will violate Lmax.empty() -> exception
+      // Then, ingest behind from sstDir2 will violate Lmax.empty()->exception
       {
         FLAGS_test_db_create_with_allow_ingest_behind = true;
         // by default, not allow overlap, so always will recreate DB
@@ -615,6 +624,7 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
     EXPECT_EQ(res.wal_ttl_seconds, 123);
     EXPECT_EQ(res.last_update_timestamp_ms, 0);
     EXPECT_FALSE(res.__isset.db_metas);
+    EXPECT_FALSE(res.__isset.properties);
   }
 
   // Verify checkDB from existed DB
@@ -706,6 +716,46 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
       EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
       EXPECT_EQ(res.options["allow_ingest_behind"], "true");
     }
+  }
+
+  const string app_p_not_define = "applicationdb.not-defined-property";
+  const string rocksdb_p_not_define = "rocksdb.not-defined-property";
+  const string p_not_define = "not-defined-property";
+  const string num_files_at_l0 =
+      rocksdb::DB::Properties::kNumFilesAtLevelPrefix + "0";
+  vector<string> property_names{{ApplicationDB::Properties::kNumLevels,
+                                 ApplicationDB::Properties::kHighestEmptyLevel,
+                                 app_p_not_define, num_files_at_l0,
+                                 rocksdb_p_not_define, p_not_define}};
+  // Verify: checkDB get properties
+  {
+    SCOPE_EXIT {
+      req.__clear();
+      res.__clear();
+    };
+
+    const string testdbP = generateDBName();
+    addDBWithRole(testdbP, "MASTER");
+
+    req.db_name = testdbP;
+    req.property_names = property_names;
+    req.__isset.property_names = true;
+
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    EXPECT_TRUE(res.__isset.properties);
+    EXPECT_EQ(res.properties[ApplicationDB::Properties::kNumLevels], "7");
+    EXPECT_EQ(res.properties[ApplicationDB::Properties::kHighestEmptyLevel],
+              "6");
+    EXPECT_EQ(res.properties.find(app_p_not_define), res.properties.end());
+    EXPECT_EQ(res.properties[num_files_at_l0], "0");
+    EXPECT_EQ(res.properties.find(rocksdb_p_not_define), res.properties.end());
+    EXPECT_EQ(res.properties.find(p_not_define), res.properties.end());
+
+    writeToDB(testdbP, "1", "1");
+    flushDB(testdbP);
+    EXPECT_NO_THROW(res = client_->future_checkDB(req).get());
+    EXPECT_EQ(res.seq_num, 1);
+    EXPECT_EQ(res.properties[num_files_at_l0], "1");
   }
 }
 

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -29,7 +29,9 @@
 #include "gtest/gtest.h"
 #include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
+#define private public
 #include "rocksdb_admin/application_db.h"
+#undef private
 #include "rocksdb_admin/tests/test_util.h"
 #include "rocksdb_replicator/rocksdb_replicator.h"
 
@@ -76,19 +78,19 @@ class ApplicationDBTestBase : public testing::Test {
   int numTableFilesAtLevel(int level) {
     std::string p;
     db_->rocksdb()->GetProperty(
-        "rocksdb.num-files-at-level" + std::to_string(level), &p);
+        DB::Properties::kNumFilesAtLevelPrefix + std::to_string(level), &p);
     return atoi(p.c_str());
   }
 
   int numCompactPending() {
     uint64_t p;
-    db_->rocksdb()->GetIntProperty("rocksdb.compaction-pending", &p);
+    db_->rocksdb()->GetIntProperty(DB::Properties::kCompactionPending, &p);
     return static_cast<int>(p);
   }
 
   string levelStats() {
     std::string p;
-    db_->rocksdb()->GetProperty("rocksdb.levelstats", &p);
+    db_->rocksdb()->GetProperty(DB::Properties::kLevelStats, &p);
     return p;
   }
 
@@ -264,6 +266,15 @@ TEST_F(ApplicationDBTestBase, SetOptionsDisableEnableAutoCompaction) {
   // the two sst at L0 will merge into 1 at L1
   EXPECT_EQ(numTableFilesAtLevel(1), 2);
   EXPECT_EQ(numCompactPending(), 0);
+}
+
+TEST_F(ApplicationDBTestBase, GetProperty) {
+  string p_val;
+  EXPECT_TRUE(db_->GetProperty(ApplicationDB::Properties::kNumLevels, &p_val));
+  EXPECT_EQ(atoi(p_val.c_str()), 7);
+  EXPECT_TRUE(db_->GetProperty(ApplicationDB::Properties::kHighestEmptyLevel, &p_val));
+  EXPECT_EQ(atoi(p_val.c_str()), 6);
+  EXPECT_TRUE(db_->DBLmaxEmpty());
 }
 
 TEST_F(ApplicationDBTestBase, GetLSMLevelInfo) {

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -20,11 +20,14 @@
 #include <ctime>
 #include <iostream>
 #include <thread>
+#include <unordered_map>
+#include <map>
 #include <vector>
 
 #include "boost/filesystem.hpp"
 #include "gflags/gflags.h"
 #include "gtest/gtest.h"
+#include "rocksdb/convenience.h"
 #include "rocksdb/db.h"
 #include "rocksdb_admin/application_db.h"
 #include "rocksdb_admin/tests/test_util.h"
@@ -51,6 +54,7 @@ using std::shared_ptr;
 using std::string;
 using std::to_string;
 using std::unique_ptr;
+using std::unordered_map;
 using std::vector;
 using std::chrono::seconds;
 using std::this_thread::sleep_for;
@@ -134,6 +138,33 @@ class ApplicationDBTestBase : public testing::Test {
   string db_path_;
   Options last_options_;
 };
+
+TEST_F(ApplicationDBTestBase, GetOptionsAsStrMap) {
+  unordered_map<string, string> option_with_expvals{
+      {"create_if_missing", "true"},
+      {"error_if_exists", "true"},
+      {"WAL_size_limit_MB", "100"},
+      {"allow_ingest_behind", "false"},
+      {"bottommost_compression", "kDisableCompressionOption"},
+      {"compaction_style", "kCompactionStyleLevel"},
+      {"disable_auto_compactions", "false"}};
+
+  vector<string> option_names{"unknown_option_name"};
+  for (const auto& map_entry : option_with_expvals) {
+    option_names.push_back(map_entry.first);
+  }
+
+  map<string, string> resp_options;
+  EXPECT_TRUE(db_->GetOptions(option_names, &resp_options).ok());
+
+  for (const auto& option_name : option_names) {
+    if (option_name == "unknown_option_name") {
+      EXPECT_EQ(resp_options.find(option_name), resp_options.end());
+    } else {
+      EXPECT_EQ(resp_options[option_name], option_with_expvals[option_name]);
+    }
+  }
+}
 
 TEST_F(ApplicationDBTestBase, SetImmutableOptionsFail) {
   EXPECT_FALSE(last_options_.allow_ingest_behind);

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -307,6 +307,7 @@ TEST_F(ApplicationDBTestBase, GetLSMLevelInfo) {
   EXPECT_TRUE(s.ok());
   // level6 is occupied by ingested data
   EXPECT_EQ(db_->getHighestEmptyLevel(), (unsigned)5);
+  EXPECT_FALSE(db_->DBLmaxEmpty());
 
   // compact DB
   rocksdb::CompactRangeOptions compact_options;
@@ -319,6 +320,7 @@ TEST_F(ApplicationDBTestBase, GetLSMLevelInfo) {
   // if change_level is false (default), compacted data will move to bottommost
   db_->rocksdb()->CompactRange(compact_options, nullptr, nullptr);
   EXPECT_EQ(db_->getHighestEmptyLevel(), (unsigned)6);
+  EXPECT_TRUE(db_->DBLmaxEmpty());
 }
 
 }  // namespace admin


### PR DESCRIPTION
In #489, we have reverted 4 previous commits, #482 , #485 , #486 , #484 . Among these changes, the 1st 3 are only changes to non-PeerToPeert info retrieval. So, these changes are backward (host with new changes can read old data without these changes from old build) and forward (old host with old build can read data from new host with include the changed data) compatible. Thus, we can revert them in 1 commit without any risk. 

NEXT: we will revert the "revert of #484 " in another separate PR to separate the "peerTopeer" change, ie. during `onBecomeFollowerFromOffline`, the local DB will get `upstreamStatus` from upstream host through `checkDB`, and compare with `localStatus` from local host through `checkDB`. 