### PR TITLE
add stats to s3util

### DIFF
--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -64,10 +64,10 @@ DEFINE_bool(disable_s3_download_stream_buffer, false,
 namespace {
   const std::string kS3GetObject = "s3_getobject";
   const std::string kS3GetObjectToStream = "s3_getobject_tostream";
-  const std::string kS3ListObject = "s3_listobject";
-  const std::string kS3ListObjectItems = "s3_listobject_items";
-  const std::string kS3ListObjectV2 = "s3_listobjectv2";
-  const std::string kS3ListObjectV2Items = "s3_listobjectv2_items";
+  const std::string kS3ListObjects = "s3_listobjects";
+  const std::string kS3ListObjectsItems = "s3_listobjects_items";
+  const std::string kS3ListObjectsV2 = "s3_listobjectsv2";
+  const std::string kS3ListObjectsV2Items = "s3_listobjectsv2_items";
   const std::string kS3ListAllObjects = "s3_listallobjects";
   const std::string kS3ListAllObjectsItems = "s3_listallobjects_items";
   const std::string kS3GetObjects = "s3_getobjects";
@@ -260,24 +260,24 @@ void S3Util::listObjectsHelper(const string& prefix, const string& delimiter,
 
 ListObjectsResponse S3Util::listObjects(const string& prefix,
                                         const string& delimiter) {
-  Stats::get()->Incr(kS3ListObject);
+  Stats::get()->Incr(kS3ListObjects);
   vector<string> objects;
   string error_message;
   listObjectsHelper(prefix, delimiter, "", &objects, nullptr, &error_message);
-  Stats::get()->Incr(kS3ListObjectItems, objects.size());
+  Stats::get()->Incr(kS3ListObjectsItems, objects.size());
   return ListObjectsResponse(objects, error_message);
 }
 
 ListObjectsResponseV2 S3Util::listObjectsV2(const string& prefix,
                                             const string& delimiter,
                                             const string& marker) {
-  Stats::get()->Incr(kS3ListObjectV2);
+  Stats::get()->Incr(kS3ListObjectsV2);
   vector<string> objects;
   string error_message;
   string next_marker;
   listObjectsHelper(prefix, delimiter, marker, &objects,
                     &next_marker, &error_message);
-  Stats::get()->Incr(kS3ListObjectV2Items, objects.size());
+  Stats::get()->Incr(kS3ListObjectsV2Items, objects.size());
   return ListObjectsResponseV2(
           ListObjectsResponseV2Body(objects, next_marker), error_message);
 }

--- a/common/thrift_client_pool.h
+++ b/common/thrift_client_pool.h
@@ -404,7 +404,7 @@ class ThriftClientPool {
 
       void operator()(T* t) {
         // We have to wait for it to avoid memory leak.
-        evb_->runImmediatelyOrRunInEventBaseThreadAndWait([t] {
+        evb_->runInEventBaseThreadAndWait([t] {
             delete t;
           });
       }
@@ -416,7 +416,7 @@ class ThriftClientPool {
     std::unique_ptr<T, Deleter> client(nullptr, deleter);
     auto ssl_ctx =
         ssl_ctx_ == nullptr ? nullptr : std::atomic_load_explicit(ssl_ctx_, std::memory_order_acquire);
-    event_loops_[idx].evb_->runImmediatelyOrRunInEventBaseThreadAndWait(
+    event_loops_[idx].evb_->runInEventBaseThreadAndWait(
         [&client, &event_loop = event_loops_[idx], &addr, &is_good,
          connect_timeout_ms, aggressively, ssl_ctx = std::move(ssl_ctx)] () mutable {
           auto channel = event_loop.getChannelFor(addr, connect_timeout_ms,

--- a/common/thrift_client_pool.h
+++ b/common/thrift_client_pool.h
@@ -404,7 +404,7 @@ class ThriftClientPool {
 
       void operator()(T* t) {
         // We have to wait for it to avoid memory leak.
-        evb_->runInEventBaseThreadAndWait([t] {
+        evb_->runImmediatelyOrRunInEventBaseThreadAndWait([t] {
             delete t;
           });
       }
@@ -416,7 +416,7 @@ class ThriftClientPool {
     std::unique_ptr<T, Deleter> client(nullptr, deleter);
     auto ssl_ctx =
         ssl_ctx_ == nullptr ? nullptr : std::atomic_load_explicit(ssl_ctx_, std::memory_order_acquire);
-    event_loops_[idx].evb_->runInEventBaseThreadAndWait(
+    event_loops_[idx].evb_->runImmediatelyOrRunInEventBaseThreadAndWait(
         [&client, &event_loop = event_loops_[idx], &addr, &is_good,
          connect_timeout_ms, aggressively, ssl_ctx = std::move(ssl_ctx)] () mutable {
           auto channel = event_loop.getChannelFor(addr, connect_timeout_ms,


### PR DESCRIPTION
Add stats to s3util apis to add some visibility of requests to S3. 

This is useful, because we often see S3 503 (ie. qps limit) error in production. With current change, we might not the qps to each S3 prefix, but, this will at least the S3 request from a instance. 

note: I also revert eventbase change in #502  since it broke the unit tests. I will remove the revert once that is fixed. 