### PR TITLE
Catch up to leader before completing offline -> follower transi…

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
@@ -91,6 +91,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
 
   private static final Logger LOG = LoggerFactory.getLogger(LeaderFollowerStateModelFactory.class);
   private static final String LOCAL_HOST_IP = "127.0.0.1";
+  private static final int LEADER_CATCH_UP_THRESHOLD = 100;
 
   private final String host;
   private final int adminPort;
@@ -249,7 +250,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
                     ") from " + hostWithHighestSeq + " for " + dbName);
             localSeq = newLocalSeq;
             if (highestSeq <= localSeq) {
-              LOG.error(dbName + " catched up!");
+              LOG.error(dbName + " caught up!");
               break;
             }
             LOG.error("Slept for " + String.valueOf(i + 1) + " seconds for replicating " + dbName);
@@ -331,6 +332,37 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
       Utils.logTransitionCompletionMessage(message);
     }
 
+  public Map<String, String> getLiveHostAndRole(NotificationContext context, String dbName) {
+    HelixAdmin admin = context.getManager().getClusterManagmentTool();
+    ExternalView view = admin.getResourceExternalView(cluster, resourceName);
+    Map<String, String> stateMap = view.getStateMap(partitionName);
+
+    // find live replicas
+    Map<String, String> liveHostAndRole = new HashMap<>();
+    for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
+      String role = instanceNameAndRole.getValue();
+      if (!role.equalsIgnoreCase("LEADER") &&
+          !role.equalsIgnoreCase("FOLLOWER") &&
+          !role.equalsIgnoreCase("OFFLINE")) {
+        continue;
+      }
+
+      String hostPort = instanceNameAndRole.getKey();
+      String host = hostPort.split("_")[0];
+      int port = Integer.parseInt(hostPort.split("_")[1]);
+
+      if (this.host.equals(host)) {
+        // myself
+        continue;
+      }
+
+      if (Utils.getLatestSequenceNumber(dbName, host, port) != -1) {
+        liveHostAndRole.put(hostPort, role);
+      }
+    }
+    return liveHostAndRole;
+  }
+
     /**
      * 3) Offline to Follower
      */
@@ -347,33 +379,8 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
           // open the DB if it's currently not opened yet
           Utils.addDB(dbName, adminPort, "FOLLOWER");
 
-          HelixAdmin admin = context.getManager().getClusterManagmentTool();
-          ExternalView view = admin.getResourceExternalView(cluster, resourceName);
-          Map<String, String> stateMap = view.getStateMap(partitionName);
-
           // find live replicas
-          Map<String, String> liveHostAndRole = new HashMap<>();
-          for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
-            String role = instanceNameAndRole.getValue();
-            if (!role.equalsIgnoreCase("LEADER") &&
-                !role.equalsIgnoreCase("FOLLOWER") &&
-                !role.equalsIgnoreCase("OFFLINE")) {
-              continue;
-            }
-
-            String hostPort = instanceNameAndRole.getKey();
-            String host = hostPort.split("_")[0];
-            int port = Integer.parseInt(hostPort.split("_")[1]);
-
-            if (this.host.equals(host)) {
-              // myself
-              continue;
-            }
-
-            if (Utils.getLatestSequenceNumber(dbName, host, port) != -1) {
-              liveHostAndRole.put(hostPort, role);
-            }
-          }
+          Map<String, String> liveHostAndRole = getLiveHostAndRole(context, dbName);
 
           // Find upstream, prefer Leader
           String upstream = null;
@@ -470,6 +477,50 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
           Utils.closeDB(dbName, adminPort);
           Utils.restoreLocalDBFromS3(adminPort, dbName, s3Bucket, s3Path, snapshotHost,
               snapshotPort);
