### PR TITLE
rocksdb_replicator: add monitoring for replication RPC request

### DIFF
--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -46,7 +46,10 @@ const std::string kReplicatorGetUpdatesSinceMs =
   "replicator_get_update_since_ms";
 const std::string kReplicatorWriteMs = "replicator_write_ms";
 const std::string kReplicatorLeaderSequenceNumbersBehind = "replicator_leader_sequence_numbers_behind";
-
+const std::string kReplicatorPullRequests = "replicator_pull_requests";
+const std::string kReplicatorPullRequestsSuccess = "replicator_pull_requests_success";
+const std::string kReplicatorPullRequestsFailure = "replicator_pull_requests_failure";
+const std::string kReplicatorPullLatency = "replicator_pull_latency";
 
 void logMetric(const std::string& metric_name, int64_t value,
                const std::string& db_name) {

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -35,6 +35,10 @@ extern const std::string kReplicatorLeaderSequenceNumbersBehind;
 extern const std::string kReplicatorLeaderReset;
 extern const std::string kReplicatorTimedOut;
 extern const std::string kReplicatorRemoteApplicationExceptionsNotFound;
+extern const std::string kReplicatorPullRequests;
+extern const std::string kReplicatorPullRequestsSuccess;
+extern const std::string kReplicatorPullRequestsFailure;
+extern const std::string kReplicatorPullLatency;
 
 // add value to metric_name. If db_name is not empty, add value to the per db
 // metric also


### PR DESCRIPTION
Add metrics for monitoring the replication requests, including success/failure counters and the RPC latency

Test via an internal private build, see stats:
- RPS: https://statsboard.pinadmin.com/share/4pjat
- latency: https://statsboard.pinadmin.com/share/9gdtn