### PR TITLE
Fix restoreTask issue - change leader role back to leader since by default db will be follower after restore

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -90,6 +90,10 @@ public class Utils {
         Integer.parseInt(partitionName.substring(lastIdx + 1)));
   }
 
+  /**
+   * @param dbName e.g. "p2p100001"
+   * @return e.g. "p2p1_1"
+   */
   public static String getPartitionName(String dbName) {
     String resourceName = dbName.substring(0, dbName.length() - 5);
     int partitionNumber = Integer.parseInt(dbName.substring(dbName.length() - 5));

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -164,7 +164,7 @@ public class Utils {
 
   public static void addRemoteOrLocalDB(String host, int adminPort, String dbName,
                                         String dbRole,
-                                        boolean overwrite_if_fail_add)
+                                        boolean overwriteIfFailAdd)
       throws RuntimeException {
     if (!dbRole.equals("SLAVE") && !dbRole.equals("FOLLOWER") && !dbRole.equals("NOOP")) {
       throw new RuntimeException("Invalid db role requested for new db " + dbName + " : " + dbRole);
@@ -183,7 +183,7 @@ public class Utils {
           LOG.error(dbName + " already exists");
           return;
         }
-        if (overwrite_if_fail_add) {
+        if (overwriteIfFailAdd) {
           LOG.error("Failed to open " + dbName, e);
           if (e.errorCode == AdminErrorCode.DB_ERROR) {
             LOG.error("Trying to overwrite open " + dbName);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTask.java
@@ -136,6 +136,7 @@ public class RestoreTask extends UserContentStore implements Task {
       } else {
         Utils.restoreRemoteOrLocalDB(host, adminPort, dbName, storePath, host, adminPort);
       }
+      Utils.addRemoteOrLocalDB(host, adminPort, dbName, "SLAVE", false);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/RestoreTask.java
@@ -144,7 +144,6 @@ public class RestoreTask extends UserContentStore implements Task {
       } else {
         Utils.restoreRemoteOrLocalDB(host, adminPort, dbName, storePath, host, adminPort);
       }
-      Utils.addRemoteOrLocalDB(host, adminPort, dbName, "FOLLOWER", false);
 
       if (isLeader) {
         Utils.changeDBRoleAndUpStream(host, adminPort, dbName, "LEADER", host, adminPort);


### PR DESCRIPTION
During restore (ie. `restoreDB` api in admin_handler), the db will be added back to `db_manager` as `replicator::DBRole::SLAVE`. Then, after restore, the 3 replicas of a shard will have 1 leader 2 followers in its helix externalView, but, the interval `dbRole` at `db_manager` will all be `replicator::DBRole::SLAVE`. Thus, we need change the previous leader back to leader role. 