### PR TITLE
Add a segment tag for db sst size.

### DIFF
--- a/common/segment_utils.cpp
+++ b/common/segment_utils.cpp
@@ -35,23 +35,24 @@ std::string DbNameToSegment(const std::string& db_name) {
   return segment;
 }
 
-void DbNameToSegmentAndVersion(const std::string& db_name, std::string* seg,
-                               std::string* v, const std::string v_deli) {
+void DbNameToSegmentAndVersion(const std::string& db_name, std::string* segment,
+                               std::string* version,
+                               const std::string version_delim) {
   if (db_name.size() <= kShardLength) {
-    *seg = db_name;
+    *segment = db_name;
     return;
   }
-  if (!v_deli.empty()) {
-    auto iter = db_name.rfind(v_deli);
+  if (!version_delim.empty()) {
+    auto iter = db_name.rfind(version_delim);
     if (iter != std::string::npos) {
-      *seg = db_name.substr(0, iter);
-      *v = db_name.substr(
-          iter + v_deli.size(),
-          db_name.size() - seg->size() - v_deli.size() - kShardLength);
+      *segment = db_name.substr(0, iter);
+      *version = db_name.substr(iter + version_delim.size(),
+                                db_name.size() - segment->size() -
+                                    version_delim.size() - kShardLength);
       return;
     }
   }
-  *seg = db_name.substr(0, db_name.size() - kShardLength);
+  *segment = db_name.substr(0, db_name.size() - kShardLength);
 }
 
 int ExtractShardId(const std::string& db_name) {

--- a/common/segment_utils.cpp
+++ b/common/segment_utils.cpp
@@ -29,10 +29,29 @@ std::string SegmentToDbName(const std::string& segment,
 }
 
 std::string DbNameToSegment(const std::string& db_name) {
+  std::string segment;
+  std::string version;
+  DbNameToSegmentAndVersion(db_name, &segment, &version, "");
+  return segment;
+}
+
+void DbNameToSegmentAndVersion(const std::string& db_name, std::string* seg,
+                               std::string* v, const std::string v_deli) {
   if (db_name.size() <= kShardLength) {
-    return db_name;
+    *seg = db_name;
+    return;
   }
-  return db_name.substr(0, db_name.size() - kShardLength);
+  if (!v_deli.empty()) {
+    auto iter = db_name.rfind(v_deli);
+    if (iter != std::string::npos) {
+      *seg = db_name.substr(0, iter);
+      *v = db_name.substr(
+          iter + v_deli.size(),
+          db_name.size() - seg->size() - v_deli.size() - kShardLength);
+      return;
+    }
+  }
+  *seg = db_name.substr(0, db_name.size() - kShardLength);
 }
 
 int ExtractShardId(const std::string& db_name) {

--- a/common/segment_utils.h
+++ b/common/segment_utils.h
@@ -27,6 +27,15 @@ std::string SegmentToDbName(const std::string& segment, const int shard_id);
 std::string DbNameToSegment(const std::string& db_name);
 
 /*
+ * Segment might have a <version> suffix, e.g. users---123[:05d], in which
+ * "users" is segment name, "---" is the versioning_delimiter and "123" is the
+ * <version> and [:05d] is a 5 digit shard number
+ */
+void DbNameToSegmentAndVersion(const std::string& db_name, std::string* seg,
+                               std::string* v,
+                               const std::string v_deli = "---");
+
+/*
  * Extract the shard id from a db name
  */
 int ExtractShardId(const std::string& db_name);

--- a/common/tests/segment_utils_test.cpp
+++ b/common/tests/segment_utils_test.cpp
@@ -15,42 +15,75 @@
 
 #include "common/segment_utils.h"
 
+#include <iostream>
 #include "gtest/gtest.h"
 
+namespace common {
+
 TEST(SegmentToDbNameTest, Basics) {
-  EXPECT_EQ(common::SegmentToDbName("seg", 1), "seg00001");
-  EXPECT_EQ(common::SegmentToDbName("seg", 12345), "seg12345");
+  EXPECT_EQ(SegmentToDbName("seg", 1), "seg00001");
+  EXPECT_EQ(SegmentToDbName("seg", 12345), "seg12345");
 }
 
 TEST(DbNameToSegmentTest, Basics) {
-  EXPECT_EQ(common::DbNameToSegment("seg00001"), "seg");
-  EXPECT_EQ(common::DbNameToSegment("seg12345"), "seg");
-  EXPECT_EQ(common::DbNameToSegment("seg12"), "seg12");
+  EXPECT_EQ(DbNameToSegment("seg00001"), "seg");
+  EXPECT_EQ(DbNameToSegment("seg12345"), "seg");
+  EXPECT_EQ(DbNameToSegment("seg12"), "seg12");
+}
+
+TEST(DbNameToSegmentAndVersionTest, Basics) {
+  std::string seg;
+  std::string v;
+
+  DbNameToSegmentAndVersion("seg", &seg, &v);
+  EXPECT_EQ(seg, "seg");
+  EXPECT_TRUE(v.empty());
+
+  DbNameToSegmentAndVersion("seg00001", &seg, &v);
+  EXPECT_EQ(seg, "seg");
+  EXPECT_TRUE(v.empty());
+
+  DbNameToSegmentAndVersion("seg---200001", &seg, &v);
+  EXPECT_EQ(seg, "seg");
+  EXPECT_EQ(v, "2");
+
+  v.clear();
+  DbNameToSegmentAndVersion("seg---200001", &seg, &v, "***");
+  EXPECT_EQ(seg, "seg---2");
+  EXPECT_TRUE(v.empty());
+
+  v.clear();
+  DbNameToSegmentAndVersion("seg---200001", &seg, &v, "--");
+  EXPECT_EQ(seg, "seg-");
+  EXPECT_EQ(v, "2");
 }
 
 TEST(ExtractShardIDTest, Basics) {
   std::string db_name;
 
   db_name = "test_db00000";
-  EXPECT_EQ(common::ExtractShardId(db_name), 0);
+  EXPECT_EQ(ExtractShardId(db_name), 0);
 
   db_name = "test_db00030";
-  EXPECT_EQ(common::ExtractShardId(db_name), 30);
+  EXPECT_EQ(ExtractShardId(db_name), 30);
 
   db_name = "test_db";
-  EXPECT_EQ(common::ExtractShardId(db_name), -1);
+  EXPECT_EQ(ExtractShardId(db_name), -1);
 }
 
 TEST(DbNameToHelixPartitionNameTest, Basics) {
   std::string db_name;
 
   db_name = "test_db00000";
-  EXPECT_EQ(common::DbNameToHelixPartitionName(db_name), "test_db_0");
+  EXPECT_EQ(DbNameToHelixPartitionName(db_name), "test_db_0");
 
   db_name = "test_db00030";
-  EXPECT_EQ(common::DbNameToHelixPartitionName(db_name), "test_db_30");
-
+  EXPECT_EQ(DbNameToHelixPartitionName(db_name), "test_db_30");
 }
+
+} // namespace common
+
+
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/rocksdb_admin/application_db_manager.cpp
+++ b/rocksdb_admin/application_db_manager.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "glog/logging.h"
+#include "common/segment_utils.h"
 
 namespace admin {
 
@@ -117,8 +118,12 @@ std::string ApplicationDBManager::DumpDBStatsAsText() const {
       sz = 0;
     }
 
-    stats += folly::stringPrintf("  total_sst_file_size db=%s: %" PRIu64 "\n",
-                                 db->db_name().c_str(), sz);
+    std::string seg;
+    std::string v;
+    common::DbNameToSegmentAndVersion(db->db_name(), &seg, &v);
+    stats += folly::stringPrintf(
+        "  total_sst_file_size segment=%s version=%s db=%s: %" PRIu64 "\n",
+        seg.c_str(), v.c_str(), db->db_name().c_str(), sz);
   }
 
   return stats;


### PR DESCRIPTION
Previously, for db (ie. a shard), we only have "db" tag, which makes it really hard to get the aggregated size of a whole segment. Plus, we have appended "version" to the segment in some of the use cases, which make the db_name as "segment""delimiter""version""shardNumber". 
Here, we added a util function `DbNameToSegmentAndVersion` to parse "segment" and "version" from a "db_name" and add them as tags to db_sst_size. 