### PR TITLE
Enable checksum

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -422,7 +422,7 @@ public class Utils {
   }
 
   public static void backupDBToS3WithLimit(String host, int adminPort, String dbName, int limitMbs,
-                                           String s3Bucket, String s3Path)
+                                           String s3Bucket, String s3Path, , boolean shareFilesWithChecksum)
       throws RuntimeException {
     LOG.error("(S3)Backup " + dbName + " from " + host + " to " + s3Path);
     try {
@@ -430,6 +430,7 @@ public class Utils {
 
       BackupDBToS3Request req = new BackupDBToS3Request(dbName, s3Bucket, s3Path);
       req.setLimit_mbs(limitMbs);
+      req.setShare_files_with_checksum(shareFilesWithChecksum);
       client.backupDBToS3(req);
     } catch (TException e) {
       LOG.error("Failed to backup DB: ", e);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -422,7 +422,7 @@ public class Utils {
   }
 
   public static void backupDBToS3WithLimit(String host, int adminPort, String dbName, int limitMbs,
-                                           String s3Bucket, String s3Path, , boolean shareFilesWithChecksum)
+                                           String s3Bucket, String s3Path, boolean shareFilesWithChecksum)
       throws RuntimeException {
     LOG.error("(S3)Backup " + dbName + " from " + host + " to " + s3Path);
     try {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -422,7 +422,8 @@ public class Utils {
   }
 
   public static void backupDBToS3WithLimit(String host, int adminPort, String dbName, int limitMbs,
-                                           String s3Bucket, String s3Path, boolean shareFilesWithChecksum)
+                                           String s3Bucket, String s3Path,
+                                           boolean shareFilesWithChecksum)
       throws RuntimeException {
     LOG.error("(S3)Backup " + dbName + " from " + host + " to " + s3Path);
     try {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTask.java
@@ -116,7 +116,7 @@ public class BackupTask extends UserContentStore implements Task {
       throws RuntimeException {
     try {
       if (useS3Store) {
-        Utils.backupDBToS3WithLimit(host, port, dbName, backupLimitMbs, s3Bucket, storePath);
+        Utils.backupDBToS3WithLimit(host, port, dbName, backupLimitMbs, s3Bucket, storePath, shareFilesWithChecksum);
       } else {
         Utils.backupDBWithLimit(host, port, dbName, storePath, backupLimitMbs,
             shareFilesWithChecksum);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTask.java
@@ -116,7 +116,8 @@ public class BackupTask extends UserContentStore implements Task {
       throws RuntimeException {
     try {
       if (useS3Store) {
-        Utils.backupDBToS3WithLimit(host, port, dbName, backupLimitMbs, s3Bucket, storePath, shareFilesWithChecksum);
+        Utils.backupDBToS3WithLimit(host, port, dbName, backupLimitMbs, s3Bucket, storePath,
+            shareFilesWithChecksum);
       } else {
         Utils.backupDBWithLimit(host, port, dbName, storePath, backupLimitMbs,
             shareFilesWithChecksum);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/BackupTaskFactory.java
@@ -74,7 +74,7 @@ public class BackupTaskFactory implements TaskFactory {
     String storePathPrefix = "";
     long resourceVersion = jobCreationTime;
     int backupLimitMbs = DEFAULT_BACKUP_LIMIT_MBS;
-    boolean shareFilesWithChecksum = true;
+    boolean shareFilesWithChecksum = false;
 
     try {
       Map<String, String> jobCmdMap = jobConfig.getJobCommandConfigMap();

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTask.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTask.java
@@ -114,7 +114,7 @@ public class DedupTask extends UserContentStore implements Task {
       LOG.error("compactDB is done");
       if (useS3Store) {
         Utils.backupDBToS3WithLimit("127.0.0.1", adminPort, dbName, backupLimitMbs, s3Bucket,
-            destStorePath);
+            destStorePath, shareFilesWithChecksum);
       } else {
         Utils.backupDBWithLimit("127.0.0.1", adminPort, dbName, destStorePath, backupLimitMbs,
             shareFilesWithChecksum);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/task/DedupTaskFactory.java
@@ -55,7 +55,7 @@ public class DedupTaskFactory implements TaskFactory {
     long resourceVersion = -1;
     String destStorePathPrefix = "";
     int backupLimitMbs = DEFAULT_BACKUP_LIMIT_MBS;
-    boolean shareFilesWithChecksum = true;
+    boolean shareFilesWithChecksum = false;
 
     try {
       Map<String, String> jobCmdMap = jobConfig.getJobCommandConfigMap();


### PR DESCRIPTION
Enable checksum in backup and dedup tasks when backing up to s3.
This change will include share_files_with_checksum option since backupDBToS3withLimit supports checksum
Testing:
Ran backup job when job config includes ROCKSDB_SHARE_FILES_WITH_CHECKSUM, and is set to True/False. Ensure d checksum is appended to backup files appropriately