### PR TITLE
Return a rocksdb status object instead of throwing the return code in…

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -107,7 +107,9 @@ rocksdb::Status RocksDBReplicator::ReplicatedDB::Write(
       // consider having a dedicated set of worker threads for admin requests,
       // and/or provide async write API when this turns out to be a problem.
       if (!max_seq_no_acked_.wait(cur_seq_no, FLAGS_replicator_timeout_ms)) {
-        throw ReturnCode::WAIT_SLAVE_TIMEOUT;
+        incCounter(kReplicatorTimedOut, 1, db_name_);
+        LOG(ERROR) << "Failed to receive ack from follower, timing out for " << db_name_;
+        return rocksdb::Status::TimedOut("Failed to receive ack from follower");
       }
       break;
     default:

--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -38,6 +38,8 @@ const std::string kReplicatorRemoteApplicationExceptionsNotFound =
   "replicator_remote_app_exceptions_source_not_found";
 const std::string kReplicatorLeaderReset =
   "replicator_remote_app_leader_reset";
+const std::string kReplicatorTimedOut =
+  "replicator_write_time_out";
 const std::string kReplicatorGetUpdatesSinceErrors =
   "replicator_get_update_since_errors";
 const std::string kReplicatorGetUpdatesSinceMs =

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -33,6 +33,7 @@ extern const std::string kReplicatorGetUpdatesSinceMs;
 extern const std::string kReplicatorWriteMs;
 extern const std::string kReplicatorLeaderSequenceNumbersBehind;
 extern const std::string kReplicatorLeaderReset;
+extern const std::string kReplicatorTimedOut;
 extern const std::string kReplicatorRemoteApplicationExceptionsNotFound;
 
 // add value to metric_name. If db_name is not empty, add value to the per db


### PR DESCRIPTION
… 2-ack mode.

When 2-ack mode is enabled and none of the followers ack the write
within the timeout period, a rocksplicator status is thrown (not sure
why). This causes cryptic messages such as:
"worker task threw unhandled non-exception object" in the logs which are
hard to understand.
Replacing that with a return of the rocksdb status. It's up to the
service logic to handle the status. Also logging the error for easier
debugging.

Testing: Forced the issue locally and verified that no exceptions are
thrown, and that the status is returned instead.