### PR TITLE
add dbmeta files for checkpoint backup/restore

### DIFF
--- a/common/file_util.cpp
+++ b/common/file_util.cpp
@@ -8,26 +8,6 @@ namespace filesystem = boost::filesystem;
 
 namespace common {
 
-void FileUtil::touch(const std::string& path) {
-  std::ofstream file(path);
-  file.close();
-}
-
-std::string FileUtil::getSuccessFilePath(const std::string& base_dir) {
-  if (!filesystem::exists(base_dir)) {
-    throw std::runtime_error(
-        "Failed to get success file path since base dir not exist, " +
-        base_dir);
-  }
-  return base_dir + ((base_dir.back() == '/') ? "_SUCCESS" : "/_SUCCESS");
-}
-
-std::string FileUtil::createSuccessFile(const std::string& base_dir) {
-  std::string path = FileUtil::getSuccessFilePath(base_dir);
-  touch(path);
-  return path;
-}
-
 std::string FileUtil::createFileWithContent(const std::string& base_dir,
                                             const std::string& filename,
                                             const std::string& content) {

--- a/common/file_util.cpp
+++ b/common/file_util.cpp
@@ -1,7 +1,8 @@
 #include "file_util.h"
 
 #include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
+#include <fstream>
+#include <sstream>
 
 namespace filesystem = boost::filesystem;
 
@@ -9,7 +10,7 @@ namespace common {
 
 void FileUtil::touch(const std::string& path) {
   try {
-    filesystem::ofstream file(path);
+    std::ofstream file(path);
     file.close();
   } catch (std::exception& e) {
     throw e;
@@ -22,16 +23,33 @@ std::string FileUtil::getSuccessFilePath(const std::string& base_dir) {
         "Failed to get success file path since base dir not exist, " +
         base_dir);
   }
-  if (base_dir.back() != '/') {
-    return base_dir + "/_SUCCESS";
-  } else {
-    return base_dir + "_SUCCESS";
-  }
+  return base_dir + ((base_dir.back() == '/') ? "_SUCCESS" : "/_SUCCESS");
 }
 
 std::string FileUtil::createSuccessFile(const std::string& base_dir) {
   std::string path = FileUtil::getSuccessFilePath(base_dir);
   touch(path);
   return path;
+}
+
+std::string FileUtil::createFileWithContent(const std::string& base_dir,
+                                            const std::string& filename,
+                                            const std::string& content) {
+  std::string path =
+      base_dir + ((base_dir.back() == '/') ? filename : ("/" + filename));
+  std::ofstream file(path);
+  file << content;
+  file.close();
+  return path;
+}
+
+void FileUtil::readFileToString(const std::string& path, std::string* content) {
+  const std::ifstream input_stream(path);
+  if (input_stream.fail()) {
+    throw std::runtime_error("Failed to open file: " + path);
+  }
+  std::stringstream buffer;
+  buffer << input_stream.rdbuf();
+  content->assign(buffer.str());
 }
 }  // namespace common

--- a/common/file_util.cpp
+++ b/common/file_util.cpp
@@ -1,10 +1,7 @@
 #include "file_util.h"
 
-#include <boost/filesystem.hpp>
 #include <fstream>
 #include <sstream>
-
-namespace filesystem = boost::filesystem;
 
 namespace common {
 

--- a/common/file_util.cpp
+++ b/common/file_util.cpp
@@ -1,0 +1,37 @@
+#include "file_util.h"
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+
+namespace filesystem = boost::filesystem;
+
+namespace common {
+
+void FileUtil::touch(const std::string& path) {
+  try {
+    filesystem::ofstream file(path);
+    file.close();
+  } catch (std::exception& e) {
+    throw e;
+  }
+}
+
+std::string FileUtil::getSuccessFilePath(const std::string& base_dir) {
+  if (!filesystem::exists(base_dir)) {
+    throw std::runtime_error(
+        "Failed to get success file path since base dir not exist, " +
+        base_dir);
+  }
+  if (base_dir.back() != '/') {
+    return base_dir + "/_SUCCESS";
+  } else {
+    return base_dir + "_SUCCESS";
+  }
+}
+
+std::string FileUtil::createSuccessFile(const std::string& base_dir) {
+  std::string path = FileUtil::getSuccessFilePath(base_dir);
+  touch(path);
+  return path;
+}
+}  // namespace common

--- a/common/file_util.cpp
+++ b/common/file_util.cpp
@@ -9,12 +9,8 @@ namespace filesystem = boost::filesystem;
 namespace common {
 
 void FileUtil::touch(const std::string& path) {
-  try {
-    std::ofstream file(path);
-    file.close();
-  } catch (std::exception& e) {
-    throw e;
-  }
+  std::ofstream file(path);
+  file.close();
 }
 
 std::string FileUtil::getSuccessFilePath(const std::string& base_dir) {

--- a/common/file_util.h
+++ b/common/file_util.h
@@ -4,14 +4,6 @@
 namespace common {
 class FileUtil {
  public:
-  // create an empty file at local file system at absoluate path
-  static void touch(const std::string& path);
-
-  static std::string getSuccessFilePath(const std::string& base_dir);
-
-  // Create an empty _SUCCESS file; the file path is "<baseDir>/_SUCCESS".
-  static std::string createSuccessFile(const std::string& base_dir);
-
   // create file at path: "<baseDir>/filename"
   static std::string createFileWithContent(const std::string& base_dir,
                                            const std::string& filename,

--- a/common/file_util.h
+++ b/common/file_util.h
@@ -11,5 +11,11 @@ class FileUtil {
 
   // Create an empty _SUCCESS file; the file path is "<baseDir>/_SUCCESS".
   static std::string createSuccessFile(const std::string& base_dir);
+
+  static std::string createFileWithContent(const std::string& base_dir,
+                                           const std::string& filename,
+                                           const std::string& content);
+
+  static void readFileToString(const std::string& path, std::string* content);
 };
 }  // namespace common

--- a/common/file_util.h
+++ b/common/file_util.h
@@ -1,0 +1,15 @@
+
+#include <string>
+
+namespace common {
+class FileUtil {
+ public:
+  // create an empty file at local file system at absoluate path
+  static void touch(const std::string& path);
+
+  static std::string getSuccessFilePath(const std::string& base_dir);
+
+  // Create an empty _SUCCESS file; the file path is "<baseDir>/_SUCCESS".
+  static std::string createSuccessFile(const std::string& base_dir);
+};
+}  // namespace common

--- a/common/file_util.h
+++ b/common/file_util.h
@@ -12,6 +12,7 @@ class FileUtil {
   // Create an empty _SUCCESS file; the file path is "<baseDir>/_SUCCESS".
   static std::string createSuccessFile(const std::string& base_dir);
 
+  // create file at path: "<baseDir>/filename"
   static std::string createFileWithContent(const std::string& base_dir,
                                            const std::string& filename,
                                            const std::string& content);

--- a/common/tests/file_util_test.cpp
+++ b/common/tests/file_util_test.cpp
@@ -1,0 +1,38 @@
+#include "common/file_util.h"
+
+#include <boost/filesystem.hpp>
+#include <string>
+#include "gtest/gtest.h"
+
+namespace filesystem = boost::filesystem;
+
+namespace common {
+TEST(FileUtilTest, Touch) {
+  std::string path = "/tmp/_SUCCESS";
+  filesystem::remove(path);
+  EXPECT_FALSE(filesystem::exists(path));
+
+  FileUtil::touch(path);
+  EXPECT_TRUE(filesystem::exists(path));
+}
+
+TEST(FileUtilTest, CreateSuccessFile) {
+  std::string path = "/tmp/_SUCCESS";
+  filesystem::remove(path);
+  EXPECT_FALSE(filesystem::exists(path));
+
+  std::string succ_path = FileUtil::createSuccessFile("/tmp");
+  EXPECT_TRUE(filesystem::exists(succ_path));
+  EXPECT_EQ(succ_path, path);
+
+  std::string nonexist_dir = "/tmp/no-exist";
+  filesystem::remove(nonexist_dir);
+  EXPECT_THROW(FileUtil::createSuccessFile(nonexist_dir), std::runtime_error);
+}
+
+}  // namespace common
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/common/tests/file_util_test.cpp
+++ b/common/tests/file_util_test.cpp
@@ -7,28 +7,6 @@
 namespace filesystem = boost::filesystem;
 
 namespace common {
-TEST(FileUtilTest, Touch) {
-  std::string path = "/tmp/_SUCCESS";
-  filesystem::remove(path);
-  EXPECT_FALSE(filesystem::exists(path));
-
-  FileUtil::touch(path);
-  EXPECT_TRUE(filesystem::exists(path));
-}
-
-TEST(FileUtilTest, CreateSuccessFile) {
-  std::string path = "/tmp/_SUCCESS";
-  filesystem::remove(path);
-  EXPECT_FALSE(filesystem::exists(path));
-
-  std::string succ_path = FileUtil::createSuccessFile("/tmp");
-  EXPECT_TRUE(filesystem::exists(succ_path));
-  EXPECT_EQ(succ_path, path);
-
-  std::string nonexist_dir = "/tmp/no-exist";
-  filesystem::remove(nonexist_dir);
-  EXPECT_THROW(FileUtil::createSuccessFile(nonexist_dir), std::runtime_error);
-}
 
 TEST(FileUtilTest, CreateFileWithContent) {
   std::string base_dir = "/tmp";

--- a/common/tests/file_util_test.cpp
+++ b/common/tests/file_util_test.cpp
@@ -30,6 +30,20 @@ TEST(FileUtilTest, CreateSuccessFile) {
   EXPECT_THROW(FileUtil::createSuccessFile(nonexist_dir), std::runtime_error);
 }
 
+TEST(FileUtilTest, CreateFileWithContent) {
+  std::string base_dir = "/tmp";
+  std::string filename = "CreateFileWithContent";
+  std::string expected_path = base_dir + "/" + filename;
+  filesystem::remove(expected_path);
+
+  auto path = FileUtil::createFileWithContent(base_dir, filename, "hello");
+  EXPECT_EQ(path, expected_path);
+
+  std::string content;
+  FileUtil::readFileToString(path, &content);
+  EXPECT_EQ(content, "hello");
+}
+
 }  // namespace common
 
 int main(int argc, char** argv) {

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1055,14 +1055,13 @@ void AdminHandler::async_tm_backupDBToS3(
     }
 
     auto meta = getMetaData(request->db_name);
-    std::string dbmeta_path = formatted_checkpoint_local_path + kMetaFilename;
+    std::string dbmeta_path;
     std::string success_filepath;
     try {
       std::string encoded_meta;
       EncodeThriftStruct(meta, &encoded_meta);
-      common::FileUtil::createFileWithContent(formatted_checkpoint_local_path,
-                                              kMetaFilename, encoded_meta);
-
+      dbmeta_path = common::FileUtil::createFileWithContent(
+          formatted_checkpoint_local_path, kMetaFilename, encoded_meta);
       success_filepath =
           common::FileUtil::createSuccessFile(formatted_checkpoint_local_path);
     } catch (std::exception& e) {

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -28,7 +28,6 @@
 #include <vector>
 #include <map>
 
-#include <boost/algorithm/string/predicate.hpp>
 #include "boost/filesystem.hpp"
 #include "common/identical_name_thread_factory.h"
 #include "common/kafka/kafka_broker_file_watcher.h"

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -524,6 +524,17 @@ TEST_F(AdminHandlerTestBase, AdminAPIsWithWriteMeta) {
       verifyMeta(meta_after_restore, testdb, true, "", "");
 
       handler_->clearMetaData(testdb);
+
+      // verify backup & restore with meta for checkpoint
+      handler_->writeMetaData(testdb, "fakes3bucket", "fakes3path");
+      EXPECT_NO_THROW(backup_resp =
+                          client_->future_backupDBToS3(backup_req).get());
+      close_resp = client_->future_closeDB(close_req).get();
+      EXPECT_NO_THROW(restore_resp =
+                          client_->future_restoreDBFromS3(restore_req).get());
+      meta_after_restore = handler_->getMetaData(testdb);
+      verifyMeta(meta_after_restore, testdb, true, "fakes3bucket",
+                 "fakes3path");
     }
 
     // not use checkpoint for db upload/download

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -497,7 +497,7 @@ TEST_F(AdminHandlerTestBase, AdminAPIsWithWriteMeta) {
       backup_req.db_name = testdb;
       backup_req.s3_bucket = FLAGS_s3_bucket;
       backup_req.s3_backup_dir =
-          FLAGS_s3_backup_prefix + " checkpoint/" + testdb;
+          FLAGS_s3_backup_prefix + "checkpoint/" + testdb;
       BackupDBToS3Response backup_resp;
       LOG(INFO) << "Backup db: " << testdb << " to "
                 << backup_req.s3_backup_dir;
@@ -513,7 +513,7 @@ TEST_F(AdminHandlerTestBase, AdminAPIsWithWriteMeta) {
       restore_req.db_name = testdb;
       restore_req.s3_bucket = FLAGS_s3_bucket;
       restore_req.s3_backup_dir =
-          FLAGS_s3_backup_prefix + " checkpoint/" + testdb;
+          FLAGS_s3_backup_prefix + "checkpoint/" + testdb;
       restore_req.upstream_ip = localIP();
       restore_req.upstream_port = 8090;
       RestoreDBFromS3Response restore_resp;

--- a/rocksdb_admin/tests/utils_test.cpp
+++ b/rocksdb_admin/tests/utils_test.cpp
@@ -1,0 +1,44 @@
+#include "rocksdb_admin/utils.h"
+
+#include <boost/filesystem.hpp>
+#include <string>
+#include "common/file_util.h"
+#include "gtest/gtest.h"
+#include "rocksdb_admin/gen-cpp2/rocksdb_admin_types.h"
+
+namespace filesystem = boost::filesystem;
+
+namespace admin {
+
+TEST(UtilsTest, ThriftSederWithFileUtils) {
+  std::string base_dir = "/tmp";
+  std::string filename = "thrift_seder";
+  std::string expected_path = base_dir + "/" + filename;
+  filesystem::remove(expected_path);
+
+  DBMetaData meta;
+  meta.set_db_name("test00000");
+  meta.set_s3_bucket("hello-bucket");
+  meta.set_s3_path("test/part-00000-");
+  std::string encodedMeta;
+  EncodeThriftStruct(meta, &encodedMeta);
+  auto path =
+      common::FileUtil::createFileWithContent(base_dir, filename, encodedMeta);
+
+  std::string content;
+  common::FileUtil::readFileToString(path, &content);
+  EXPECT_EQ(content, encodedMeta);
+
+  DBMetaData decodedMeta;
+  DecodeThriftStruct(content, &decodedMeta);
+  EXPECT_EQ(decodedMeta.db_name, "test00000");
+  EXPECT_EQ(decodedMeta.s3_bucket, "hello-bucket");
+  EXPECT_EQ(decodedMeta.s3_path, "test/part-00000-");
+}
+
+}  // namespace admin
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rocksdb_admin/tests/utils_test.cpp
+++ b/rocksdb_admin/tests/utils_test.cpp
@@ -10,6 +10,16 @@ namespace filesystem = boost::filesystem;
 
 namespace admin {
 
+TEST(UtilsTest, ThriftSeder) {
+  // decode Meta from empty string is !ok
+  std::string content;
+  DBMetaData meta;
+  EXPECT_FALSE(DecodeThriftStruct(content, &meta));
+  EXPECT_TRUE(meta.db_name.empty());
+  EXPECT_FALSE(meta.__isset.s3_bucket);
+  EXPECT_FALSE(meta.__isset.s3_path);
+}
+
 TEST(UtilsTest, ThriftSederWithFileUtils) {
   std::string base_dir = "/tmp";
   std::string filename = "thrift_seder";


### PR DESCRIPTION
There are two changes in this PR:

- Rocksplicator uses Helix to manage shard movement. When a new replica bootstrap, it involves Backup&Restore. By default, it relies on rocksdb::backupengine to manage the backup and restore, which also enables to backup/restore with customized meta. This is useful if during the new replica boostrap, some info (ie. meta) need to pass from Leader replica to the new replica. In addition, admin handler also build a customized "backup/restore" process bypassing the rocksdb::backupengine by adopting rocksdb::checkpoint directly; however, this customized "backup/restore" does not support backup/restore with meta. 
-- Thus, in this PR: at backup path, it encodes data (ie. meta) into a string and save to a local "dbmeta" file; then, it will be uploaded to s3 along with other files in the checkpoint. At the restore path, it will download all files from s3, and check whether local restored DB has a `dbmeta` file, if so, it will decode the meta data and remove the `dbmeta` file.

- S3 supports eventual consistency. To guarantee restore path lists all the objects backuped at backup path, a `_SUCCESS` file is appended as the last object during backup path; then, restore path will check the existence of `_SUCCESS` to ensure the backup's integrity. 