### PR TITLE
S3concurrent (#526)

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -6,7 +6,7 @@ AUX_SOURCE_DIRECTORY(./ COMMON_FILES)
 add_library(common ${COMMON_FILES})
 
 target_link_libraries(common jemalloc jvm glog gflags ssl wangle
-        folly aws-cpp-sdk-core aws-cpp-sdk-s3 boost_system
+        folly aws-cpp-sdk-core aws-cpp-sdk-s3 aws-cpp-sdk-transfer boost_system
         boost_filesystem thrift thriftcpp2 jsoncpp_lib_static zstd)
 
 add_subdirectory(rocksdb_glogger)

--- a/common/rocksdb_env_s3.cpp
+++ b/common/rocksdb_env_s3.cpp
@@ -420,22 +420,27 @@ Status S3Env::RenameFile(const std::string& src, const std::string& target) {
       if (file == "." || file == "..") {
         continue;
       }
-      auto copy_resp = s3_util_->putObject(target + file, local_target_path + file);
-      if (!copy_resp.Error().empty()) {
-        LOG(ERROR) << "Error happened when uploading file to S3: "
-                   << copy_resp.Error();
-        return Status::IOError();
+      if (s3_conc_) {
+        s3_conc_->enqueuePutObject(s3_bucket_, target + file, local_target_path + file, sync_group_id_);
+      } else {
+        auto copy_resp = s3_util_->putObject(target + file, local_target_path + file);
+        if (!copy_resp.Error().empty()) {
+          LOG(ERROR) << "Error happened when uploading file to S3: " << copy_resp.Error();
+          return Status::IOError();
+        }
       }
     }
   } else {
-    auto copy_resp = s3_util_->putObject(target, local_target_path);
-    if (!copy_resp.Error().empty()) {
-      LOG(ERROR) << "Error happened when uploading file to S3: "
-                 << copy_resp.Error();
-      return Status::IOError();
+    if (s3_conc_) {
+      s3_conc_->enqueuePutObject(s3_bucket_, target, local_target_path, sync_group_id_);
+    } else {
+      auto copy_resp = s3_util_->putObject(target, local_target_path);
+      if (!copy_resp.Error().empty()) {
+        LOG(ERROR) << "Error happened when uploading file to S3: " << copy_resp.Error();
+        return Status::IOError();
+      }
     }
   }
-
   return Status::OK();
 }
 

--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -84,6 +84,7 @@ namespace common {
 std::mutex S3Util::counter_mutex_;
 std::uint32_t S3Util::instance_counter_(0);
 const uint32_t kPageSize = getpagesize();
+SDKOptions S3Util::options_;
 
 DirectIOWritableFile::DirectIOWritableFile(const string& file_path)
     : fd_(-1)
@@ -488,9 +489,160 @@ shared_ptr<S3Util> S3Util::BuildS3Util(
         std::make_shared<AwsS3RateLimiter>(
             write_ratelimit_mb * 1024 * 1024);
   }
-  SDKOptions options;
   return std::shared_ptr<S3Util>(
-      new S3Util(bucket, aws_config, options, read_ratelimit_mb, write_ratelimit_mb));
+      new S3Util(bucket, aws_config, read_ratelimit_mb, write_ratelimit_mb));
 }
 
