### PR TITLE
rocksdb_replicator: add Write instrumentation 

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -85,49 +85,61 @@ rocksdb::Status RocksDBReplicator::ReplicatedDB::Write(
     throw ReturnCode::WRITE_TO_SLAVE;
   }
 
+  auto write_begin = GetCurrentTimeMs();
+
   incCounter(kReplicatorWriteBytes, updates->GetDataSize(), db_name_);
 
   auto ms = GetCurrentTimeMs();
   updates->PutLogData(rocksdb::Slice(reinterpret_cast<const char*>(&ms),
                                      sizeof(ms)));
-  auto start = GetCurrentTimeMs();
+  auto write_leader_begin = GetCurrentTimeMs();
   auto status = db_wrapper_->WriteToLeader(options, updates);
-  auto end = GetCurrentTimeMs();
-  logMetric(kReplicatorWriteMs, start < end ? end - start : 0, db_name_);
-  
+  auto write_leader_end = GetCurrentTimeMs();
+  auto write_leader_time = write_leader_begin < write_leader_end ? write_leader_end - write_leader_begin : 0;
+  logMetric(kReplicatorWriteToLeaderMs, write_leader_time, db_name_);
+
+  if (!status.ok()) {
+    incCounter(kReplicatorWriteLeaderFailure, 1, db_name_);
+    auto write_failure_end = GetCurrentTimeMs();
+    logMetric(kReplicatorWriteFailureResponseTime, write_begin < write_failure_end? write_failure_end - write_begin:0, db_name_);
+    return status;
+  }
+
   auto replication_mode =  common::DBConfigManager::get()->getReplicationMode(db_name_);
   // TODO(prem) : remove support for gflags soon
   // for now we have to support both till all clusters are migrated
   if (FLAGS_replicator_replication_mode > replication_mode) {
     replication_mode = FLAGS_replicator_replication_mode;
   }
