### PR TITLE
clarify admin_handler::setDBOptions only support set column family op…

### DIFF
--- a/rocksdb_admin/rocksdb_admin.thrift
+++ b/rocksdb_admin/rocksdb_admin.thrift
@@ -235,6 +235,7 @@ struct KafkaMessagePayload {
   2: optional binary value
 }
 
+// currently, only support set column family options, not rocksdb::DBOptions
 struct SetDBOptionsRequest {
   # For keys supported in this map, please refer to:
   # https://github.com/facebook/rocksdb/blob/master/util/cf_options.h#L161


### PR DESCRIPTION
…tions, not rocksdb::DBOptions. 

If we aim to support set rocksdb::DBOptions, the admin handler api must call `DB::SetDBOptions`. For now, the admin_handler only call `DB::SetOptions`, which limit to change to column family options. 