### PR TITLE
Differentiate between empty config and invalid config

### DIFF
--- a/common/dbconfig.cpp
+++ b/common/dbconfig.cpp
@@ -54,6 +54,10 @@ DBConfigPtr DBConfigManager::parseConfig(const Json::Value& root) {
   static const std::string ACK_MODE = "ack_mode";
   static const std::string DATASET = "dataset";
 
+  if (!root.isObject()) {
+    return nullptr;
+  }
+
   DBConfig newDBConfig;
 
   if (root.isMember(DATASET)) {
@@ -75,10 +79,7 @@ DBConfigPtr DBConfigManager::parseConfig(const Json::Value& root) {
       }
     }
   }
-  if (newDBConfig.dataSetConfigMap.size() == 0) {
-    // no data was loaded..
-    return nullptr;
-  }
+
   return std::make_shared<const DBConfig>(std::move(newDBConfig));
 }
 

--- a/common/tests/dbconfig_test.cpp
+++ b/common/tests/dbconfig_test.cpp
@@ -61,8 +61,7 @@ TEST(DBConfigTest, BasicFromObject) {
 
 TEST(DBConfigTest, InvalidContent) {
   auto cfgMgr = DBConfigManager::get();
-  std::string content = R"({
-  })";
+  std::string content = R"()";
 
   Json::Value root;
   Json::Reader reader;
@@ -75,7 +74,7 @@ TEST(DBConfigTest, InvalidContent) {
 
 TEST(DBConfigTest, EmptyContent) {
   auto cfgMgr = DBConfigManager::get();
-  std::string content = R"()";
+  std::string content = R"({})";
 
   Json::Value root;
   Json::Reader reader;
@@ -83,7 +82,7 @@ TEST(DBConfigTest, EmptyContent) {
     LOG(ERROR) << "Could not parse json config :" << content;
   }
 
-  EXPECT_FALSE(cfgMgr->loadJsonObject(root));
+  EXPECT_TRUE(cfgMgr->loadJsonObject(root));
 }
 
 }  // namespace common


### PR DESCRIPTION
- When an empty json is specified all setting become default
- If an invalid json is specified , it is ignored