### PR TITLE
Put replicator sequence number in Update sent from leader to follower

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -363,7 +363,6 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
           logMetric(kReplicatorGetUpdatesSinceMs, start < end ? end - start : 0,
                     db->db_name_);
         }
-
         if (use_cached_iter || status.ok() || status.IsNotFound()) {
           ReplicateResponse response;
           uint64_t read_bytes = 0;
@@ -372,6 +371,7 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
                ++i, iter->Next()) {
             auto result = iter->GetBatch();
             Update update;
+            update.set_seq_no(result.sequence);
             next_seq_no += result.writeBatchPtr->Count();
             const auto& str = result.writeBatchPtr->Data();
             read_bytes += str.size();

--- a/rocksdb_replicator/thrift/replicator.thrift
+++ b/rocksdb_replicator/thrift/replicator.thrift
@@ -48,6 +48,9 @@ struct Update {
   # When this update was first applied to the Master.
   # A value of 0 means it is unavilable
   2: required i64 timestamp,
+
+  # The sequence number of this update on the leader
+  3: optional i64 seq_no,
 }
 
 struct ReplicateResponse {


### PR DESCRIPTION
 in replication

Can be used by followers that are not rocksdb instances (e.g. rocksobserver)