### PR TITLE
Add option to read upstream cluster zk from add db request

### DIFF
--- a/cdc_admin/cdc_admin.thrift
+++ b/cdc_admin/cdc_admin.thrift
@@ -34,7 +34,7 @@ struct AddObserverRequest {
   # if this db is already being observed, an ALREADY_EXIST error is thrown
   1: required string db_name,
   2: required string upstream_ip,
-  # The following are needed if the replicator zk and helix cluster will not be provided via command-line args
+  # provide the upstream replicator's zk and helix cluster through request instead of command-line args
   3: optional string replicator_zk_cluster,
   4: optional string replicator_helix_cluster,
 }

--- a/cdc_admin/cdc_admin.thrift
+++ b/cdc_admin/cdc_admin.thrift
@@ -34,6 +34,9 @@ struct AddObserverRequest {
   # if this db is already being observed, an ALREADY_EXIST error is thrown
   1: required string db_name,
   2: required string upstream_ip,
+  # The following are needed if the replicator zk and helix cluster will not be provided via command-line args
+  3: optional string replicator_zk_cluster,
+  4: optional string replicator_helix_cluster,
 }
 
 struct AddObserverResponse {

--- a/cdc_admin/cdc_admin_handler.cpp
+++ b/cdc_admin/cdc_admin_handler.cpp
@@ -116,13 +116,15 @@ void CDCAdminHandler::async_tm_addObserver(
   // add the db to db_manager
   std::string err_msg;
   replicator::DBRole role = replicator::DBRole::SLAVE;
+  const std::string replicator_zk_cluster = request->__isset.replicator_zk_cluster ? request->replicator_zk_cluster : std::string("");
+  const std::string replicator_helix_cluster = request->__isset.replicator_helix_cluster ? request->replicator_helix_cluster : std::string("");
 
   // TODO(indy): Read sequence # from kafka
   // And create a db wrapper based on the internal producer
   std::unique_ptr<replicator::TestDBProxy> db_wrapper =
       std::make_unique<replicator::TestDBProxy>(request->db_name, 0);
   if (!db_manager_->addDB(
-          request->db_name, std::move(db_wrapper), role, std::move(upstream_addr), &err_msg)) {
+          request->db_name, std::move(db_wrapper), role, std::move(upstream_addr), replicator_zk_cluster, replicator_helix_cluster, &err_msg)) {
     e.errorCode = CDCAdminErrorCode::ADMIN_ERROR;
     e.message = std::move(err_msg);
     callback.release()->exceptionInThread(std::move(e));

--- a/cdc_admin/cdc_admin_handler.cpp
+++ b/cdc_admin/cdc_admin_handler.cpp
@@ -116,15 +116,23 @@ void CDCAdminHandler::async_tm_addObserver(
   // add the db to db_manager
   std::string err_msg;
   replicator::DBRole role = replicator::DBRole::SLAVE;
-  const std::string replicator_zk_cluster = request->__isset.replicator_zk_cluster ? request->replicator_zk_cluster : std::string("");
-  const std::string replicator_helix_cluster = request->__isset.replicator_helix_cluster ? request->replicator_helix_cluster : std::string("");
+  const std::string replicator_zk_cluster =
+      request->__isset.replicator_zk_cluster ? request->replicator_zk_cluster : std::string("");
+  const std::string replicator_helix_cluster = request->__isset.replicator_helix_cluster
+                                                   ? request->replicator_helix_cluster
+                                                   : std::string("");
 
   // TODO(indy): Read sequence # from kafka
   // And create a db wrapper based on the internal producer
   std::unique_ptr<replicator::TestDBProxy> db_wrapper =
       std::make_unique<replicator::TestDBProxy>(request->db_name, 0);
-  if (!db_manager_->addDB(
-          request->db_name, std::move(db_wrapper), role, std::move(upstream_addr), replicator_zk_cluster, replicator_helix_cluster, &err_msg)) {
+  if (!db_manager_->addDB(request->db_name,
+                          std::move(db_wrapper),
+                          role,
+                          std::move(upstream_addr),
+                          replicator_zk_cluster,
+                          replicator_helix_cluster,
+                          &err_msg)) {
     e.errorCode = CDCAdminErrorCode::ADMIN_ERROR;
     e.message = std::move(err_msg);
     callback.release()->exceptionInThread(std::move(e));

--- a/cdc_admin/cdc_application_db.cpp
+++ b/cdc_admin/cdc_application_db.cpp
@@ -19,7 +19,9 @@ namespace cdc_admin {
 CDCApplicationDB::CDCApplicationDB(const std::string& db_name,
                                    std::shared_ptr<replicator::DbWrapper> db_wrapper,
                                    replicator::DBRole role,
-                                   std::unique_ptr<folly::SocketAddress> upstream_addr)
+                                   std::unique_ptr<folly::SocketAddress> upstream_addr,
+                                   const std::string& replicator_zk_cluster,
+                                   const std::string& replicator_helix_cluster)
     : db_name_(db_name),
       db_(std::move(db_wrapper)),
       upstream_addr_(std::move(upstream_addr)),
@@ -31,7 +33,9 @@ CDCApplicationDB::CDCApplicationDB(const std::string& db_name,
         db_,
         role,
         upstream_addr_ ? *upstream_addr_ : folly::SocketAddress(),
-        &replicated_db_);
+        &replicated_db_,
+        replicator_zk_cluster,
+        replicator_helix_cluster);
     if (ret != replicator::ReturnCode::OK) {
       throw ret;
     }

--- a/cdc_admin/cdc_application_db.h
+++ b/cdc_admin/cdc_application_db.h
@@ -30,7 +30,9 @@ public:
   CDCApplicationDB(const std::string& db_name,
                    std::shared_ptr<replicator::DbWrapper> db_wrapper,
                    replicator::DBRole role,
-                   std::unique_ptr<folly::SocketAddress> upstream_addr);
+                   std::unique_ptr<folly::SocketAddress> upstream_addr,
+                   const std::string& replicator_zk_cluster,
+                   const std::string& replicator_helix_cluster);
 
   // Name of this db
   const std::string& db_name() const { return db_name_; }

--- a/cdc_admin/cdc_application_db_manager.h
+++ b/cdc_admin/cdc_application_db_manager.h
@@ -45,6 +45,8 @@ public:
              std::unique_ptr<UnderlyingDBType> db,
              replicator::DBRole role,
              std::unique_ptr<folly::SocketAddress> upstream_addr,
+             const std::string& replicator_zk_cluster,
+             const std::string& replicator_helix_cluster,
              std::string* error_message) {
     std::unique_lock<std::shared_mutex> lock(dbs_lock_);
     if (dbs_.find(db_name) != dbs_.end()) {
@@ -56,7 +58,8 @@ public:
     auto underlying_db_ptr =
         std::shared_ptr<UnderlyingDBType>(db.release(), [](UnderlyingDBType* db) {});
     auto application_db_ptr = std::make_shared<ApplicationDBType>(
-        db_name, std::move(underlying_db_ptr), role, std::move(upstream_addr));
+        db_name, std::move(underlying_db_ptr), role, std::move(upstream_addr),
+        replicator_zk_cluster, replicator_helix_cluster);
 
     dbs_.emplace(db_name, std::move(application_db_ptr));
     return true;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/CdcLeaderStandbyStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/CdcLeaderStandbyStateModelFactory.java
@@ -125,7 +125,7 @@ public class CdcLeaderStandbyStateModelFactory extends StateModelFactory<StateMo
       String dbName = Utils.getDbName(this.partitionName);
       String hostPort = HelixClient.getleaderInstanceId(upstreamClusterConnectString, upstreamClusterName, this.resourceName, this.partitionName);
       String ip = hostPort.split("_")[0];
-      CdcUtils.addObserver(dbName, ip, this.adminPort);
+      CdcUtils.addObserver(dbName, ip, this.adminPort, upstreamClusterConnectString, upstreamClusterName);
       Utils.logTransitionCompletionMessage(message);
     }
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/CdcUtils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/CdcUtils.java
@@ -53,11 +53,13 @@ public class CdcUtils {
    * @param upstreamAddr The upstream address of the leader for the partition
    * @param adminPort the port to make the request on
    */
-  public static AddObserverResponse addObserver(String dbName, String upstreamAddr, int adminPort) {
+  public static AddObserverResponse addObserver(String dbName, String upstreamAddr, int adminPort, String upstreamZk, String upstreamClusterName) {
     try {
       LOG.error("Add observer for: " + dbName);
       CdcAdmin.Client client = getLocalCdcAdminClient(adminPort);
       AddObserverRequest req = new AddObserverRequest(dbName, upstreamAddr);
+      req.setReplicator_zk_cluster(upstreamZk);
+      req.setReplicator_helix_cluster(upstreamClusterName);
       return client.addObserver(req);
     } catch (CDCAdminException e) {
       LOG.error("Cdc admin exception when adding observer for " + dbName);

--- a/rocksdb_replicator/rocksdb_replicator.cpp
+++ b/rocksdb_replicator/rocksdb_replicator.cpp
@@ -109,8 +109,8 @@ ReturnCode RocksDBReplicator::addDB(const std::string& db_name,
                                     const DBRole role,
                                     const folly::SocketAddress& upstream_addr,
                                     ReplicatedDB** replicated_db,
-                   const std::string& replicator_zk_cluster,
-                   const std::string& replicator_helix_cluster) {
+                                    const std::string& replicator_zk_cluster,
+                                    const std::string& replicator_helix_cluster) {
   std::shared_ptr<ReplicatedDB> new_db(
     new ReplicatedDB(db_name, std::move(db_wrapper), executor_.get(),
                      role, upstream_addr, &client_pool_, replicator_zk_cluster, replicator_helix_cluster));

--- a/rocksdb_replicator/rocksdb_replicator.cpp
+++ b/rocksdb_replicator/rocksdb_replicator.cpp
@@ -101,22 +101,19 @@ ReturnCode RocksDBReplicator::addDB(const std::string& db_name,
   std::shared_ptr<DbWrapper> db_wrapper(
     new RocksDbWrapper(db_name, std::move(db))
   );
-  return addDB(db_name, db_wrapper, role, upstream_addr, replicated_db);
+  return addDB(db_name, db_wrapper, role, upstream_addr, replicated_db = replicated_db);
 }
 
 ReturnCode RocksDBReplicator::addDB(const std::string& db_name,
                                     std::shared_ptr<DbWrapper> db_wrapper,
                                     const DBRole role,
                                     const folly::SocketAddress& upstream_addr,
-                                    ReplicatedDB** replicated_db) {
-  // Change this
-  // Oh you already did :) 
-  // Well sort of
-  // Make it so you pass in the wrapper
-  // OR can pass in the db and then you make it # overloading # c++ # expert
+                                    ReplicatedDB** replicated_db,
+                   const std::string& replicator_zk_cluster,
+                   const std::string& replicator_helix_cluster) {
   std::shared_ptr<ReplicatedDB> new_db(
     new ReplicatedDB(db_name, std::move(db_wrapper), executor_.get(),
-                     role, upstream_addr, &client_pool_));
+                     role, upstream_addr, &client_pool_, replicator_zk_cluster, replicator_helix_cluster));
 
   if (!db_map_.add(db_name, new_db)) {
     return ReturnCode::DB_PRE_EXIST;

--- a/rocksdb_replicator/rocksdb_replicator.cpp
+++ b/rocksdb_replicator/rocksdb_replicator.cpp
@@ -101,7 +101,7 @@ ReturnCode RocksDBReplicator::addDB(const std::string& db_name,
   std::shared_ptr<DbWrapper> db_wrapper(
     new RocksDbWrapper(db_name, std::move(db))
   );
-  return addDB(db_name, db_wrapper, role, upstream_addr, replicated_db = replicated_db);
+  return addDB(db_name, db_wrapper, role, upstream_addr, replicated_db);
 }
 
 ReturnCode RocksDBReplicator::addDB(const std::string& db_name,

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -113,7 +113,9 @@ class RocksDBReplicator {
                  const folly::SocketAddress& upstream_addr
                  = folly::SocketAddress(),
                  common::ThriftClientPool<ReplicatorAsyncClient>* client_pool
-                 = nullptr);
+                 = nullptr,
+                 const std::string& replicator_zk_cluster = "",
+                 const std::string& replicator_helix_cluster = "");
 
     void pullFromUpstream();
     void resetUpstream();
@@ -143,6 +145,8 @@ class RocksDBReplicator {
     std::mutex cached_iters_mutex_;
     detail::MaxNumberBox max_seq_no_acked_;
     std::shared_ptr<replicator::DbWrapper> db_wrapper_;
+    std::string replicator_zk_cluster_;
+    std::string replicator_helix_cluster_;
 
     friend class ReplicatorHandler;
     friend class RocksDBReplicator;
@@ -179,7 +183,10 @@ class RocksDBReplicator {
                    const DBRole role,
                    const folly::SocketAddress& upstream_addr
                    = folly::SocketAddress(),
-                   ReplicatedDB** replicated_db = nullptr);
+                   ReplicatedDB** replicated_db = nullptr,
+                   const std::string& replicator_zk_cluster = "",
+                   const std::string& replicator_helix_cluster = "");
+
 
   /*
    * Remove a db from the library.


### PR DESCRIPTION
instead of from command-line args

This will allow us to observe multiple rocksplicator clusters from one rocksobserver cluster