+        }
+
+        try {
+          LOG.error(dbName + " Catching up live updates to leader");
+          Map<String, String> liveHostAndRole = getLiveHostAndRole(context, dbName);
+          // Find upstream, prefer Leader
+          String upstream = null;
+          for (Map.Entry<String, String> instanceNameAndRole : liveHostAndRole.entrySet()) {
+            String role = instanceNameAndRole.getValue();
+            if (role.equalsIgnoreCase("OFFLINE")) {
+              continue;
+            }
+            if (role.equalsIgnoreCase("LEADER")) {
+              upstream = instanceNameAndRole.getKey();
+              break;
+            } else {
+              upstream = instanceNameAndRole.getKey();
+            }
+          }
+
+          String upstreamHost = (upstream == null ? LOCAL_HOST_IP : upstream.split("_")[0]);
+          LOG.error(dbName + " got leader " + upstreamHost);
+          int upstreamPort =
+              (upstream == null ? adminPort : Integer.parseInt(upstream.split("_")[1]));
+
+          long local_seq_num;
+          long leader_seq_num;
+          // wait for up to 10 mins
+          for (int i = 0; i < 600; ++i) {
+            local_seq_num = Utils.getLocalLatestSequenceNumber(dbName, adminPort);
+            leader_seq_num = Utils.getLatestSequenceNumber(dbName, upstreamHost, upstreamPort);
+
+            // If leader sequence number is within threshold, consider caught up.
+            if (leader_seq_num < local_seq_num + LEADER_CATCH_UP_THRESHOLD) {
+              LOG.error(dbName + " caught up!");
+              break;
+            }
+            TimeUnit.SECONDS.sleep(1);
+          }
+        } catch (Exception e) {
+          // We've already backed up leader data and restored, ignore exception while
+          // waiting to catch up to leader
+          // TODO (rajathprasad): Add a stat for monitoring.
+          LOG.error("Failed to catch up to leader after backup " + dbName, e);
         }
       }
     }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
@@ -89,6 +89,7 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
 
   private static final Logger LOG = LoggerFactory.getLogger(MasterSlaveStateModelFactory.class);
   private static final String LOCAL_HOST_IP = "127.0.0.1";
+  private static final int MASTER_CATCH_UP_THRESHOLD = 100;
 
   private final String host;
   private final int adminPort;
@@ -328,6 +329,37 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
       Utils.logTransitionCompletionMessage(message);
     }
 
+    public Map<String, String> getLiveHostAndRole(NotificationContext context, String dbName) {
+      HelixAdmin admin = context.getManager().getClusterManagmentTool();
+      ExternalView view = admin.getResourceExternalView(cluster, resourceName);
+      Map<String, String> stateMap = view.getStateMap(partitionName);
+
+      // find live replicas
+      Map<String, String> liveHostAndRole = new HashMap<>();
+      for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
+        String role = instanceNameAndRole.getValue();
+        if (!role.equalsIgnoreCase("MASTER") &&
+            !role.equalsIgnoreCase("SLAVE") &&
+            !role.equalsIgnoreCase("OFFLINE")) {
+          continue;
+        }
+
+        String hostPort = instanceNameAndRole.getKey();
+        String host = hostPort.split("_")[0];
+        int port = Integer.parseInt(hostPort.split("_")[1]);
+
+        if (this.host.equals(host)) {
+          // myself
+          continue;
+        }
+
+        if (Utils.getLatestSequenceNumber(dbName, host, port) != -1) {
+          liveHostAndRole.put(hostPort, role);
+        }
+      }
+      return liveHostAndRole;
+    }
+
     /**
      * 3) Offline to Slave
      */
@@ -344,33 +376,8 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
           // open the DB if it's currently not opened yet
           Utils.addDB(dbName, adminPort);
 
-          HelixAdmin admin = context.getManager().getClusterManagmentTool();
-          ExternalView view = admin.getResourceExternalView(cluster, resourceName);
-          Map<String, String> stateMap = view.getStateMap(partitionName);
-
           // find live replicas
