### PR TITLE
Revert revert 484

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
@@ -395,11 +395,11 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
           // check if the local replica needs rebuild
           CheckDBResponse
               localStatus =
-              Utils.checkRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, true, null);
+              Utils.checkRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, true, null, null);
           CheckDBResponse upstreamStatus = null;
           if (!upstreamHost.equals(LOCAL_HOST_IP) && !upstreamHost.equals(this.host)) {
             upstreamStatus =
-                Utils.checkRemoteOrLocalDB(upstreamHost, upstreamPort, dbName, true, null);
+                Utils.checkRemoteOrLocalDB(upstreamHost, upstreamPort, dbName, true, null, null);
           }
 
           boolean needRebuild = true;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
@@ -403,8 +403,12 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
           }
 
           boolean needRebuild = true;
-          if (upstreamStatus != null && !upstreamStatus.db_metas.equals(localStatus.db_metas)) {
-            LOG.error("upstreamStatus exist and differ from localStatus, rebuild.");
+          if (upstreamStatus != null && upstreamStatus.isSetDb_metas() && !upstreamStatus.db_metas
+              .equals(localStatus.db_metas)) {
+            LOG.error(String.format(
+                "upstreamStatus exist and differ from localStatus, rebuild. upstreamStatus: %s, "
+                    + "localStatus: %s",
+                upstreamStatus.toString(), localStatus.toString()));
           } else if (liveHostAndRole.isEmpty()) {
             LOG.error("No other live replicas, skip rebuild " + dbName);
             needRebuild = false;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
@@ -88,6 +88,7 @@ import java.util.concurrent.TimeUnit;
 public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> {
 
   private static final Logger LOG = LoggerFactory.getLogger(MasterSlaveStateModelFactory.class);
+  private static final String LOCAL_HOST_IP = "127.0.0.1";
 
   private final String host;
   private final int adminPort;
@@ -234,7 +235,7 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
           LOG.error("Found another host " + hostWithHighestSeq + " with higher seq num: " +
               String.valueOf(highestSeq) + " for " + dbName);
           Utils.changeDBRoleAndUpStream(
-              "localhost", adminPort, dbName, "SLAVE", hostWithHighestSeq, adminPort);
+              LOCAL_HOST_IP, adminPort, dbName, "SLAVE", hostWithHighestSeq, adminPort);
 
           // wait for up to 10 mins
           for (int i = 0; i < 600; ++i) {
@@ -258,7 +259,7 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
         }
 
         // changeDBRoleAndUpStream(me, "Master")
-        Utils.changeDBRoleAndUpStream("localhost", adminPort, dbName, "MASTER",
+        Utils.changeDBRoleAndUpStream(LOCAL_HOST_IP, adminPort, dbName, "MASTER",
             "", adminPort);
 
         // Get the latest external view and state map
@@ -311,8 +312,8 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
       Utils.logTransitionMessage(message);
 
       try (Locker locker = new Locker(partitionMutex)) {
-        Utils.changeDBRoleAndUpStream("localhost", adminPort, Utils.getDbName(partitionName),
-            "SLAVE", "127.0.0.1", adminPort);
+        Utils.changeDBRoleAndUpStream(LOCAL_HOST_IP, adminPort, Utils.getDbName(partitionName),
+            "SLAVE", LOCAL_HOST_IP, adminPort);
         leaderEventsCollector.addEvent(LeaderEventType.PARTICIPANT_LEADER_DOWN_SUCCESS, null);
       } catch (RuntimeException e) {
         leaderEventsCollector.addEvent(LeaderEventType.PARTICIPANT_LEADER_DOWN_FAILURE, null);
@@ -382,17 +383,26 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
               upstream = instanceNameAndRole.getKey();
             }
           }
-          String upstreamHost = (upstream == null ? "127.0.0.1" : upstream.split("_")[0]);
+          String upstreamHost = (upstream == null ? LOCAL_HOST_IP : upstream.split("_")[0]);
           snapshotHost = upstreamHost;
           int upstreamPort =
               (upstream == null ? adminPort : Integer.parseInt(upstream.split("_")[1]));
           snapshotPort = upstreamPort;
 
           // check if the local replica needs rebuild
-          CheckDBResponse localStatus = Utils.checkLocalDB(dbName, adminPort);
+          CheckDBResponse
+              localStatus =
+              Utils.checkRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, true, null);
+          CheckDBResponse upstreamStatus = null;
+          if (!upstreamHost.equals(LOCAL_HOST_IP) && !upstreamHost.equals(this.host)) {
+            upstreamStatus =
+                Utils.checkRemoteOrLocalDB(upstreamHost, upstreamPort, dbName, true, null);
+          }
 
           boolean needRebuild = true;
-          if (liveHostAndRole.isEmpty()) {
+          if (upstreamStatus != null && !upstreamStatus.db_metas.equals(localStatus.db_metas)) {
+            LOG.error("upstreamStatus exist and differ from localStatus, rebuild.");
+          } else if (liveHostAndRole.isEmpty()) {
             LOG.error("No other live replicas, skip rebuild " + dbName);
             needRebuild = false;
           } else if (System.currentTimeMillis() <
@@ -410,7 +420,7 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
 
           // if rebuild is not needed, setup upstream and return
           if (!needRebuild) {
-            Utils.changeDBRoleAndUpStream("localhost", adminPort, dbName, "SLAVE",
+            Utils.changeDBRoleAndUpStream(LOCAL_HOST_IP, adminPort, dbName, "SLAVE",
                 upstreamHost, upstreamPort);
             Utils.logTransitionCompletionMessage(message);
             return;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
@@ -392,11 +392,11 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
           // check if the local replica needs rebuild
           CheckDBResponse
               localStatus =
-              Utils.checkRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, true, null);
+              Utils.checkRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, true, null, null);
           CheckDBResponse upstreamStatus = null;
           if (!upstreamHost.equals(LOCAL_HOST_IP) && !upstreamHost.equals(this.host)) {
             upstreamStatus =
-                Utils.checkRemoteOrLocalDB(upstreamHost, upstreamPort, dbName, true, null);
+                Utils.checkRemoteOrLocalDB(upstreamHost, upstreamPort, dbName, true, null, null);
           }
 
           boolean needRebuild = true;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
@@ -400,8 +400,12 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
           }
 
           boolean needRebuild = true;
-          if (upstreamStatus != null && !upstreamStatus.db_metas.equals(localStatus.db_metas)) {
-            LOG.error("upstreamStatus exist and differ from localStatus, rebuild.");
+          if (upstreamStatus != null && upstreamStatus.isSetDb_metas() && !upstreamStatus.db_metas
+              .equals(localStatus.db_metas)) {
+            LOG.error(String.format(
+                "upstreamStatus exist and differ from localStatus, rebuild. upstreamStatus: %s, "
+                    + "localStatus: %s",
+                upstreamStatus.toString(), localStatus.toString()));
           } else if (liveHostAndRole.isEmpty()) {
             LOG.error("No other live replicas, skip rebuild " + dbName);
             needRebuild = false;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -286,18 +286,20 @@ public class Utils {
    */
   @Deprecated
   public static CheckDBResponse checkLocalDB(String dbName, int adminPort) throws RuntimeException {
-    return checkRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, false, null);
+    return checkRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, false, null, null);
   }
 
   public static CheckDBResponse checkRemoteOrLocalDB(String host, int adminPort, String dbName,
                                                      boolean includeMeta,
-                                                     List<String> optionNames) {
+                                                     List<String> optionNames,
+                                                     List<String> property_names) {
     try {
       Admin.Client client = getAdminClient(host, adminPort);
 
       CheckDBRequest req = new CheckDBRequest(dbName);
       req.setInclude_meta(includeMeta);
       req.setOption_names(optionNames);
+      req.setProperty_names(property_names);
 
       return client.checkDB(req);
     } catch (TException e) {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -47,12 +47,14 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class Utils {
 
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
+  private static final String LOCAL_HOST_IP = "127.0.0.1";
 
   /**
    * Build a thrift client to local adminPort
@@ -61,7 +63,7 @@ public class Utils {
    * @throws TTransportException
    */
   public static Admin.Client getLocalAdminClient(int adminPort) throws TTransportException {
-    return getAdminClient("localhost", adminPort);
+    return getAdminClient(LOCAL_HOST_IP, adminPort);
   }
 
   /**
@@ -116,7 +118,7 @@ public class Utils {
    */
   public static void closeDB(String dbName, int adminPort) {
     try {
-      closeRemoteOrLocalDB("localhost", adminPort, dbName);
+      closeRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName);
     } catch (RuntimeException e) {
       LOG.error("closeDB failed with exception", e);
     }
@@ -157,7 +159,7 @@ public class Utils {
     try {
       try {
         client = getLocalAdminClient(adminPort);
-        req = new AddDBRequest(dbName, "127.0.0.1");
+        req = new AddDBRequest(dbName, LOCAL_HOST_IP);
         req.setDb_role(dbRole);
         client.addDB(req);
       } catch (AdminException e) {
@@ -218,7 +220,7 @@ public class Utils {
   public static long getLocalLatestSequenceNumber(String dbName, int adminPort)
       throws RuntimeException {
     LOG.error("Get local seq number");
-    long seqNum = getLatestSequenceNumber(dbName, "localhost", adminPort);
+    long seqNum = getLatestSequenceNumber(dbName, LOCAL_HOST_IP, adminPort);
     if (seqNum == -1) {
       throw new RuntimeException("Failed to fetch local sequence number for DB: " + dbName);
     }
@@ -275,23 +277,35 @@ public class Utils {
   }
 
   /**
-   * Check the status of a local DB
+   * Check the status of a local DB.
+   * This method is deprecated, please use @checkRemoteOrLocalDB
    * @param dbName
    * @param adminPort
    * @return the DB status
    * @throws RuntimeException
    */
+  @Deprecated
   public static CheckDBResponse checkLocalDB(String dbName, int adminPort) throws RuntimeException {
+    return checkRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, false, null);
+  }
+
+  public static CheckDBResponse checkRemoteOrLocalDB(String host, int adminPort, String dbName,
+                                                     boolean includeMeta,
+                                                     List<String> optionNames) {
     try {
-      Admin.Client client = getLocalAdminClient(adminPort);
+      Admin.Client client = getAdminClient(host, adminPort);
 
       CheckDBRequest req = new CheckDBRequest(dbName);
+      req.setInclude_meta(includeMeta);
+      req.setOption_names(optionNames);
+
       return client.checkDB(req);
     } catch (TException e) {
       LOG.error("Failed to check DB: ", e);
       throw new RuntimeException(e);
     }
   }
+
 
   /**
    * Backup the DB on the host
@@ -343,7 +357,7 @@ public class Utils {
   public static void restoreLocalDB(int adminPort, String dbName, String hdfsPath,
                                     String upsreamHost, int upstreamPort)
       throws RuntimeException {
-    restoreRemoteOrLocalDB("localhost", adminPort, dbName, hdfsPath, upsreamHost, upstreamPort);
+    restoreRemoteOrLocalDB(LOCAL_HOST_IP, adminPort, dbName, hdfsPath, upsreamHost, upstreamPort);
   }
 
   public static void restoreRemoteOrLocalDB(String host, int adminPort, String dbName,
@@ -432,7 +446,7 @@ public class Utils {
   public static void restoreLocalDBFromS3(int adminPort, String dbName, String s3Bucket,
                                           String s3Path, String upsreamHost, int upstreamPort)
       throws RuntimeException {
-    restoreRemoteOrLocalDBFromS3("localhost", adminPort, dbName, s3Bucket, s3Path, upsreamHost,
+    restoreRemoteOrLocalDBFromS3(LOCAL_HOST_IP, adminPort, dbName, s3Bucket, s3Path, upsreamHost,
         upstreamPort);
   }
 


### PR DESCRIPTION
This PR revert  the 484 revert in #489 

Basically, during Offline->Follower/S transition, it get Upstream's status from `checkDB` and compare with local status from local `checkDB`. Specifically, it upstreamStatus.db_metas is different localStatus, which means local DB need to rebuild from the upstream. 