### PR TITLE
Protect config around SharedMutex

### DIFF
--- a/common/dbconfig.h
+++ b/common/dbconfig.h
@@ -12,6 +12,7 @@
 
 #include "common/config.h"
 #include "common/jsoncpp/include/json/json.h"
+#include <folly/SharedMutex.h>
 
 /**
  * {
@@ -28,9 +29,10 @@ namespace common {
 
 struct DBConfig {
   std::unordered_map<std::string, ConfigPtr> dataSetConfigMap;
+  using uptr  = std::unique_ptr<const DBConfig>;
 };
 
-using DBConfigPtr  = std::shared_ptr<const DBConfig>;
+
 
 /**
  * DBConfigManager manages the per-dataset and service level
@@ -70,9 +72,10 @@ public:
 private:
   /* No direct instantiation. Use the global static via ::get()*/
   DBConfigManager();
-  DBConfigPtr dbConfig_;
+  DBConfig::uptr dbConfig_;
   ConfigPtr getConfig(const std::string& dbName) const;
-  DBConfigPtr parseConfig(const Json::Value& root);
+  DBConfig::uptr parseConfig(const Json::Value& root);
   std::atomic<bool> fDataLoaded_;
+  mutable folly::SharedMutex lock;
 };
 }  // namespace common

--- a/common/tests/dbconfig_test.cpp
+++ b/common/tests/dbconfig_test.cpp
@@ -61,8 +61,7 @@ TEST(DBConfigTest, BasicFromObject) {
 
 TEST(DBConfigTest, InvalidContent) {
   auto cfgMgr = DBConfigManager::get();
-  std::string content = R"({
-  })";
+  std::string content = R"()";
 
   Json::Value root;
   Json::Reader reader;
@@ -75,7 +74,7 @@ TEST(DBConfigTest, InvalidContent) {
 
 TEST(DBConfigTest, EmptyContent) {
   auto cfgMgr = DBConfigManager::get();
-  std::string content = R"()";
+  std::string content = R"({})";
 
   Json::Value root;
   Json::Reader reader;
@@ -83,7 +82,7 @@ TEST(DBConfigTest, EmptyContent) {
     LOG(ERROR) << "Could not parse json config :" << content;
   }
 
-  EXPECT_FALSE(cfgMgr->loadJsonObject(root));
+  EXPECT_TRUE(cfgMgr->loadJsonObject(root));
 }
 
 }  // namespace common


### PR DESCRIPTION
There were too many concerns about avoiding rw-lock around the config
var. The primary reason it was avoided was performance. We will roll
this back if this hits perf issues. [folly/SharedMutex ](https://github.com/facebook/folly/blob/main/folly/SharedMutex.h)seems to be quite performant