### PR TITLE
Initialize atomic variables to 0.

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -483,6 +483,10 @@ AdminHandler::AdminHandler(
       LOG(INFO) << "Stopping DB deletioin thread ...";
     });
   }
+
+  // Initialize the atomic int variables
+  num_current_s3_sst_downloadings_.store(0);
+  num_current_s3_sst_uploadings_.store(0);
 }
 
 AdminHandler::~AdminHandler() {


### PR DESCRIPTION
According to the docs at https://en.cppreference.com/w/cpp/atomic/atomic/atomic, variables are not initialized. So initializing them in the constructor here.