### PR TITLE
S3concurrent

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -6,7 +6,7 @@ AUX_SOURCE_DIRECTORY(./ COMMON_FILES)
 add_library(common ${COMMON_FILES})
 
 target_link_libraries(common jemalloc jvm glog gflags ssl wangle
-        folly aws-cpp-sdk-core aws-cpp-sdk-s3 boost_system
+        folly aws-cpp-sdk-core aws-cpp-sdk-s3 aws-cpp-sdk-transfer boost_system
         boost_filesystem thrift thriftcpp2 jsoncpp_lib_static zstd)
 
 add_subdirectory(rocksdb_glogger)

--- a/common/rocksdb_env_s3.cpp
+++ b/common/rocksdb_env_s3.cpp
@@ -421,7 +421,7 @@ Status S3Env::RenameFile(const std::string& src, const std::string& target) {
         continue;
       }
       if (s3_conc_) {
-        s3_conc_->enqueuePutObject(target + file, local_target_path + file, sync_group_id_);
+        s3_conc_->enqueuePutObject(s3_bucket_, target + file, local_target_path + file, sync_group_id_);
       } else {
         auto copy_resp = s3_util_->putObject(target + file, local_target_path + file);
         if (!copy_resp.Error().empty()) {
@@ -432,7 +432,7 @@ Status S3Env::RenameFile(const std::string& src, const std::string& target) {
     }
   } else {
     if (s3_conc_) {
-      s3_conc_->enqueuePutObject(target, local_target_path, sync_group_id_);
+      s3_conc_->enqueuePutObject(s3_bucket_, target, local_target_path, sync_group_id_);
     } else {
       auto copy_resp = s3_util_->putObject(target, local_target_path);
       if (!copy_resp.Error().empty()) {

--- a/common/rocksdb_env_s3.h
+++ b/common/rocksdb_env_s3.h
@@ -59,12 +59,19 @@ class S3FatalException : public std::exception {
 class S3Env : public Env {
 
  public:
-  explicit S3Env(const std::string& s3_key_prefix,
+  explicit S3Env(const std::string& s3_bucket,
+                 const std::string& s3_key_prefix,
                  const std::string& local_directory,
-                 std::shared_ptr<common::S3Util> s3_util) :
+                 std::shared_ptr<common::S3Util> s3_util,
+                 common::S3Concurrent* const s3_conc,
+                 const std::string& sync_group_id) :
+      s3_bucket_(s3_bucket),
       s3_key_prefix_(s3_key_prefix),
       local_directory_(local_directory),
-      s3_util_(std::move(s3_util)) {
+      s3_util_(std::move(s3_util)),
+      s3_conc_(s3_conc),
+      sync_group_id_(sync_group_id)
+  {
     posix_env_ = Env::Default();
   }
 
@@ -186,12 +193,18 @@ class S3Env : public Env {
   Env* GetBaseEnv() { return posix_env_; }
 
  private:
+  // s3 bucket
+  const std::string s3_bucket_;
   // s3 object key prefix
   const std::string s3_key_prefix_;
   // Local directory to temporarily store the files downloaded from/uploading to S3
   const std::string local_directory_;
+
+  const std::string sync_group_id_;
+
   // S3 util used for accessing AWS S3
   std::shared_ptr<common::S3Util> s3_util_;
+  common::S3Concurrent* s3_conc_{};
   // This object is derived from Env, but not from
   // posixEnv. We have posixEnv as an encapsulated
   // object here so that we can use posix timers,

--- a/common/rocksdb_env_s3.h
+++ b/common/rocksdb_env_s3.h
@@ -199,7 +199,7 @@ class S3Env : public Env {
   const std::string s3_key_prefix_;
   // Local directory to temporarily store the files downloaded from/uploading to S3
   const std::string local_directory_;
-
+  // string common to all files in a db backup operation
   const std::string sync_group_id_;
 
   // S3 util used for accessing AWS S3

--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -625,7 +625,7 @@ bool S3Concurrent::Sync(const string& sync_group_id) {
       LOG(INFO) << "S3Concurrent::Sync success: " << h->GetTargetFilePath();
       Stats::get()->Incr(kS3PutObject);
       num_bytes_transferred += h->GetBytesTransferred();
-      num_files_transferred ++;
+      num_files_transferred++;
     } else {
       LOG(INFO) << "S3Concurrent::Sync fail "<< h->GetTargetFilePath();
       failures_.push_back(h);

--- a/common/s3util.h
+++ b/common/s3util.h
@@ -330,6 +330,7 @@ private:
   std::mutex handles_mutex_;
   map<string, vector<std::shared_ptr<Aws::Transfer::TransferHandle>>> handles_;
   vector<std::shared_ptr<Aws::Transfer::TransferHandle>> failures_;
+  const int default_s3_upload_MBps;
 };
 
 }  // namespace common

--- a/common/s3util.h
+++ b/common/s3util.h
@@ -315,7 +315,7 @@ class S3Concurrent {
                         const string& local_path,
                         const string& key,
                         const string& sync_group_id);
-  bool Sync(const string&sync_group_id);
+  bool Sync(const string& sync_group_id);
   bool setUploadMBps(uint64_t upload_MBps);
   void clearFailures();
 

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -1009,7 +1009,7 @@ if (FLAGS_enable_checkpoint_backup) {
       }
       s3_conc_->enqueuePutObject(request->s3_bucket, formatted_s3_dir_path + kMetaFilename, dbmeta_path, sync_group_id);
     }
-    if (!s3_conc_->Sync(formatted_s3_dir_path)) {
+    if (!s3_conc_->Sync(sync_group_id)) {
       SetException("Failed to sync all files to s3", AdminErrorCode::DB_ADMIN_ERROR, &callback);
       common::Stats::get()->Incr(kS3BackupFailure);
     }

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -98,7 +98,7 @@ DEFINE_int32(max_s3_sst_loading_concurrency, 999,
              "Max S3 SST loading concurrency");
 
 DEFINE_int32(s3_download_limit_mb, 0, "S3 download sst bandwidth");
-DEFINE_int32(s3_upload_limit_mb, 600, "S3 upload sst bandwidth");
+DEFINE_int32(s3_upload_limit_mb, 450, "S3 upload sst bandwidth");
 
 DEFINE_int32(kafka_ts_update_interval, 1000, "Number of kafka messages consumed"
                                              " before updating meta_db");

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -98,6 +98,7 @@ DEFINE_int32(max_s3_sst_loading_concurrency, 999,
              "Max S3 SST loading concurrency");
 
 DEFINE_int32(s3_download_limit_mb, 0, "S3 download sst bandwidth");
+DEFINE_int32(s3_upload_limit_mb, 600, "S3 upload sst bandwidth");
 
 DEFINE_int32(kafka_ts_update_interval, 1000, "Number of kafka messages consumed"
                                              " before updating meta_db");
@@ -484,8 +485,7 @@ AdminHandler::AdminHandler(
     });
   }
 
-  const int upload_MBps = 600; // fixed upper bw limit for now.
-  s3_conc_ = std::make_shared<common::S3Concurrent>(upload_MBps); 
+  s3_conc_ = std::make_shared<common::S3Concurrent>(FLAGS_s3_upload_limit_mb);
 }
 
 AdminHandler::~AdminHandler() {

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -922,6 +922,7 @@ void AdminHandler::async_tm_backupDBToS3(
     num_current_s3_sst_uploadings_.fetch_sub(1);
   };
   common::Timer timer(kS3BackupMs);
+  LOG(INFO) << "S3 Backup " << request->db_name << " to " << request->s3_backup_dir;
 
   auto ts = common::timeutil::GetCurrentTimestamp();
   auto local_path = folly::stringPrintf("%ss3_tmp/%s%d/", FLAGS_rocksdb_dir.c_str(), request->db_name.c_str(), ts);
@@ -1041,7 +1042,7 @@ if (FLAGS_enable_checkpoint_backup) {
     return;
   }
   LOG(INFO) << "S3 Backup is done for " << request->db_name
-            << " with latency(ms)" << timer.getElapsedTimeMs();
+            << " with latency(ms) " << timer.getElapsedTimeMs();
   common::Stats::get()->Incr(kS3BackupSuccess);
   callback->result(BackupDBToS3Response());
 }

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -483,6 +483,9 @@ AdminHandler::AdminHandler(
       LOG(INFO) << "Stopping DB deletioin thread ...";
     });
   }
+
+  int upload_MBps = 600; // set as fixed for now.
+  s3_conc_ = std::make_shared<common::S3Concurrent>("pinterest-jackson", upload_MBps); 
 }
 
 AdminHandler::~AdminHandler() {
@@ -725,7 +728,7 @@ bool AdminHandler::restoreDBHelper(const std::string& db_name,
   assert(env_holder != nullptr);
   db_admin_lock_.Lock(db_name);
   SCOPE_EXIT { db_admin_lock_.Unlock(db_name); };
-
+  
   auto db = db_manager_->getDB(db_name, nullptr);
   if (db) {
     e->errorCode = AdminErrorCode::DB_EXIST;
@@ -911,38 +914,32 @@ void AdminHandler::async_tm_backupDBToS3(
     std::unique_ptr<apache::thrift::HandlerCallback<std::unique_ptr<
       BackupDBToS3Response>>> callback,
     std::unique_ptr<BackupDBToS3Request> request) {
+  LOG(INFO) << "S3 Backup " << request->db_name << " to " << request->s3_backup_dir;
+
   AdminException e;
   const auto n = num_current_s3_sst_uploadings_.fetch_add(1);
   SCOPE_EXIT {
     num_current_s3_sst_uploadings_.fetch_sub(1);
   };
-
-  if (n >= FLAGS_max_s3_sst_loading_concurrency) {
-    auto err_str =
-        folly::stringPrintf("Concurrent uploading/downloading limit hits %d by %s",
-                            n, request->db_name.c_str());
-    SetException(err_str, AdminErrorCode::DB_ADMIN_ERROR, &callback);
-    LOG(ERROR) << err_str;
-    common::Stats::get()->Incr(kS3BackupFailure);
-    return;
-  }
-
   common::Timer timer(kS3BackupMs);
-  LOG(INFO) << "S3 Backup " << request->db_name << " to " << request->s3_backup_dir;
+
   auto ts = common::timeutil::GetCurrentTimestamp();
   auto local_path = folly::stringPrintf("%ss3_tmp/%s%d/", FLAGS_rocksdb_dir.c_str(), request->db_name.c_str(), ts);
+  const std::string sync_group_id = request->s3_backup_dir;
+  
   boost::system::error_code remove_err;
   boost::system::error_code create_err;
   boost::filesystem::remove_all(local_path, remove_err);
   boost::filesystem::create_directories(local_path, create_err);
+
   SCOPE_EXIT { boost::filesystem::remove_all(local_path, remove_err); };
   if (remove_err || create_err) {
     SetException("Cannot remove/create dir for backup: " + local_path, AdminErrorCode::DB_ADMIN_ERROR, &callback);
     common::Stats::get()->Incr(kS3BackupFailure);
     return;
   }
-
-  if (FLAGS_enable_checkpoint_backup) {
+  
+if (FLAGS_enable_checkpoint_backup) {
     db_admin_lock_.Lock(request->db_name);
     SCOPE_EXIT { db_admin_lock_.Unlock(request->db_name); };
 
@@ -986,70 +983,15 @@ void AdminHandler::async_tm_backupDBToS3(
     auto local_s3_util = createLocalS3Util(request->limit_mbs, request->s3_bucket);
     std::string formatted_s3_dir_path = ensure_ends_with_pathsep(request->s3_backup_dir);
     std::string formatted_checkpoint_local_path = ensure_ends_with_pathsep(checkpoint_local_path);
-    auto upload_func = [&](const std::string& dest, const std::string& source) {
-      LOG(INFO) << "Copying " << source << " to " << dest;
-      auto copy_resp = local_s3_util->putObject(dest, source);
-      if (!copy_resp.Error().empty()) {
-        LOG(ERROR)
-            << "Error happened when uploading files from checkpoint to S3: "
-            << copy_resp.Error();
-        return false;
-      }
-      return true;
-    };
 
-    if (FLAGS_checkpoint_backup_batch_num_upload > 1) {
-      // Upload checkpoint files to s3 in parallel
-      std::vector<std::vector<std::string>> file_batches(FLAGS_checkpoint_backup_batch_num_upload);
-      for (size_t i = 0; i < checkpoint_files.size(); ++i) {
-        auto& file = checkpoint_files[i];
-        if (file == "." || file == "..") {
-          continue;
-        }
-        file_batches[i%FLAGS_checkpoint_backup_batch_num_upload].push_back(file);
+    for (const auto& file : checkpoint_files) {
+      if (file == "." || file == "..") {
+        continue;
       }
-
-      std::vector<folly::Future<bool>> futures;
-      for (auto& files : file_batches) {
-        auto p = folly::Promise<bool>();
-        futures.push_back(p.getFuture());
-
-        S3UploadAndDownloadExecutor()->add(
-            [&, files = std::move(files), p = std::move(p)]() mutable {
-              for (const auto& file : files) {
-                if (!upload_func(formatted_s3_dir_path + file, formatted_checkpoint_local_path + file)) {
-                  p.setValue(false);
-                  return;
-                }
-              }
-              p.setValue(true);
-            });
-      }
-
-      for (auto& f : futures) {
-        auto res = std::move(f).get();
-        if (!res) {
-          SetException("Error happened when uploading files from checkpoint to S3",
-                       AdminErrorCode::DB_ADMIN_ERROR,
-                       &callback);
-          common::Stats::get()->Incr(kS3BackupFailure);
-          return;
-        }
-      }
-    } else {
-      for (const auto& file : checkpoint_files) {
-        if (file == "." || file == "..") {
-          continue;
-        }
-        if (!upload_func(formatted_s3_dir_path + file, formatted_checkpoint_local_path + file)) {
-          // If there is error in one file uploading, then we fail the whole backup process
-          SetException("Error happened when uploading files from checkpoint to S3",
-                       AdminErrorCode::DB_ADMIN_ERROR,
-                       &callback);
-          common::Stats::get()->Incr(kS3BackupFailure);
-          return;
-        }
-      }
+      s3_conc_->enqueuePutObject(formatted_s3_dir_path + file,
+                                 formatted_checkpoint_local_path + file,
+                                 //request->s3_bucket,
+                                 sync_group_id);
     }
 
     if (request->__isset.include_meta && request->include_meta) {
@@ -1066,20 +1008,21 @@ void AdminHandler::async_tm_backupDBToS3(
         common::Stats::get()->Incr(kS3BackupFailure);
         return;
       }
-      if (!upload_func(formatted_s3_dir_path + kMetaFilename, dbmeta_path)) {
-        SetException("Error happened when upload meta from checkpoint to S3",
-                     AdminErrorCode::DB_ADMIN_ERROR, &callback);
-        common::Stats::get()->Incr(kS3BackupFailure);
-        return;
-      }
+      s3_conc_->enqueuePutObject(formatted_s3_dir_path + kMetaFilename, dbmeta_path,
+                                 //request->s3_bucket,
+                                 sync_group_id);
     }
-
+    if (!s3_conc_->Sync(formatted_s3_dir_path)) {
+      SetException("Failed to sync all files to s3", AdminErrorCode::DB_ADMIN_ERROR, &callback);
+      common::Stats::get()->Incr(kS3BackupFailure);
+    }
     // Delete the directory to remove the snapshot.
     boost::filesystem::remove_all(local_path);
+
   } else {
     auto local_s3_util = createLocalS3Util(request->limit_mbs, request->s3_bucket);
     std::string formatted_s3_dir_path = rtrim(request->s3_backup_dir, '/');
-    rocksdb::Env* s3_env = new rocksdb::S3Env(formatted_s3_dir_path, local_path, std::move(local_s3_util));
+    rocksdb::Env* s3_env = new rocksdb::S3Env(request->s3_bucket, formatted_s3_dir_path, local_path, std::move(local_s3_util), s3_conc_.get(), sync_group_id);
     const bool share_files_with_checksum = request->__isset.share_files_with_checksum && request->share_files_with_checksum;
     const bool include_meta = request->__isset.include_meta && request->include_meta;
     if (!backupDBHelper(request->db_name,
@@ -1095,9 +1038,13 @@ void AdminHandler::async_tm_backupDBToS3(
       return;
     }
   }
-
+  if (!s3_conc_->Sync(sync_group_id)) {
+    callback.release()->exceptionInThread(std::move(e));
+    common::Stats::get()->Incr(kS3BackupFailure);
+    return;
+  }
   LOG(INFO) << "S3 Backup is done for " << request->db_name
-            << " with latency(ms) " << timer.getElapsedTimeMs();
+            << " with latency(ms)" << timer.getElapsedTimeMs();
   common::Stats::get()->Incr(kS3BackupSuccess);
   callback->result(BackupDBToS3Response());
 }
@@ -1125,6 +1072,7 @@ void AdminHandler::async_tm_restoreDBFromS3(
   auto ts = common::timeutil::GetCurrentTimestamp();
   auto local_path = FLAGS_enable_checkpoint_backup ? FLAGS_rocksdb_dir + request->db_name :
                     folly::stringPrintf("%ss3_tmp/%s%d/", FLAGS_rocksdb_dir.c_str(), request->db_name.c_str(), ts);
+  const std::string sync_group_id = request->s3_backup_dir;
   boost::system::error_code remove_err;
   boost::system::error_code create_err;
   boost::filesystem::remove_all(local_path, remove_err);
@@ -1275,8 +1223,8 @@ void AdminHandler::async_tm_restoreDBFromS3(
     }
   } else {
     std::string formatted_s3_dir_path = rtrim(request->s3_backup_dir, '/');
-    rocksdb::Env* s3_env = new rocksdb::S3Env(
-        formatted_s3_dir_path, std::move(local_path), std::move(local_s3_util));
+    rocksdb::Env* s3_env = new rocksdb::S3Env(request->s3_bucket, formatted_s3_dir_path, std::move(local_path),
+                                              std::move(local_s3_util), s3_conc_.get(), sync_group_id);
 
     if (!restoreDBHelper(request->db_name,
                          formatted_s3_dir_path,
@@ -1339,7 +1287,7 @@ void AdminHandler::async_tm_checkDB(
     }
   }
 
-  if (request->__isset.include_meta) {
+  if (request->__isset.include_meta && request->include_meta) {
     auto meta = getMetaData(request->db_name);
     std::map<std::string, std::string> metas;
     metas["s3_bucket"] = meta.s3_bucket;
@@ -1586,7 +1534,6 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     std::unique_ptr<AddS3SstFilesToDBRequest> request) {
   admin::AdminException e;
   e.errorCode = AdminErrorCode::DB_ADMIN_ERROR;
-
   db_admin_lock_.Lock(request->db_name);
   SCOPE_EXIT { db_admin_lock_.Unlock(request->db_name); };
 

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -162,8 +162,6 @@ class AdminHandler : virtual public AdminSvIf {
   std::unique_ptr<ApplicationDBManager> db_manager_;
   RocksDBOptionsGeneratorType rocksdb_options_;
 
-  // handles aws sdk init
-  common::Initialize aws_init;
   // S3 util used for download
   std::shared_ptr<common::S3Util> s3_util_;
   // Lock for protecting the s3 util

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -161,10 +161,15 @@ class AdminHandler : virtual public AdminSvIf {
 
   std::unique_ptr<ApplicationDBManager> db_manager_;
   RocksDBOptionsGeneratorType rocksdb_options_;
+
+  // handles aws sdk init
+  common::Initialize aws_init;
   // S3 util used for download
   std::shared_ptr<common::S3Util> s3_util_;
   // Lock for protecting the s3 util
   mutable std::mutex s3_util_lock_;
+  // for concurrent s3 transfers
+  std::shared_ptr<common::S3Concurrent> s3_conc_;
   // db that contains meta data for all local rocksdb instances
   std::unique_ptr<rocksdb::DB> meta_db_;
   // segments which allow for overlapping keys when adding SST files


### PR DESCRIPTION
Added S3Concurrent class which uses aws sdk transfermanager to support concurrent, partitioned uploads.
Previous per-host upload speeds didn't exceed ~70MBps.  With changes, upwards of 500MBps are available.  
Large files are partitioned into smaller ranges for concurrent uploads.