-  if (status.ok()) {
-    cond_var_.notifyAll();
 
-    // TODO(bol): change it once RocksDB guarantees the sequence number is in
-    // the write batch.
-    auto cur_seq_no = db_wrapper_->LatestSequenceNumber();
-    if (seq_no) {
-      *seq_no = cur_seq_no;
-    }
+  cond_var_.notifyAll();
 
-    switch (replication_mode) {
-    case 1:
-    case 2:
-      // TODO(bol): This potentially could block all worker threads. We may
-      // consider having a dedicated set of worker threads for admin requests,
-      // and/or provide async write API when this turns out to be a problem.
-      if (!max_seq_no_acked_.wait(cur_seq_no, FLAGS_replicator_timeout_ms)) {
-        incCounter(kReplicatorTimedOut, 1, db_name_);
-        LOG(ERROR) << "Failed to receive ack from follower, timing out for " << db_name_;
-        return rocksdb::Status::TimedOut("Failed to receive ack from follower");
-      }
-      break;
-    default:
-      CHECK(replication_mode == 0)
-        << "Invalid replicaton mode " << replication_mode;
-    }
+  // TODO(bol): change it once RocksDB guarantees the sequence number is in
+  // the write batch.
+  auto cur_seq_no = db_wrapper_->LatestSequenceNumber();
+  if (seq_no) {
+    *seq_no = cur_seq_no;
   }
+
+  switch (replication_mode) {
+  case 1:
+  case 2:
+    // TODO(bol): This potentially could block all worker threads. We may
+    // consider having a dedicated set of worker threads for admin requests,
+    // and/or provide async write API when this turns out to be a problem.
+    if (!max_seq_no_acked_.wait(cur_seq_no, FLAGS_replicator_timeout_ms)) {
+      incCounter(kReplicatorWriteWaitTimedOut, 1, db_name_);
+      LOG(ERROR) << "Failed to receive ack from follower, timing out for " << db_name_;
+      return rocksdb::Status::TimedOut("Failed to receive ack from follower");
+    }
+    break;
+  default:
+    CHECK(replication_mode == 0)
+      << "Invalid replicaton mode " << replication_mode;
+  }
+  auto write_success_end = GetCurrentTimeMs();
+  logMetric(kReplicatorWriteSuccessResponseTime, write_begin < write_success_end? write_success_end - write_begin:0, db_name_);
+  incCounter(kReplicatorWriteSuccess, 1, db_name_);
 
   return status;
 }

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -101,7 +101,7 @@ rocksdb::Status RocksDBReplicator::ReplicatedDB::Write(
   if (!status.ok()) {
     incCounter(kReplicatorWriteLeaderFailure, 1, db_name_);
     auto write_failure_end = GetCurrentTimeMs();
-    logMetric(kReplicatorWriteFailureResponseTime, write_begin < write_failure_end? write_failure_end - write_begin:0, db_name_);
+    logMetric(kReplicatorWriteFailureResponseTime, write_begin < write_failure_end? write_failure_end - write_begin : 0, db_name_);
     return status;
   }
 
@@ -138,7 +138,7 @@ rocksdb::Status RocksDBReplicator::ReplicatedDB::Write(
       << "Invalid replicaton mode " << replication_mode;
   }
   auto write_success_end = GetCurrentTimeMs();
-  logMetric(kReplicatorWriteSuccessResponseTime, write_begin < write_success_end? write_success_end - write_begin:0, db_name_);
+  logMetric(kReplicatorWriteSuccessResponseTime, write_begin < write_success_end? write_success_end - write_begin : 0, db_name_);
   incCounter(kReplicatorWriteSuccess, 1, db_name_);
 
   return status;

--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -31,6 +31,7 @@ const std::string kReplicatorLatency = "replicator_latency_ms";
 const std::string kReplicatorOutBytes = "replicator_out_bytes";
 const std::string kReplicatorInBytes = "replicator_in_bytes";
 const std::string kReplicatorWriteBytes = "replicator_write_bytes";
+
 const std::string kReplicatorConnectionErrors = "replicator_connection_errors";
 const std::string kReplicatorRemoteApplicationExceptions =
   "replicator_remote_app_exceptions";
@@ -38,13 +39,22 @@ const std::string kReplicatorRemoteApplicationExceptionsNotFound =
   "replicator_remote_app_exceptions_source_not_found";
 const std::string kReplicatorLeaderReset =
   "replicator_remote_app_leader_reset";
-const std::string kReplicatorTimedOut =
-  "replicator_write_time_out";
+
 const std::string kReplicatorGetUpdatesSinceErrors =
   "replicator_get_update_since_errors";
 const std::string kReplicatorGetUpdatesSinceMs =
   "replicator_get_update_since_ms";
-const std::string kReplicatorWriteMs = "replicator_write_ms";
+
+const std::string kReplicatorWriteSuccess =
+  "replicator_write_success";
+const std::string kReplicatorWriteLeaderFailure =
+  "replicator_write_leader_failure";
+const std::string kReplicatorWriteWaitTimedOut =
+  "replicator_write_wait_time_out";
+const std::string kReplicatorWriteToLeaderMs = "replicator_write_to_leader_ms";
+const std::string kReplicatorWriteSuccessResponseTime = "replicator_write_success_response_time";
+const std::string kReplicatorWriteFailureResponseTime = "replicator_write_failure_response_time";
+
 const std::string kReplicatorLeaderSequenceNumbersBehind = "replicator_leader_sequence_numbers_behind";
 const std::string kReplicatorPullRequests = "replicator_pull_requests";
 const std::string kReplicatorPullRequestsSuccess = "replicator_pull_requests_success";

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -26,15 +26,24 @@ extern const std::string kReplicatorLatency;
 extern const std::string kReplicatorOutBytes;
 extern const std::string kReplicatorInBytes;
 extern const std::string kReplicatorWriteBytes;
+
 extern const std::string kReplicatorConnectionErrors;
 extern const std::string kReplicatorRemoteApplicationExceptions;
+extern const std::string kReplicatorRemoteApplicationExceptionsNotFound;
+
 extern const std::string kReplicatorGetUpdatesSinceErrors;
 extern const std::string kReplicatorGetUpdatesSinceMs;
-extern const std::string kReplicatorWriteMs;
+
 extern const std::string kReplicatorLeaderSequenceNumbersBehind;
 extern const std::string kReplicatorLeaderReset;
-extern const std::string kReplicatorTimedOut;
-extern const std::string kReplicatorRemoteApplicationExceptionsNotFound;
+
+extern const std::string kReplicatorWriteSuccess;
+extern const std::string kReplicatorWriteLeaderFailure;
+extern const std::string kReplicatorWriteWaitTimedOut;
+extern const std::string kReplicatorWriteToLeaderMs;
+extern const std::string kReplicatorWriteSuccessResponseTime;
+extern const std::string kReplicatorWriteFailureResponseTime;
+
 extern const std::string kReplicatorPullRequests;
 extern const std::string kReplicatorPullRequestsSuccess;
 extern const std::string kReplicatorPullRequestsFailure;


### PR DESCRIPTION
This PR adds the following metrics for instrumenting the `Write` path:

Success & failure counters:
- `kReplicatorWriteSuccess`
- `kReplicatorWriteLeaderFailure`
- `kReplicatorWriteWaitTimedOut`

Latency metrics:
- `kReplicatorWriteToLeaderMs` (just a rename from existing `kReplicatorTimedOut`)
- `kReplicatorWriteSuccessResponseTime`
- `kReplicatorWriteFailureResponseTime`

This will help us track the internal write behavior in rocksplicator (instead of just relying on client side metrics)

Pure metrics addition/change (and small refactor as part of that), no other production logic change