### PR TITLE
Add a function to ping the JVM.

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -334,6 +334,10 @@ public class Participant {
     }
   }
 
+  public static void ping() {
+    LOG.error("[participant] Received ping");
+  }
+
   private Participant(String zkConnectString, String clusterName, String instanceName,
                       String stateModelType, int port, String postUrl, boolean useS3Backup,
                       String s3BucketName, boolean runSpectator)

--- a/common/helix_client.cpp
+++ b/common/helix_client.cpp
@@ -306,4 +306,35 @@ std::string GetLeaderInstanceId(
     return JStringToString(env, jstr);
 }
 
+void PingJVM() {
+    auto env = getRunningVM();
+
+    if (env == nullptr) {
+        LOG(ERROR) << "Failed to get env";
+        return;
+    }
+
+    jclass ParticipantClass;
+    jmethodID pingMethod;
+
+    ParticipantClass = env->FindClass("com/pinterest/rocksplicator/Participant");
+    if (!ParticipantClass) {
+        env->ExceptionDescribe();
+        LOG(ERROR) << "Failed to find Participant class";
+        return;
+    }
+
+    pingMethod = env->GetStaticMethodID(ParticipantClass,
+                                        "ping",
+                                        "()V");
+    if (!pingMethod) {
+        LOG(ERROR) << "Failed to GetStaticMethodID";
+        env->ExceptionDescribe();
+        return;
+    }
+
+    LOG(INFO) << "Calling ping method in JVM";
+    env->CallStaticVoidMethod(ParticipantClass, pingMethod);
+}
+
 }  // namespace common

--- a/common/helix_client.h
+++ b/common/helix_client.h
@@ -57,4 +57,6 @@ std::string GetLeaderInstanceId(
   const std::string& resource,
   const std::string& partition);
 
+void PingJVM();
+
 }  // namespace common

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -29,6 +29,7 @@
 #include <map>
 
 #include "boost/filesystem.hpp"
+#include "common/helix_client.h"
 #include "common/identical_name_thread_factory.h"
 #include "common/kafka/kafka_broker_file_watcher.h"
 #include "common/kafka/kafka_consumer_pool.h"
@@ -1301,6 +1302,16 @@ void AdminHandler::async_tm_checkDB(
     std::unique_ptr<apache::thrift::HandlerCallback<std::unique_ptr<
       CheckDBResponse>>> callback,
     std::unique_ptr<CheckDBRequest> request) {
+
+  // Ping JVM
+  try {
+    common::PingJVM();
+  } catch (const std::exception& ex) {
+    SetException("Failed to call PingJVM, " + std::string(ex.what()),
+                  AdminErrorCode::DB_ADMIN_ERROR, &callback);
+    return;
+  }
+
   AdminException e;
   auto db = getDB(request->db_name, &e);
   if (db == nullptr) {


### PR DESCRIPTION
We are seeing instances where helix participant is not processing any
new state transitions. Adding a 'ping' function for debugging purposes
to check if the JVM is alive.
Piggybacking this JVM call with the checkDB API (which is also used for
debugging).