+void S3Util::TryAwsInitAPI() {
+  std::lock_guard<std::mutex> guard(counter_mutex_);
+  if (instance_counter_ == 0) {
+    LOG(INFO) << "Aws::InitAPI";
+    Aws::InitAPI(options_);
+  }
+  ++instance_counter_;
+}
+
+void S3Util::TryAwsShutdownAPI() {
+  std::lock_guard<std::mutex> guard(counter_mutex_);
+  --instance_counter_;
+  if (instance_counter_ == 0) {
+    LOG(INFO) << "Aws::ShutdownAPI";
+    Aws::ShutdownAPI(options_);
+  }
+}
+
+
+S3Concurrent::S3Concurrent(const int upload_MBps)
+  : executor_(2),  // n_threads
+    transfer_config_(&executor_),
+    default_s3_upload_MBps(upload_MBps)
+{
+  S3Util::TryAwsInitAPI();
+  const uint64_t MB = 1000*1000;
+  const uint64_t max_heap_size = 400 * MB;
+  const uint64_t buffer_size = 25 * MB;
+  int max_connections = 16; // reasonable upper limit, good for 10Gbps.
+  // throttle concurrency according to desired rate.
+  // 2 threads allows for some file interleaving while limiting cpu exposure.
+  if (upload_MBps != 0) {
+    const int MBps_per_connection_est = 70;
+    max_connections = std::min(max_connections, std::max(1, (int)(upload_MBps/MBps_per_connection_est)));
+    rate_limiter_ = Aws::MakeShared<Aws::Utils::RateLimits::DefaultRateLimiter<>>("S3Concurrent", upload_MBps * MB);
+    client_config_.writeRateLimiter = rate_limiter_;
+  }
+  LOG(INFO) << "S3Concurrent() upload_MBps: " << upload_MBps
+            << " max_connections: " << max_connections
+            << " max_heap_size MB: " << max_heap_size / MB
+            << " buffer_size MB: " << buffer_size / MB;
+  int socket_timeout_ms = 3000;
+  client_config_.connectTimeoutMs = socket_timeout_ms;
+  client_config_.requestTimeoutMs = socket_timeout_ms;
+  client_config_.maxConnections = max_connections;
+  client_config_.region = "us-east-1";
+
+  s3_client_ = std::make_shared<Aws::S3::S3Client>(client_config_);
+  transfer_config_.s3Client = s3_client_;
+  transfer_config_.transferBufferMaxHeapSize = max_heap_size;
+  transfer_config_.bufferSize = buffer_size;
+  transfer_config_.transferInitiatedCallback =
+    [](const Aws::Transfer::TransferManager*,
+       const std::shared_ptr<const Aws::Transfer::TransferHandle>& th) {
+      LOG(INFO) << "Transfer Status = " << static_cast<int>(th->GetStatus())
+                << ", File Path: " << th->GetTargetFilePath() << "\n";
+    };
+
+  transfer_config_.errorCallback =
+    [](const Aws::Transfer::TransferManager*,
+       const std::shared_ptr<const Aws::Transfer::TransferHandle>& th,
+       const Aws::Client::AWSError<Aws::S3::S3Errors>& error) {
+      LOG(ERROR)
+        << "Failed to download file. s3 bucket: "  << th->GetBucketName()
+        << ", s3 key: " << th->GetKey()
+        << ", target_path: " << th->GetTargetFilePath()
+        << ", error: " << th->GetLastError().GetMessage();
+    };
+  context_ = Aws::MakeShared<Aws::Client::AsyncCallerContext>("upload");
+  transfer_manager_ = Aws::Transfer::TransferManager::Create(transfer_config_);
+}
+
+S3Concurrent::~S3Concurrent() {
+    S3Util::TryAwsShutdownAPI();
+}
+
+bool S3Concurrent::setUploadMBps(uint64_t upload_MBps) {
+  // rate limiter is currently setup only with creation of
+  // S3Concurrent object.  rate limit changes via this function only
+  // serve to adjust rate if an initial non-zero rate was set (the
+  // default case).
+  const uint64_t MB = 1000*1000;
+  if (rate_limiter_){
+    uint64_t new_rate_MB = (upload_MBps > 0)? upload_MBps: default_s3_upload_MBps;
+    rate_limiter_->SetRate(new_rate_MB * MB);
+    return true;
+  }
+  return false;
+}
+
+bool S3Concurrent::enqueuePutObject(const string& s3_bucket, const string& key,
+                                    const string& local_path, const string& sync_group_id){
+  LOG(INFO) << "S3Concurrent::enqueuePutObject" << " key: " << key;
+  {
+    std::lock_guard<std::mutex> lock(handles_mutex_);
+    auto sync_collection_ptr = handles_.find(sync_group_id);
+    if (sync_collection_ptr == handles_.end()) {
+      handles_[sync_group_id] = vector<std::shared_ptr<Aws::Transfer::TransferHandle>>();
+    }
+    handles_[sync_group_id].push_back(
+        std::move(transfer_manager_->UploadFile(local_path,
+                                                s3_bucket,
+                                                key,
+                                                "application/octet-stream",
+                                                Aws::Map<Aws::String, Aws::String>(),
+                                                context_)));
+  }
+  return true;
+}
+
+bool S3Concurrent::Sync(const string& sync_group_id) {
+  uint64_t num_files_transferred = 0;
+  uint64_t num_bytes_transferred = 0;
+  uint64_t num_failures = 0;
+  LOG(INFO) << "S3Concurrent::Sync()";
+  vector<std::shared_ptr<Aws::Transfer::TransferHandle>> sync_group;
+  {
+    std::lock_guard<std::mutex> lock(handles_mutex_);
+    auto sync_group_ptr = handles_.find(sync_group_id);
+    if (sync_group_ptr == handles_.end()) {
+      return true;
+    }
+    sync_group.swap(sync_group_ptr->second);
+    handles_.erase(sync_group_ptr);
+  }
+  
+  for(auto &h: sync_group){
+    h->WaitUntilFinished();
+    if (h->GetStatus() == Aws::Transfer::TransferStatus::COMPLETED) {
+      LOG(INFO) << "S3Concurrent::Sync success: " << h->GetTargetFilePath();
+      Stats::get()->Incr(kS3PutObject);
+      num_bytes_transferred += h->GetBytesTransferred();
+      num_files_transferred++;
+    } else {
+      LOG(INFO) << "S3Concurrent::Sync fail "<< h->GetTargetFilePath();
+      failures_.push_back(h);
+      num_failures++;
+      LOG(ERROR)
+        << "Error happened when uploading files from checkpoint to S3: "
+        << h->GetLastError();
+    }
+  }
+
+  LOG(INFO) << "S3Concurrent::Sync complete "
+            << " transferred: " << num_files_transferred
+            << " failures: " << num_failures;
+  return num_files_transferred == sync_group.size();
+}
+
+void S3Concurrent::clearFailures() {
+  failures_.clear();
+}
 }  // namespace common

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -98,6 +98,7 @@ DEFINE_int32(max_s3_sst_loading_concurrency, 999,
              "Max S3 SST loading concurrency");
 
 DEFINE_int32(s3_download_limit_mb, 0, "S3 download sst bandwidth");
