### PR TITLE
Add simple backoff mechanism for file_watcher

### DIFF
--- a/common/file_watcher.h
+++ b/common/file_watcher.h
@@ -101,6 +101,7 @@ class FileWatcher {
   std::string ReadFileAndHash(const std::string& file_name, uint64_t* hash);
   int RegisterFile(const std::string& file_name, const bool check_dup = true);
   void ScheduleRegisterMonitoredFile(const std::string& file_name);
+  void ScheduleRegisterMonitoredFile(const std::string& file_name, const int time_slot_index);
   void CheckFileAndCallback(const std::string& file_name, State* state);
 
   struct INotifyHandler : public folly::EventHandler {


### PR DESCRIPTION
FileWatcher is used to watch changes in config files or other model file changes in rocksplicator applications.
In case of configurations like shardmap, they are latency sensitive. A blanket 2 second delay in all cases can cause significant drop in SR when shardmap needs to be updated as soon as it is available on the disk.

In order to adapt the file_watcher to different needs, we add a simple backoff mechanism which in case of configurations should be quick to register a file for re-registration without having to necessarily wait for 2 seconds.