### PR TITLE
Add Upstream Validator

### DIFF
--- a/common/tests/thrift_router_test.cpp
+++ b/common/tests/thrift_router_test.cpp
@@ -1069,6 +1069,24 @@ TEST(ThriftRouterTest, UnreachableHost) {
     ReturnCode::BAD_HOST);
 }
 
+TEST(ThriftRouterTest, GetLeader) {
+  // load the cluster info
+  std::string content = g_config_v3;
+  auto cluster = common::parseConfig(content, "");
+
+  std::string segment = "user_pins";
+
+  auto leader = cluster->getLeader(segment, 5);
+  EXPECT_TRUE(leader.empty());
+
+  leader = cluster->getLeader(segment, 0);
+  EXPECT_EQ(leader.getHostStr(), "localhost");
+  EXPECT_EQ(leader.getPort(), 8092);
+
+  leader = cluster->getLeader(segment, 2);
+  EXPECT_EQ(leader.getPort(), 8090);
+
+}
 int main(int argc, char** argv) {
   FLAGS_always_prefer_local_host = false;
   ::testing::InitGoogleTest(&argc, argv);

--- a/common/thrift_router.h
+++ b/common/thrift_router.h
@@ -73,6 +73,9 @@ struct SegmentInfo {
 struct ClusterLayout {
   std::map<SegmentName, SegmentInfo> segments;
   std::set<Host> all_hosts;
+
+  folly::SocketAddress getLeader(const std::string segment, uint shardid) const;
+  void dump() const;
 };
 
 }  // namespace detail

--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -128,6 +128,10 @@ class ApplicationDB {
     return upstream_addr_.get();
   }
 
+  uint64_t getLatestSequenceNumber() const {
+    return db_->GetLatestSequenceNumber();
+  }
+
   ~ApplicationDB();
 
  private:

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -202,11 +202,21 @@ void RocksDBReplicator::ReplicatedDB::resetUpstream() {
     if (tokens.size() == 2 && tokens[0] != upstream_addr_.getAddressStr()) {
       incCounter(kReplicatorLeaderReset, 1, db_name_);
       LOG(ERROR) << "[resetUpstream] Resetting upstream for " << db_name_ << " to " << tokens[0];
-      upstream_addr_.setFromIpPort(tokens[0], FLAGS_rocksdb_replicator_port);
-      // Update client with new upstream address.
-      client_ = client_pool_->getClient(upstream_addr_);
+      folly::SocketAddress addr;
+      addr.setFromIpPort(tokens[0], FLAGS_rocksdb_replicator_port);
+      resetUpstream(addr);
     }
   }
+}
+
+void RocksDBReplicator::ReplicatedDB::resetUpstream(folly::SocketAddress addr) {
+  
+  // force port
+  addr.setPort(FLAGS_rocksdb_replicator_port);
+  upstream_addr_ = addr;
+  
+  // Update client with new upstream address.
+  client_ = client_pool_->getClient(upstream_addr_);
 }
 
 void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {

--- a/rocksdb_replicator/rocksdb_replicator.cpp
+++ b/rocksdb_replicator/rocksdb_replicator.cpp
@@ -53,7 +53,8 @@ RocksDBReplicator::RocksDBReplicator()
     , server_("disabled", false)
 #endif
     , thread_()
-    , cleaner_() {
+    , cleaner_()
+    , upstreamValidator_() {
 #if __GNUC__ >= 8
   executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
 #else
@@ -88,6 +89,7 @@ RocksDBReplicator::RocksDBReplicator()
 
 RocksDBReplicator::~RocksDBReplicator() {
   db_map_.clear();
+  upstreamValidator_.stopAndWait();
   cleaner_.stopAndWait();
   server_.stop();
   thread_.join();
@@ -174,6 +176,10 @@ ReturnCode RocksDBReplicator::write(const std::string& db_name,
 std::string RocksDBReplicator::getTextStats() {
   // TODO(bol) add stats
   return "TBD";
+}
+
+void RocksDBReplicator::setShardMapPath(const std::string& path) {
+  strShardMapPath = path;
 }
 
 }  // namespace replicator

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -35,6 +35,7 @@
 #include "rocksdb_replicator/non_blocking_condition_variable.h"
 #include "rocksdb_replicator/db_wrapper.h"
 #include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
+#include "rocksdb_replicator/upstream_validator.h"
 #include "folly/SocketAddress.h"
 #include "rocksdb/db.h"
 #include "thrift/lib/cpp2/server/ThriftServer.h"
@@ -120,6 +121,7 @@ class RocksDBReplicator {
 
     void pullFromUpstream();
     void resetUpstream();
+    void resetUpstream(folly::SocketAddress addr);
     using CallbackType =
       apache::thrift::HandlerCallback<std::unique_ptr<ReplicateResponse>>;
     void handleReplicateRequest(std::unique_ptr<CallbackType> callback,
@@ -152,6 +154,7 @@ class RocksDBReplicator {
     friend class ReplicatorHandler;
     friend class RocksDBReplicator;
     friend class CachedIterCleaner;
+    friend class UpstreamValidator;
   };
 
   static RocksDBReplicator* instance() {
@@ -223,6 +226,8 @@ class RocksDBReplicator {
   RocksDBReplicator(const RocksDBReplicator&) = delete;
   RocksDBReplicator& operator=(const RocksDBReplicator&) = delete;
 
+  void setShardMapPath(const std::string& path);
+
  private:
   class CachedIterCleaner {
    public:
@@ -257,6 +262,12 @@ class RocksDBReplicator {
   std::thread thread_;
 
   CachedIterCleaner cleaner_;
+
+  // TODO(prem) : move to DBConfig
+  std::string strShardMapPath;
+  UpstreamValidator upstreamValidator_;
+
+  friend class UpstreamValidator;
 };
 
 }  // namespace replicator

--- a/rocksdb_replicator/upstream_validator.cpp
+++ b/rocksdb_replicator/upstream_validator.cpp
@@ -1,0 +1,212 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author prem (prem@pinterest.com)
+//
+
+#include <folly/io/async/EventBase.h>
+#if __GNUC__ >= 8
+#include "folly/system/ThreadName.h"
+#else
+#include <folly/ThreadName.h>
+#endif
+#include <gflags/gflags.h>
+#include <time.h>
+
+#include "common/segment_utils.h"
+#include "common/stats/stats.h"
+#include "common/thrift_router.h"
+#include "rocksdb_replicator/rocksdb_replicator.h"
+
+// 600 seconds / 10m
+#define INITIAL_DELAY 10
+// TODO(prem) change to DBConfig soon
+DEFINE_int32(replicator_upstreamvalidator_interval_ms, 60 * 1000, "Interval at which Upstreams are checked");
+
+namespace replicator {
+
+
+void UpstreamValidator::State::setSequenceNo(uint64_t seq_no, uint64_t lastmod) {
+  this->seq_no = seq_no;
+  this->lastmod = lastmod;
+}
+
+UpstreamValidator::UpstreamValidator()
+    : thread_(), evb_() {
+  runCount = 0;
+  scheduleValidation();
+  thread_ = std::thread([this] {
+      if (!folly::setThreadName("UpstreamValidator")) {
+        LOG(ERROR) << "failed to setThreadName() for UpstreamValidator thread";
+      }
+
+      LOG(INFO) << "starting upstream validator thread";
+      this->evb_.loopForever();
+      LOG(INFO) << "stopping upstream validator thread";
+    });
+}
+
+void UpstreamValidator::scheduleValidation() {
+  evb_.runAfterDelay([this] {
+    validate();
+    this->scheduleValidation();
+  },
+  FLAGS_replicator_upstreamvalidator_interval_ms);
+}
+
+/**
+ * @brief 
+ * dormant_followers = list of whose slaves whose sequence number has not progressed
+ *  if dormant_followers.size() > 0:
+ *    get_shardmap()
+ *    for each dormant_follower:
+ *      check if upstream is set correctly from shardmap
+ *      if not:
+ *         reset to the correct upstream
+ */
+void UpstreamValidator::validate() {
+  static std::string localhostip = "127.0.0.1";
+  static std::string localhost = "localhost";
+  
+  /**
+   * check if the feature is disabled
+   */ 
+
+  // TODO: feature check
+
+  auto strShardMapPath = RocksDBReplicator::instance()->strShardMapPath;
+
+  if (strShardMapPath.empty()) {
+    LOG(ERROR) << "ShardMap path not set, unable to validate...";
+    return;
+  }
+
+  // load the cluster info
+  std::string content;
+  CHECK(folly::readFile(strShardMapPath.c_str(), content));
+
+  auto cluster = common::parseConfig(std::move(content), "");
+  CHECK(cluster);
+  
+  LOG(INFO) << "shardmap location: " << strShardMapPath;
+  std::lock_guard<std::mutex> g(mutex_);
+  runCount++;
+  for (auto item : followers) {
+    const auto& name = item.first;
+    const auto& state = item.second;
+
+    std::shared_ptr<RocksDBReplicator::ReplicatedDB> db;
+    auto& db_map_ = RocksDBReplicator::instance()->db_map_;
+    if (!db_map_.get(name, &db)) {
+      // db missing.. something wrong
+      LOG(ERROR) << "db missing in map : " << name;
+      continue;
+    }
+
+    // get the latest seq number
+    const auto seq_no = db->db_wrapper_->LatestSequenceNumber();
+    if (state.seq_no != seq_no) {
+      followers[name].setSequenceNo(seq_no, runCount);
+    } else {
+      // there has been no progress
+
+      LOG(INFO) << "seqno has not changed for db=" << name << " seqno=" << seq_no << " after run=" << runCount;
+
+      /**
+       * check if the service has just started
+       * Effectively start checking after some time
+       */ 
+      if (runCount < INITIAL_DELAY) {
+        continue;
+      }
+
+      /**
+       * Wait for atleast few runs of mistmatch to see if the system recovers
+       * by itself (3 runs)
+       */
+      if (runCount - followers[name].lastmod < 3) {
+        continue;
+      }
+
+      /**
+       * Check if the upstream was reset recently 
+       */
+
+      if (runCount - followers[name].reset < 2) {
+        // skip if needed
+      }
+
+      const auto upstream = db->upstream_addr_.getAddressStr();
+
+      if (upstream == localhost || upstream == localhostip) {
+         LOG(ERROR) << "localhost set as upstream for db=" << name << " up:" << upstream;
+      }
+
+      // get the segment and shardid from dbname
+      auto segment = common::DbNameToSegment(name);
+      int  shardid = common::ExtractShardId(name);
+      if (shardid < 0) {
+        LOG(ERROR) << "unable to extract shardid from " << name;
+        continue;
+      }
+
+      // check if the upstream has been set correctly.
+      auto leader = cluster->getLeader(segment, shardid);
+      if (leader.empty()) {
+        LOG(ERROR) << "No Leader set for segment=" << segment << " shard=" << shardid;
+        continue;
+      }
+
+      if (upstream != leader.getAddressStr()) {
+        // current upstream does NOT match the leader set in the shardmap
+        LOG(INFO) << "resetting upstream ... current:" << upstream << " expected:" << leader.getAddressStr();
+        
+        followers[name].reset = runCount;
+        // TODO() : add metric
+        // set it to proper upstream !!
+        db->resetUpstream(leader);
+      }
+    }
+  }
+}
+
+bool UpstreamValidator::add(const std::string& name) {
+  std::lock_guard<std::mutex> g(mutex_);
+  const auto& iter = followers.find(name);
+  if (iter != followers.end()) {
+    // already exists
+    return false;
+  }
+  followers[name].setSequenceNo(0, runCount);
+  return true;
+}
+
+bool UpstreamValidator::remove(const std::string& name) {
+  std::lock_guard<std::mutex> g(mutex_);
+  const auto& iter = followers.find(name);
+  if (iter == followers.end()) {
+    // does not exist
+    return false;
+  }
+  followers.erase(iter);
+  return true;
+}
+
+void UpstreamValidator::stopAndWait() {
+  evb_.terminateLoopSoon();
+  thread_.join();
+}
+
+}  // namespace replicator

--- a/rocksdb_replicator/upstream_validator.h
+++ b/rocksdb_replicator/upstream_validator.h
@@ -1,0 +1,61 @@
+/// Copyright 2021 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+//
+// @author prem (prem@pinterest.com)
+//
+
+#include <folly/io/async/EventBase.h>
+#include <mutex>
+#include <thread>
+
+
+namespace replicator {
+  /**
+   * @brief 
+   * Validates the upstreams of followers who are not replicating
+   */
+  class UpstreamValidator {
+   public:
+    UpstreamValidator();
+    void stopAndWait();
+
+    // add a follower
+    bool add(const std::string& name);
+
+    // remove a follower
+    bool remove(const std::string& name);
+
+   private:
+    struct State {
+      uint64_t seq_no = 0;
+      uint64_t lastmod = 0;
+      uint64_t reset = 0;
+
+      void setSequenceNo(uint64_t seq_no, uint64_t lastmod);
+    };
+
+    void scheduleValidation();
+    void validate();
+    std::thread thread_;
+
+    // map of follower db names to state
+    std::map<std::string, State> followers;
+    std::mutex mutex_;
+
+    // to keep track of how many times validation has run
+    uint64_t runCount;
+    folly::EventBase evb_;
+  };
+}


### PR DESCRIPTION
Upstream Validation by Followers
--------------------------------
Once in a while , we have noticed that followers do not get the right upstream set up. We believe that these are because of messages from the Controller being missed dude to race conditions. We will identify and fix those issues separately. 

Solution
--------
If the upstream is different from the one specified in the Cluster Map then set it explicitly. For now do this only for the followers whose sequence number does not change

Design
-------
- UpstreamValidator will be a member of RocksDBReplicator 
- UpstreamValidator will run a validation task once every  N  seconds ( say N=60) 
- Track the LatestSequenceNumber when the validator runs
- Identify dormant followers (no change in seq no)
- Check if upstream of dormant followers matches with the cluster map
- Keep track the runcount of the thread 
- Reset the upstream address & re-init the client pool if necessary
