### PR TITLE
LeaderFollowerStateModelFactory: fix a typo

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
@@ -657,7 +657,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
           for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
             String[] hostPort = instanceNameAndRole.getKey().split("_");
             String hostName = hostPort[0];
-            int port = Integer.parseInt(ihostPort[1]);
+            int port = Integer.parseInt(hostPort[1]);
             if (this.host.equals(hostName) || upstreamHost.equals(hostName)) {
               //  mysel or upstream
               continue;


### PR DESCRIPTION
Looks like I accidentally introduced a typo in a previous change https://github.com/pinterest/rocksplicator/pull/569 upon landing,
fixing that. Verified by running `mvn test` and it now passes

(Also surprised we don't have CI test setup for this)