### PR TITLE
Reset upstream whenever we get an exception from the leader we have

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -235,6 +235,7 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
           } catch (const std::exception& ex) {
             LOG(ERROR) << "std::exception: " << ex.what();
             incCounter(kReplicatorConnectionErrors, 1, db->db_name_);
+            db->resetUpstream();
             db->client_ = db->client_pool_->getClient(db->upstream_addr_);
           }
         } else {

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -60,6 +60,8 @@ DEFINE_string(replicator_zk_cluster, "", "Zookeeper cluster");
 DEFINE_string(replicator_helix_cluster, "", "Helix cluster");
 DEFINE_int32(replication_error_reset_upstream_percentage, 10,
              "what percentage of replication errors should query helix for the latest leader");
+DEFINE_bool(reset_upstream_on_exception, false, 
+            "Flag to control whether to reset the upstream address for a generic exception in replication");
 DECLARE_int32(rocksdb_replicator_port);
 
 
@@ -235,7 +237,9 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
           } catch (const std::exception& ex) {
             LOG(ERROR) << "std::exception: " << ex.what();
             incCounter(kReplicatorConnectionErrors, 1, db->db_name_);
-            db->resetUpstream();
+            if (FLAGS_reset_upstream_on_exception) {
+              db->resetUpstream();
+            }
             db->client_ = db->client_pool_->getClient(db->upstream_addr_);
           }
         } else {

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -60,7 +60,7 @@ DEFINE_string(replicator_zk_cluster, "", "Zookeeper cluster");
 DEFINE_string(replicator_helix_cluster, "", "Helix cluster");
 DEFINE_int32(replication_error_reset_upstream_percentage, 10,
              "what percentage of replication errors should query helix for the latest leader");
-DEFINE_bool(reset_upstream_on_exception, false, 
+DEFINE_bool(reset_upstream_on_std_exception, false, 
             "Flag to control whether to reset the upstream address for a generic exception in replication");
 DECLARE_int32(rocksdb_replicator_port);
 
@@ -237,7 +237,7 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
           } catch (const std::exception& ex) {
             LOG(ERROR) << "std::exception: " << ex.what();
             incCounter(kReplicatorConnectionErrors, 1, db->db_name_);
-            if (FLAGS_reset_upstream_on_exception) {
+            if (FLAGS_reset_upstream_on_std_exception) {
               db->resetUpstream();
             }
             db->client_ = db->client_pool_->getClient(db->upstream_addr_);


### PR DESCRIPTION
In RocksObserver, we are not notified of leader changes by the new leader. We rely on resetUpstream() in the follower to find the new leader. 
If the old leader was killed, we receive this exception once: 
```
            if (ex.code == ErrorCode::SOURCE_NOT_FOUND) {
              // This could happen if this db missed a request about the latest upstream.
              // So try to reset it.
              incCounter(kReplicatorRemoteApplicationExceptionsNotFound, 1, db->db_name_);
              db->resetUpstream();
            }
```
However, the upstream is not reset every time that function is called, only a portion of the time: 
```
  // Query helix only FLAGS_replication_error_reset_upstream_percentage %ge of the requests.
  // This is to avoid excessive load to Helix (zk)
  if (folly::Random::rand32(0, 99) >= FLAGS_replication_error_reset_upstream_percentage) {
    LOG(ERROR) << "[resetUpstream] Skip checking latest upstream for " << db_name_;
    return;
  }
``` 
(Default: 10%)
On future pulls, we do not receive that particular exception, rather, the std::exception case. Currently we do not reset the leader when we receive another type of exception, so we will permanently be unable to reset the leader.
This could potentially happen in Rocksplicator as well, but less likely, since the new leader sends out updates to its followers as well, and we would only hit this case if the update is missed.
This does work, but I'm not sure we *should* do this. We could put extra load on Helix if the cluster is in trouble and there is no leader. So, let me know if y'all have other ideas for a better approach here. 