### PR TITLE
rocksdb_replicator: post max_seq_no_acked_ regardless of replication mode

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -319,15 +319,15 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
     logMetric(kReplicatorLeaderSequenceNumbersBehind, seq_no - leaderSeqNum, db ->db_name_);
   }
 
+  // post the largest sequence number the Slave has committed
+  max_seq_no_acked_.post(seq_no);
+
   auto replication_mode =  common::DBConfigManager::get()->getReplicationMode(db_name_);
   // for now we have to support both till all clusters are migrated
   if (FLAGS_replicator_replication_mode > replication_mode) {
     replication_mode = FLAGS_replicator_replication_mode;
   }
-  if (replication_mode == 1 || replication_mode == 2) {
-    // post the largest sequence number the Slave has committed
-    max_seq_no_acked_.post(seq_no);
-  }
+
   auto timeout = request->max_wait_ms;
 
   cond_var_.runIfConditionOrWaitForNotify(


### PR DESCRIPTION
We now support dynamically modifying the replication mode for a db, and the way we use the `max_seq_no_acked_` may run into edge case issues:

**Background on how this `max_seq_no_acked_` is used:**
Currently we only updates `max_seq_no_acked_` in two places:
- replication mode = 1 or 2: when the leader receives a replication request from a follower with the latest sequence number it committed
- replication mode = 1: when the leader sent an rocskdb update with a specific sequence  out to the network (without waiting for follower ack)

On the `Write` Path, if replication_mode is 1 or 2, the leader which received the write will wait for `max_seq_no_acked_` to catch up to it's own local latest sequence, before returning the response to the client. It doesn't wait if replication_mode is 0.

**Possible issues**
As we can see, `max_seq_no_acked_` is not updated when replication_mode == 0. This mean the following can happen:
- db is operating with replication_mode == 2
- a write request arrives and wait for `max_seq_no_acked_` to catch up
- db switched to replication_mode == 0, and as a result, `max_seq_no_acked_` is not updated even when followers ACKed the leader that they have received the write.
- the write request times out after **5s** , during which all other requests may be blocked and may cause cascading failures/timeouts. 

**Proposed solution**
This PR proposes a simple fix: always update `max_seq_no_acked_` regardless of the replication mode, i.e. even when replication_mode == 0, `max_seq_no_acked_` will have the largest sequence number ACKed by followers. This fixes the above race condition when switching from replication mode 2 to 0.  There is no impact to stable states:
- in replication_mode 1 & 2, there is no logic change with this PR
- in replication_mode 0, only change is we update the `max_seq_no_acked_` upon follower ACK, but since we don't wait for `max_seq_no_acked_` anyway in the Write path, it's a no-op.
