### PR TITLE
Avoid logging binary string by logging thrift deserialized struct

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
@@ -416,9 +416,9 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
           if (upstreamStatus != null && upstreamStatus.isSetDb_metas() && !upstreamStatus.db_metas
               .equals(localStatus.db_metas)) {
             LOG.error(String.format(
-                "upstreamStatus exist and differ from localStatus, rebuild. upstreamStatus: %s, "
-                    + "localStatus: %s",
-                upstreamStatus.toString(), localStatus.toString()));
+                "upstreamStatus exist and differ from localStatus for %s, rebuild. "
+                    + "upstreamStatus: %s, localStatus: %s", dbName, upstreamStatus.toString(),
+                localStatus.toString()));
           } else if (liveHostAndRole.isEmpty()) {
             LOG.error("No other live replicas, skip rebuild " + dbName);
             needRebuild = false;

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -781,12 +781,15 @@ bool AdminHandler::restoreDBHelper(const std::string& db_name,
 
   DBMetaData meta;
   const std::string& meta_from_backup = backup_infos.back().app_metadata;
-  LOG(INFO) << "Get backupInfo.app_metadata:" << meta_from_backup << " from backupId: " << std::to_string(latest_backup_id);
-  if (!meta_from_backup.empty() && !DecodeThriftStruct(meta_from_backup, &meta)) {
-      e->errorCode = AdminErrorCode::DB_ERROR;
-      e->message = "Failed to decode DBMetaData";
-      return false;
-  } 
+  LOG(INFO) << "Get backupInfo.app_metadata (hexlified):"
+            << folly::hexlify(meta_from_backup)
+            << " from backupId: " << std::to_string(latest_backup_id);
+  if (!meta_from_backup.empty() &&
+      !DecodeThriftStruct(meta_from_backup, &meta)) {
+    e->errorCode = AdminErrorCode::DB_ERROR;
+    e->message = "Failed to decode DBMetaData";
+    return false;
+  }
   meta.set_db_name(db_name);
   if (!writeMetaData(meta.db_name, meta.s3_bucket, meta.s3_path)) {
     e->errorCode = AdminErrorCode::DB_ADMIN_ERROR;

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -781,9 +781,6 @@ bool AdminHandler::restoreDBHelper(const std::string& db_name,
 
   DBMetaData meta;
   const std::string& meta_from_backup = backup_infos.back().app_metadata;
-  LOG(INFO) << "Get backupInfo.app_metadata (hexlified):"
-            << folly::hexlify(meta_from_backup)
-            << " from backupId: " << std::to_string(latest_backup_id);
   if (!meta_from_backup.empty() &&
       !DecodeThriftStruct(meta_from_backup, &meta)) {
     e->errorCode = AdminErrorCode::DB_ERROR;
@@ -791,6 +788,9 @@ bool AdminHandler::restoreDBHelper(const std::string& db_name,
     return false;
   }
   meta.set_db_name(db_name);
+  LOG(INFO) << "Write DBMetaData db_name: " << meta.db_name
+            << ", s3_bucket: " << meta.s3_bucket << ", s3_path" << meta.s3_path
+            << " from backupId: " << std::to_string(latest_backup_id);
   if (!writeMetaData(meta.db_name, meta.s3_bucket, meta.s3_path)) {
     e->errorCode = AdminErrorCode::DB_ADMIN_ERROR;
     e->message = "RestoreDBHelper failed to write DBMetaData from restore's app_metadata for " + meta.db_name;


### PR DESCRIPTION
For string with binary data, if we directly log the binary string to log file. It will make the log grep confusing:
```
$grep -rn 'Get backupInfo.app_metadata' <service>.INFO
Binary file rockstore.INFO matches

# to actually grep the log (line with binary string)
grep -a -rn 'Get backupInfo.app_metadata' <service>.INFO
```
One way to avoid logging binary string is to hexlify it into hex string. But, then, it is not straightforward to under the hex string from the log. 
Or, in this case, we log the thrift struct after thrift deserialize from the binary string. 