+DEFINE_int32(s3_upload_limit_mb, 450, "S3 upload sst bandwidth");
 
 DEFINE_int32(kafka_ts_update_interval, 1000, "Number of kafka messages consumed"
                                              " before updating meta_db");
@@ -483,6 +484,8 @@ AdminHandler::AdminHandler(
       LOG(INFO) << "Stopping DB deletioin thread ...";
     });
   }
+
+  s3_conc_ = std::make_shared<common::S3Concurrent>(FLAGS_s3_upload_limit_mb);
 }
 
 AdminHandler::~AdminHandler() {
@@ -725,7 +728,7 @@ bool AdminHandler::restoreDBHelper(const std::string& db_name,
   assert(env_holder != nullptr);
   db_admin_lock_.Lock(db_name);
   SCOPE_EXIT { db_admin_lock_.Unlock(db_name); };
-
+  
   auto db = db_manager_->getDB(db_name, nullptr);
   if (db) {
     e->errorCode = AdminErrorCode::DB_EXIST;
@@ -911,38 +914,33 @@ void AdminHandler::async_tm_backupDBToS3(
     std::unique_ptr<apache::thrift::HandlerCallback<std::unique_ptr<
       BackupDBToS3Response>>> callback,
     std::unique_ptr<BackupDBToS3Request> request) {
+  LOG(INFO) << "S3 Backup " << request->db_name << " to " << request->s3_backup_dir;
+
   AdminException e;
   const auto n = num_current_s3_sst_uploadings_.fetch_add(1);
   SCOPE_EXIT {
     num_current_s3_sst_uploadings_.fetch_sub(1);
   };
-
-  if (n >= FLAGS_max_s3_sst_loading_concurrency) {
-    auto err_str =
-        folly::stringPrintf("Concurrent uploading/downloading limit hits %d by %s",
-                            n, request->db_name.c_str());
-    SetException(err_str, AdminErrorCode::DB_ADMIN_ERROR, &callback);
-    LOG(ERROR) << err_str;
-    common::Stats::get()->Incr(kS3BackupFailure);
-    return;
-  }
-
   common::Timer timer(kS3BackupMs);
   LOG(INFO) << "S3 Backup " << request->db_name << " to " << request->s3_backup_dir;
+
   auto ts = common::timeutil::GetCurrentTimestamp();
   auto local_path = folly::stringPrintf("%ss3_tmp/%s%d/", FLAGS_rocksdb_dir.c_str(), request->db_name.c_str(), ts);
+  const std::string sync_group_id = request->s3_backup_dir;
+  
   boost::system::error_code remove_err;
   boost::system::error_code create_err;
   boost::filesystem::remove_all(local_path, remove_err);
   boost::filesystem::create_directories(local_path, create_err);
+
   SCOPE_EXIT { boost::filesystem::remove_all(local_path, remove_err); };
   if (remove_err || create_err) {
     SetException("Cannot remove/create dir for backup: " + local_path, AdminErrorCode::DB_ADMIN_ERROR, &callback);
     common::Stats::get()->Incr(kS3BackupFailure);
     return;
   }
-
-  if (FLAGS_enable_checkpoint_backup) {
+  
+if (FLAGS_enable_checkpoint_backup) {
     db_admin_lock_.Lock(request->db_name);
     SCOPE_EXIT { db_admin_lock_.Unlock(request->db_name); };
 
@@ -986,70 +984,14 @@ void AdminHandler::async_tm_backupDBToS3(
     auto local_s3_util = createLocalS3Util(request->limit_mbs, request->s3_bucket);
     std::string formatted_s3_dir_path = ensure_ends_with_pathsep(request->s3_backup_dir);
     std::string formatted_checkpoint_local_path = ensure_ends_with_pathsep(checkpoint_local_path);
-    auto upload_func = [&](const std::string& dest, const std::string& source) {
-      LOG(INFO) << "Copying " << source << " to " << dest;
-      auto copy_resp = local_s3_util->putObject(dest, source);
-      if (!copy_resp.Error().empty()) {
-        LOG(ERROR)
-            << "Error happened when uploading files from checkpoint to S3: "
-            << copy_resp.Error();
-        return false;
+    s3_conc_->setUploadMBps(request->limit_mbs);
+    for (const auto& file : checkpoint_files) {
+      if (file == "." || file == "..") {
+        continue;
       }
-      return true;
-    };
-
-    if (FLAGS_checkpoint_backup_batch_num_upload > 1) {
-      // Upload checkpoint files to s3 in parallel
-      std::vector<std::vector<std::string>> file_batches(FLAGS_checkpoint_backup_batch_num_upload);
-      for (size_t i = 0; i < checkpoint_files.size(); ++i) {
-        auto& file = checkpoint_files[i];
-        if (file == "." || file == "..") {
-          continue;
-        }
-        file_batches[i%FLAGS_checkpoint_backup_batch_num_upload].push_back(file);
-      }
-
-      std::vector<folly::Future<bool>> futures;
-      for (auto& files : file_batches) {
-        auto p = folly::Promise<bool>();
-        futures.push_back(p.getFuture());
-
-        S3UploadAndDownloadExecutor()->add(
-            [&, files = std::move(files), p = std::move(p)]() mutable {
-              for (const auto& file : files) {
-                if (!upload_func(formatted_s3_dir_path + file, formatted_checkpoint_local_path + file)) {
-                  p.setValue(false);
-                  return;
-                }
-              }
-              p.setValue(true);
-            });
-      }
-
-      for (auto& f : futures) {
-        auto res = std::move(f).get();
-        if (!res) {
-          SetException("Error happened when uploading files from checkpoint to S3",
-                       AdminErrorCode::DB_ADMIN_ERROR,
-                       &callback);
-          common::Stats::get()->Incr(kS3BackupFailure);
-          return;
-        }
-      }
-    } else {
-      for (const auto& file : checkpoint_files) {
-        if (file == "." || file == "..") {
-          continue;
-        }
-        if (!upload_func(formatted_s3_dir_path + file, formatted_checkpoint_local_path + file)) {
-          // If there is error in one file uploading, then we fail the whole backup process
-          SetException("Error happened when uploading files from checkpoint to S3",
-                       AdminErrorCode::DB_ADMIN_ERROR,
-                       &callback);
-          common::Stats::get()->Incr(kS3BackupFailure);
-          return;
-        }
-      }
+      s3_conc_->enqueuePutObject(request->s3_bucket, formatted_s3_dir_path + file,
+                                 formatted_checkpoint_local_path + file,
+                                 sync_group_id);
     }
 
     if (request->__isset.include_meta && request->include_meta) {
@@ -1066,20 +1008,19 @@ void AdminHandler::async_tm_backupDBToS3(
         common::Stats::get()->Incr(kS3BackupFailure);
         return;
       }
-      if (!upload_func(formatted_s3_dir_path + kMetaFilename, dbmeta_path)) {
-        SetException("Error happened when upload meta from checkpoint to S3",
-                     AdminErrorCode::DB_ADMIN_ERROR, &callback);
-        common::Stats::get()->Incr(kS3BackupFailure);
-        return;
-      }
+      s3_conc_->enqueuePutObject(request->s3_bucket, formatted_s3_dir_path + kMetaFilename, dbmeta_path, sync_group_id);
     }
-
+    if (!s3_conc_->Sync(sync_group_id)) {
+      SetException("Failed to sync all files to s3", AdminErrorCode::DB_ADMIN_ERROR, &callback);
+      common::Stats::get()->Incr(kS3BackupFailure);
+    }
     // Delete the directory to remove the snapshot.
     boost::filesystem::remove_all(local_path);
+
   } else {
     auto local_s3_util = createLocalS3Util(request->limit_mbs, request->s3_bucket);
     std::string formatted_s3_dir_path = rtrim(request->s3_backup_dir, '/');
-    rocksdb::Env* s3_env = new rocksdb::S3Env(formatted_s3_dir_path, local_path, std::move(local_s3_util));
+    rocksdb::Env* s3_env = new rocksdb::S3Env(request->s3_bucket, formatted_s3_dir_path, local_path, std::move(local_s3_util), s3_conc_.get(), sync_group_id);
     const bool share_files_with_checksum = request->__isset.share_files_with_checksum && request->share_files_with_checksum;
     const bool include_meta = request->__isset.include_meta && request->include_meta;
     if (!backupDBHelper(request->db_name,
@@ -1095,7 +1036,11 @@ void AdminHandler::async_tm_backupDBToS3(
       return;
     }
   }
-
+  if (!s3_conc_->Sync(sync_group_id)) {
+    callback.release()->exceptionInThread(std::move(e));
+    common::Stats::get()->Incr(kS3BackupFailure);
+    return;
+  }
   LOG(INFO) << "S3 Backup is done for " << request->db_name
             << " with latency(ms) " << timer.getElapsedTimeMs();
   common::Stats::get()->Incr(kS3BackupSuccess);
@@ -1125,6 +1070,7 @@ void AdminHandler::async_tm_restoreDBFromS3(
   auto ts = common::timeutil::GetCurrentTimestamp();
   auto local_path = FLAGS_enable_checkpoint_backup ? FLAGS_rocksdb_dir + request->db_name :
                     folly::stringPrintf("%ss3_tmp/%s%d/", FLAGS_rocksdb_dir.c_str(), request->db_name.c_str(), ts);
+  const std::string sync_group_id = request->s3_backup_dir;
   boost::system::error_code remove_err;
   boost::system::error_code create_err;
   boost::filesystem::remove_all(local_path, remove_err);
@@ -1275,8 +1221,8 @@ void AdminHandler::async_tm_restoreDBFromS3(
     }
   } else {
     std::string formatted_s3_dir_path = rtrim(request->s3_backup_dir, '/');
-    rocksdb::Env* s3_env = new rocksdb::S3Env(
-        formatted_s3_dir_path, std::move(local_path), std::move(local_s3_util));
+    rocksdb::Env* s3_env = new rocksdb::S3Env(request->s3_bucket, formatted_s3_dir_path, std::move(local_path),
+                                              std::move(local_s3_util), s3_conc_.get(), sync_group_id);
 
     if (!restoreDBHelper(request->db_name,
                          formatted_s3_dir_path,
@@ -1586,7 +1532,6 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     std::unique_ptr<AddS3SstFilesToDBRequest> request) {
   admin::AdminException e;
   e.errorCode = AdminErrorCode::DB_ADMIN_ERROR;
-
   db_admin_lock_.Lock(request->db_name);
   SCOPE_EXIT { db_admin_lock_.Unlock(request->db_name); };
 

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -161,10 +161,13 @@ class AdminHandler : virtual public AdminSvIf {
 
   std::unique_ptr<ApplicationDBManager> db_manager_;
   RocksDBOptionsGeneratorType rocksdb_options_;
+
   // S3 util used for download
   std::shared_ptr<common::S3Util> s3_util_;
   // Lock for protecting the s3 util
   mutable std::mutex s3_util_lock_;
+  // for concurrent s3 transfers
+  std::shared_ptr<common::S3Concurrent> s3_conc_;
   // db that contains meta data for all local rocksdb instances
   std::unique_ptr<rocksdb::DB> meta_db_;
   // segments which allow for overlapping keys when adding SST files


### PR DESCRIPTION
* Add class to support concurrent s3 uploads.

* Added rate limiter.  Misc fixes from comments

* rework aws sdk initialization to work without requiring modification of host application

* Fix handling of 0 upload speed to mean restore original speed, not limit speed to 0.

* Fix whitespace

* Fix for bad Sync argument.  Logging cleanup

* Adjust default s3 upload speed

* Restore log entry and whitespace fixes

Co-authored-by: krandall <krandall@pinterest.com>
(Authored by krandall, I'm just merging this since Keith does not have push permisssions yet)