### PR TITLE
Enable zstd compression in Ubuntu 18.

### DIFF
--- a/common/thrift_client_pool.cpp
+++ b/common/thrift_client_pool.cpp
@@ -41,6 +41,8 @@ DEFINE_int32(thrift_client_pool_log_frequency, 1000, "Log frequency");
 
 DEFINE_bool(channel_enable_snappy, false, "Enable snappy compression or not");
 
+DEFINE_bool(channel_enable_zstd, false, "Enable zstd compression or not");
+
 DEFINE_bool(use_framed_transport_for_binary_protocol, true,
             "Use framed transport for binary protocol");
 

--- a/common/thrift_client_pool.h
+++ b/common/thrift_client_pool.h
@@ -56,6 +56,8 @@ DECLARE_int32(thrift_client_pool_log_frequency);
 
 DECLARE_bool(channel_enable_snappy);
 
+DECLARE_bool(channel_enable_zstd);
+
 DECLARE_bool(use_framed_transport_for_binary_protocol);
 
 namespace common {
@@ -275,6 +277,11 @@ class ThriftClientPool {
         if (FLAGS_channel_enable_snappy) {
           channel->setTransform(apache::thrift::transport::THeader::SNAPPY_TRANSFORM);
         }
+#if __GNUC__ >= 8
+        if (FLAGS_channel_enable_zstd) {
+          channel->setTransform(apache::thrift::transport::THeader::ZSTD_TRANSFORM);
+        }
+#endif
         if (USE_BINARY_PROTOCOL) {
           channel->setProtocolId(apache::thrift::protocol::T_BINARY_PROTOCOL);
           if (FLAGS_use_framed_transport_for_binary_protocol) {


### PR DESCRIPTION
Snappy compression has been deprecated in favor of zstd in U18.