### PR TITLE
rocksdb_replicator: resolve compiler warning on initialization order

### DIFF
--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -129,6 +129,7 @@ class RocksDBReplicator {
     void cleanIdleCachedIters();
 
     const std::string db_name_;
+    std::shared_ptr<replicator::DbWrapper> db_wrapper_;
     folly::Executor* const executor_;
     const DBRole role_;
     folly::SocketAddress upstream_addr_;
@@ -142,7 +143,6 @@ class RocksDBReplicator {
                 uint64_t>> cached_iters_;
     std::mutex cached_iters_mutex_;
     detail::MaxNumberBox max_seq_no_acked_;
-    std::shared_ptr<replicator::DbWrapper> db_wrapper_;
     std::string replicator_zk_cluster_;
     std::string replicator_helix_cluster_;
 

--- a/rocksdb_replicator/rocksdb_wrapper.h
+++ b/rocksdb_replicator/rocksdb_wrapper.h
@@ -18,8 +18,8 @@ public:
   RocksDbWrapper(const std::string& db_name, std::shared_ptr<rocksdb::DB> db);
 
 private:
-  std::shared_ptr<rocksdb::DB> db_;
   const std::string db_name_;
+  std::shared_ptr<rocksdb::DB> db_;
   rocksdb::WriteOptions write_options_;
 };
 

--- a/rocksdb_replicator/test_db_proxy.h
+++ b/rocksdb_replicator/test_db_proxy.h
@@ -18,8 +18,8 @@ public:
   TestDBProxy(const std::string& db_name, rocksdb::SequenceNumber seq_no = 0);
 
 private:
-  rocksdb::SequenceNumber seq_no_;
   const std::string db_name_;
+  rocksdb::SequenceNumber seq_no_;
 };
 
 }  // namespace replicator


### PR DESCRIPTION
Simply resolving some compiler warnings as I see in the rocksdb_replicator dir, e.g.
```
/rocksplicator/rocksdb_replicator/test_db_proxy.h:22:21: warning: 'replicator::TestDBProxy::db_name_' will be initialized after [-Wreorder]
   const std::string db_name_;
```