### PR TITLE
thrift_client_pool: close bad channel before creating a new one

### DIFF
--- a/common/thrift_client_pool.h
+++ b/common/thrift_client_pool.h
@@ -237,6 +237,11 @@ class ThriftClientPool {
         // good for use and it's not too soon to create a new one or we want to
         // be aggressive
         if (!channel_good && (!too_soon || aggressively)) {
+          // close the bad channel before establising a new one.
+          // This is to avoid potentially accumulating CLOSE_WAIT on the client side.
+          if (channel) {
+            channel->closeNow();
+          }
           should_new_channel = true;
         }
       }


### PR DESCRIPTION
We see rocksplicator based applications leaking CLOSE_WAIT sockets, which is typically
due to applications not closing its own sockets properly after the connection has been closed
by the remote server. 

To fix that, when creating a new client for a destination address, we ensure the existing thrift channel (socket)
is closed, before creating a new one. 