### PR TITLE
Correctly pass in replication mode to the replication handler

### DIFF
--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -20,6 +20,7 @@
 
 #include <folly/io/async/EventBase.h>
 
+#include <atomic>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -148,6 +149,7 @@ class RocksDBReplicator {
     std::shared_ptr<replicator::DbWrapper> db_wrapper_;
     std::string replicator_zk_cluster_;
     std::string replicator_helix_cluster_;
+    std::atomic<uint32_t> replication_mode_;
 
     friend class ReplicatorHandler;
     friend class RocksDBReplicator;


### PR DESCRIPTION
Correctly pass in replication mode for replication mode replication handler to deal with.

Details
-------
- The Config was not passed into the replication handler
- So the threads were waiting at Numberbox::wait for the repl to complete
- But as the repl-handler did know about the repl-mode, it did not do a post
- So all the waits timedout thereby increasing the latency ..

Tests
------
- Checked with various rep modes[0,1,2]
- Made sure it is reflected correctly on writes and in the replication handler
- No latency spikes
- Also ran Repl Consistency checker to verify