### PR TITLE
in CDC admin, accept db wrapper implementation passed in

### DIFF
--- a/cdc_admin/cdc_admin_handler.cpp
+++ b/cdc_admin/cdc_admin_handler.cpp
@@ -124,8 +124,7 @@ void CDCAdminHandler::async_tm_addObserver(
 
   // TODO(indy): Read sequence # from kafka
   // And create a db wrapper based on the internal producer
-  std::unique_ptr<replicator::TestDBProxy> db_wrapper =
-      std::make_unique<replicator::TestDBProxy>(request->db_name, 0);
+  std::unique_ptr<replicator::DbWrapper> db_wrapper = getDbWrapper(request->db_name);
   if (!db_manager_->addDB(request->db_name,
                           std::move(db_wrapper),
                           role,

--- a/cdc_admin/cdc_admin_handler.h
+++ b/cdc_admin/cdc_admin_handler.h
@@ -75,9 +75,7 @@ protected:
   common::ObjectLock<std::string> db_admin_lock_;
 
   virtual std::unique_ptr<replicator::DbWrapper> getDbWrapper(std::string db_name) {
-      std::unique_ptr<replicator::TestDBProxy> db_wrapper =
-          std::make_unique<replicator::TestDBProxy>(db_name, 0);
-      return db_wrapper;
+      return std::make_unique<replicator::TestDBProxy>(db_name, 0);
   }
 
 private:

--- a/cdc_admin/cdc_admin_handler.h
+++ b/cdc_admin/cdc_admin_handler.h
@@ -27,6 +27,7 @@
 #else
 #include "cdc_admin/gen-cpp2/CdcAdmin.h"
 #endif
+#include "rocksdb_replicator/test_db_proxy.h"
 
 namespace cdc_admin {
 
@@ -72,6 +73,12 @@ protected:
   // Put db_admin_lock in protected to provide flexibility
   // of overriding some admin functions
   common::ObjectLock<std::string> db_admin_lock_;
+
+  virtual std::unique_ptr<replicator::DbWrapper> getDbWrapper(std::string db_name) {
+      std::unique_ptr<replicator::TestDBProxy> db_wrapper =
+          std::make_unique<replicator::TestDBProxy>(db_name, 0);
+      return db_wrapper;
+  }
 
 private:
   std::unique_ptr<replicator::DbWrapper> removeDB(const std::string& db_name,

--- a/cdc_admin/cdc_admin_handler.h
+++ b/cdc_admin/cdc_admin_handler.h
@@ -74,7 +74,7 @@ protected:
   // of overriding some admin functions
   common::ObjectLock<std::string> db_admin_lock_;
 
-  virtual std::unique_ptr<replicator::DbWrapper> getDbWrapper(std::string db_name) {
+  virtual std::unique_ptr<replicator::DbWrapper> getDbWrapper(const std::string& db_name) {
       return std::make_unique<replicator::TestDBProxy>(db_name, 0);
   }
 

--- a/rocksdb_replicator/test_db_proxy.h
+++ b/rocksdb_replicator/test_db_proxy.h
@@ -1,3 +1,4 @@
+#pragma once
 
 #include "rocksdb_replicator/db_wrapper.h"
 #include "rocksdb_replicator/replicator_stats.h"


### PR DESCRIPTION
By default, print the updates to the log files, but can be overridden to use any db_wrapper