### PR TITLE
rocksdb_replicator: remove unused getTextStats

### DIFF
--- a/rocksdb_replicator/rocksdb_replicator.cpp
+++ b/rocksdb_replicator/rocksdb_replicator.cpp
@@ -170,9 +170,4 @@ ReturnCode RocksDBReplicator::write(const std::string& db_name,
   }
 }
 
-std::string RocksDBReplicator::getTextStats() {
-  // TODO(bol) add stats
-  return "TBD";
-}
-
 }  // namespace replicator

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -209,12 +209,6 @@ class RocksDBReplicator {
                    rocksdb::WriteBatch* updates,
                    rocksdb::SequenceNumber* seq_no = nullptr);
 
-  /*
-   * Get stats of the library in the same text format as the java ostrich
-   * library.
-   */
-  std::string getTextStats();
-
   // no copy or move
   RocksDBReplicator(const RocksDBReplicator&) = delete;
   RocksDBReplicator& operator=(const RocksDBReplicator&) = delete;


### PR DESCRIPTION
Not in use, and I don't think it's not relevant either, given we already support exporting the stats in ostrich format (hence the TODO is done)