### PR TITLE
thrift_router: refactor and simplify hosts filtering and ranking

### DIFF
--- a/common/thrift_router.h
+++ b/common/thrift_router.h
@@ -419,7 +419,7 @@ class ThriftRouter {
       const Role role,
       const std::string& segment,
       const int shrink_target) {
-        auto comparator = [this, hostToRole, role, &segment, rotation_counter]
+        auto comparator = [this, &hostToRole, role, &segment, rotation_counter]
         (const Host* h1, const Host* h2) -> bool {
         // prefer master to slave
         if (role == Role::ANY && !FLAGS_always_prefer_local_host) {


### PR DESCRIPTION
Motivated by reviewing https://github.com/pinterest/rocksplicator/pull/554, where our hosts selection logic in `thrift_router` is bloated and causing lots of confusions, e.g. `RankHostsByGroupPrefixLengthAndShrinkTo` is called 3 times in a single function. https://github.com/pinterest/rocksplicator/pull/554 had to check AZ in multiple places -- error prone and make things even more un-readable. 

This PR attempts to simplify the host selection logic, by separating it into two phases in sequential: (1) filtering, and (2) sorting. 

There shouldn't be any perf impact because we still do two pass of the host list: one for filtering by role & AZ, and another for sorting the list. 

No production logic change, and passing existing test should suffice.