### PR TITLE
Do not crash the process if kafka serverset path is invalid/not present.

### DIFF
--- a/common/kafka/kafka_broker_file_watcher.cpp
+++ b/common/kafka/kafka_broker_file_watcher.cpp
@@ -52,7 +52,7 @@ std::string ParseKafkaBrokerList(const std::string& content) {
 KafkaBrokerFileWatcher::KafkaBrokerFileWatcher(std::string local_serverset_path)
     : local_serverset_path_(std::move(local_serverset_path)) {
   // Add file watcher for Kafka serverset.
-  CHECK(common::FileWatcher::Instance()->AddFile(
+  if (!common::FileWatcher::Instance()->AddFile(
       local_serverset_path_, [this](std::string content) {
         const auto new_kafka_broker_list = ParseKafkaBrokerList(content);
         if (new_kafka_broker_list.empty()) {
@@ -68,7 +68,9 @@ KafkaBrokerFileWatcher::KafkaBrokerFileWatcher(std::string local_serverset_path)
               kafka_broker_list_rw_lock_);
           kafka_broker_list_ = new_kafka_broker_list;
         }
-      })) << "Failed to add file watcher to " << local_serverset_path_;
+      })) {
+        throw std::runtime_error("Failed to add file watcher to " + local_serverset_path_);
+  }
 }
 
 KafkaBrokerFileWatcher::~KafkaBrokerFileWatcher() {


### PR DESCRIPTION
If the kafka serverset path is not present, the CHECK would fail and
crash the process. CHECKs should be reserved only during process start
up, not during state transitions.
So removing the use of CHECK in favor of raising an exception. With
this, an exception is returned and the state transition would fail.

Testing:
On a test cluster, sent a startMessageIngestion request with an invalid
serverset path and verified that an error is returned in the API.
```
AdminException: AdminException(message='Failed to start kafka watcher: testtest00016 Failed to add file watcher to /tmp/non-existant-file', errorCode=5)
```