-          Map<String, String> liveHostAndRole = new HashMap<>();
-          for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
-            String role = instanceNameAndRole.getValue();
-            if (!role.equalsIgnoreCase("MASTER") &&
-                !role.equalsIgnoreCase("SLAVE") &&
-                !role.equalsIgnoreCase("OFFLINE")) {
-              continue;
-            }
-
-            String hostPort = instanceNameAndRole.getKey();
-            String host = hostPort.split("_")[0];
-            int port = Integer.parseInt(hostPort.split("_")[1]);
-
-            if (this.host.equals(host)) {
-              // myself
-              continue;
-            }
-
-            if (Utils.getLatestSequenceNumber(dbName, host, port) != -1) {
-              liveHostAndRole.put(hostPort, role);
-            }
-          }
+          Map<String, String> liveHostAndRole = getLiveHostAndRole(context, dbName);
 
           // Find upstream, prefer Master
           String upstream = null;
@@ -467,6 +474,49 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
           Utils.closeDB(dbName, adminPort);
           Utils.restoreLocalDBFromS3(adminPort, dbName, s3Bucket, s3Path, snapshotHost,
               snapshotPort);
+        }
+
+        try {
+          LOG.error(dbName + " Catching up live updates to master");
+          Map<String, String> liveHostAndRole = getLiveHostAndRole(context, dbName);
+          // Find upstream, prefer Master
+          String upstream = null;
+          for (Map.Entry<String, String> instanceNameAndRole : liveHostAndRole.entrySet()) {
+            String role = instanceNameAndRole.getValue();
+            if (role.equalsIgnoreCase("OFFLINE")) {
+              continue;
+            }
+            if (role.equalsIgnoreCase("MASTER")) {
+              upstream = instanceNameAndRole.getKey();
+              break;
+            } else {
+              upstream = instanceNameAndRole.getKey();
+            }
+          }
+
+          String upstreamHost = (upstream == null ? LOCAL_HOST_IP : upstream.split("_")[0]);
+          LOG.error(dbName + " got master " + upstreamHost);
+          int upstreamPort =
+              (upstream == null ? adminPort : Integer.parseInt(upstream.split("_")[1]));
+
+          long local_seq_num;
+          long master_seq_num;
+          // wait for up to 10 mins
+          for (int i = 0; i < 600; ++i) {
+            local_seq_num = Utils.getLocalLatestSequenceNumber(dbName, adminPort);
+            master_seq_num = Utils.getLatestSequenceNumber(dbName, upstreamHost, upstreamPort);
+
+            // If master sequence number is within threshold, consider caught up.
+            if (master_seq_num < local_seq_num + MASTER_CATCH_UP_THRESHOLD) {
+              LOG.error(dbName + " caught up!");
+              break;
+            }
+            TimeUnit.SECONDS.sleep(1);
+          }
+        } catch (Exception e) {
+          // We've already backed up master data and restored, ignore exception while
+          // waiting to catch up to master
+          LOG.error("Failed to catch up to master after backup " + dbName, e);
         }
       }
     }


### PR DESCRIPTION
…tion.

Current behavior in offline -> follower transition for a new offline
shard:
1. Find current leader.
2. Issue backup of DB.
3. Restore DB
4. Done.

Steps 2 and 3 can take up to an hour (and for some cases even more). So
the new follower could be lagging behind the leader for hours worth of
realtime updates.

Helix sometimes promotes a newly provisioned follower immediately to a
leader for load balancing. This causes the follower -> leader transition
to wait until the follower catches up to all the real time updates it
does not have. This causes drop in availability since there is no leader
for this shard during this period of time.

Proposed solution and behavior:
1. Find current leader.
2. Issue backup of DB.
3. Restore DB
4. Wait until the new follower has caught up to the leader (with a small
threshold)
5. Done.

With the proposed solution, future follower -> leader transitions can
complete quicker, improving availability.