### PR TITLE
Add introspection for rocksdb replicator 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "*.tcc": "cpp"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.tcc": "cpp"
+    }
+}

--- a/common/network_util.cpp
+++ b/common/network_util.cpp
@@ -51,4 +51,14 @@ const std::string& getLocalIPAddress() {
   return local_ip;
 }
 
+std::string getNetworkAddressStr(const folly::SocketAddress& addr) noexcept {
+  std::string add_str = "unknown_addr";
+  try {
+    add_str = addr.getAddressStr();
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "cannot get upstream address: " << e.what();
+  }
+  return add_str;
+}
+
 }  // namespace common

--- a/common/network_util.h
+++ b/common/network_util.h
@@ -16,11 +16,20 @@
 
 #include <string>
 
+#include "folly/SocketAddress.h"
+
+
 namespace common {
 
 /*
  * Get the local IP address from eth0.
  */
 const std::string& getLocalIPAddress();
+
+/**
+ * Get a string representation if the provide address is IPv4 or IPv6,
+ * otherwise "unknown_addr" is returned.
+ */
+std::string getNetworkAddressStr(const folly::SocketAddress&) noexcept;
 
 }  // namespace common

--- a/common/network_util.h
+++ b/common/network_util.h
@@ -27,7 +27,7 @@ namespace common {
 const std::string& getLocalIPAddress();
 
 /**
- * Get a string representation if the provide address is IPv4 or IPv6,
+ * Get a string representation of the provide socket address if it is IPv4 or IPv6,
  * otherwise "unknown_addr" is returned.
  */
 std::string getNetworkAddressStr(const folly::SocketAddress&) noexcept;

--- a/common/tests/network_util_test.cpp
+++ b/common/tests/network_util_test.cpp
@@ -1,0 +1,25 @@
+#include "common/network_util.h"
+
+#include "gtest/gtest.h"
+#include "folly/SocketAddress.h"
+
+
+namespace common {
+
+TEST(NetworkUtilTest, GetNetworkAddressStr) {
+  folly::SocketAddress addr;
+  EXPECT_THROW(addr.setFromIpPort("bad-ip", 1234), std::runtime_error);
+  EXPECT_EQ(common::getNetworkAddressStr(addr), "unknown_addr");
+
+  addr.setFromIpPort("255.254.253.252", 8888);
+  EXPECT_EQ(common::getNetworkAddressStr(addr), "255.254.253.252");
+  addr.setFromIpPort("2620:0:1cfe:face:b00c::3:65535");
+  EXPECT_EQ(common::getNetworkAddressStr(addr), "2620:0:1cfe:face:b00c::3");
+}
+
+}  // namespace common
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/common/tests/network_util_test.cpp
+++ b/common/tests/network_util_test.cpp
@@ -8,6 +8,8 @@ namespace common {
 
 TEST(NetworkUtilTest, GetNetworkAddressStr) {
   folly::SocketAddress addr;
+  EXPECT_EQ(common::getNetworkAddressStr(addr), "unknown_addr");
+
   EXPECT_THROW(addr.setFromIpPort("bad-ip", 1234), std::runtime_error);
   EXPECT_EQ(common::getNetworkAddressStr(addr), "unknown_addr");
 

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -508,6 +508,10 @@ std::shared_ptr<ApplicationDB> AdminHandler::getDB(
 
   return db;
 }
+std::string AdminHandler::introspectDB() {
+  return db_manager_->introspect();
+}
+
 
 std::unique_ptr<rocksdb::DB> AdminHandler::removeDB(
     const std::string& db_name,

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -508,8 +508,8 @@ std::shared_ptr<ApplicationDB> AdminHandler::getDB(
 
   return db;
 }
-std::string AdminHandler::introspectDB() {
-  return db_manager_->introspect();
+std::string AdminHandler::IntrospectDB() const {
+  return db_manager_->Introspect();
 }
 
 

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -136,6 +136,8 @@ class AdminHandler : virtual public AdminSvIf {
   std::shared_ptr<ApplicationDB> getDB(const std::string& db_name,
                                        AdminException* ex);
 
+  std::string introspectDB();                                   
+
   // Dump stats for all DBs as a text string
   std::string DumpDBStatsAsText() const;
 

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -135,8 +135,8 @@ class AdminHandler : virtual public AdminSvIf {
 
   std::shared_ptr<ApplicationDB> getDB(const std::string& db_name,
                                        AdminException* ex);
-
-  std::string introspectDB();                                   
+  // Introspect the DB manager state
+  std::string IntrospectDB() const;                                   
 
   // Dump stats for all DBs as a text string
   std::string DumpDBStatsAsText() const;

--- a/rocksdb_admin/application_db.cpp
+++ b/rocksdb_admin/application_db.cpp
@@ -224,4 +224,9 @@ uint32_t ApplicationDB::getHighestEmptyLevel() {
   return *empty_levels.rbegin();
 }
 
+std::string ApplicationDB::introspect() {
+  // TODO: add other useful information
+  return replicated_db_->introspect();
+}
+
 }  // namespace admin

--- a/rocksdb_admin/application_db.cpp
+++ b/rocksdb_admin/application_db.cpp
@@ -224,9 +224,11 @@ uint32_t ApplicationDB::getHighestEmptyLevel() {
   return *empty_levels.rbegin();
 }
 
-std::string ApplicationDB::introspect() {
-  // TODO: add other useful information
-  return replicated_db_->introspect();
+std::string ApplicationDB::Introspect() {
+  if (replicated_db_) {
+    return replicated_db_->Introspect();
+  }
+  return "__no_replicated_db__";
 }
 
 }  // namespace admin

--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -126,7 +126,7 @@ class ApplicationDB {
     return upstream_addr_.get();
   }
 
-  std::string introspect();
+  std::string Introspect();
 
   ~ApplicationDB();
 

--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -126,6 +126,8 @@ class ApplicationDB {
     return upstream_addr_.get();
   }
 
+  std::string introspect();
+
   ~ApplicationDB();
 
  private:

--- a/rocksdb_admin/application_db_manager.cpp
+++ b/rocksdb_admin/application_db_manager.cpp
@@ -137,6 +137,17 @@ std::vector<std::string> ApplicationDBManager::getAllDBNames()  {
     return db_names;
 }
 
+std::string ApplicationDBManager::introspect() {
+  std::stringstream ss;
+  for (const auto& db : dbs_) {
+    // TODO: introspect each ApplicationDB
+    ss << db.first << ":" << std::endl;
+    ss << db.second->introspect() << std::endl;
+  }
+  ss << std::endl;
+  return ss.str();
+}
+
 ApplicationDBManager::~ApplicationDBManager() {
   auto itor = dbs_.begin();
   while (itor != dbs_.end()) {

--- a/rocksdb_admin/application_db_manager.cpp
+++ b/rocksdb_admin/application_db_manager.cpp
@@ -22,6 +22,7 @@
 
 #include "glog/logging.h"
 #include "common/segment_utils.h"
+#include "common/jsoncpp/include/json/json.h"
 
 namespace admin {
 
@@ -137,15 +138,17 @@ std::vector<std::string> ApplicationDBManager::getAllDBNames()  {
     return db_names;
 }
 
-std::string ApplicationDBManager::introspect() {
+std::string ApplicationDBManager::Introspect() const {
+  // TODO: consider json output
   std::stringstream ss;
+  ss << "ApplicationDBManager: " << std::endl;
+  std::shared_lock<std::shared_mutex> lock(dbs_lock_);
   for (const auto& db : dbs_) {
-    // TODO: introspect each ApplicationDB
     ss << db.first << ":" << std::endl;
-    ss << db.second->introspect() << std::endl;
+    ss << " " << db.second->Introspect() << std::endl;
   }
-  ss << std::endl;
   return ss.str();
+
 }
 
 ApplicationDBManager::~ApplicationDBManager() {

--- a/rocksdb_admin/application_db_manager.cpp
+++ b/rocksdb_admin/application_db_manager.cpp
@@ -22,7 +22,6 @@
 
 #include "glog/logging.h"
 #include "common/segment_utils.h"
-#include "common/jsoncpp/include/json/json.h"
 
 namespace admin {
 
@@ -139,16 +138,15 @@ std::vector<std::string> ApplicationDBManager::getAllDBNames()  {
 }
 
 std::string ApplicationDBManager::Introspect() const {
-  // TODO: consider json output
+  // TODO(jz): consider json output
   std::stringstream ss;
-  ss << "ApplicationDBManager: " << std::endl;
+  ss << "ApplicationDBManager:" << std::endl;
   std::shared_lock<std::shared_mutex> lock(dbs_lock_);
   for (const auto& db : dbs_) {
     ss << db.first << ":" << std::endl;
     ss << " " << db.second->Introspect() << std::endl;
   }
   return ss.str();
-
 }
 
 ApplicationDBManager::~ApplicationDBManager() {

--- a/rocksdb_admin/application_db_manager.h
+++ b/rocksdb_admin/application_db_manager.h
@@ -82,6 +82,9 @@ class ApplicationDBManager {
   // as compaction across all dbs currently maintained.
   std::vector<std::string> getAllDBNames();
 
+  // Introspect internal states
+  std::string introspect();
+
   ~ApplicationDBManager();
 
  private:

--- a/rocksdb_admin/application_db_manager.h
+++ b/rocksdb_admin/application_db_manager.h
@@ -83,7 +83,7 @@ class ApplicationDBManager {
   std::vector<std::string> getAllDBNames();
 
   // Introspect internal states
-  std::string introspect();
+  std::string Introspect() const;
 
   ~ApplicationDBManager();
 

--- a/rocksdb_admin/application_db_manager.h
+++ b/rocksdb_admin/application_db_manager.h
@@ -82,7 +82,7 @@ class ApplicationDBManager {
   // as compaction across all dbs currently maintained.
   std::vector<std::string> getAllDBNames();
 
-  // Introspect internal states
+  // Introspect ApplicationDBManager internal states
   std::string Introspect() const;
 
   ~ApplicationDBManager();

--- a/rocksdb_admin/tests/application_db_manager_test.cpp
+++ b/rocksdb_admin/tests/application_db_manager_test.cpp
@@ -41,17 +41,20 @@ TEST(ApplicationDBManagerTest, Basics) {
   admin::ApplicationDBManager db_manager;
   std::string error_message;
   auto ret = db_manager.addDB("test_db", std::move(test_db),
-    replicator::DBRole::SLAVE, &error_message);
+    replicator::DBRole::MASTER, &error_message);
   ASSERT_TRUE(ret);
 
   ret = db_manager.addDB("test_db", std::move(test_db),
-    replicator::DBRole::SLAVE, &error_message);
+    replicator::DBRole::MASTER, &error_message);
   ASSERT_FALSE(ret);
 
   {
     auto ret_db = db_manager.getDB("test_db", &error_message);
     EXPECT_NE(ret_db, nullptr);
   }
+
+  const char * test_db_state =  "ApplicationDBManager: \ntest_db:\n ReplicatedDB: \n  name: test_db\n  DBRole: MASTER\n  upstream_addr: unknown_addr\n  cur_seq_no: 0\n\n";
+  EXPECT_EQ(db_manager.Introspect(), std::string(test_db_state));
 
   auto ret_rocksdb = db_manager.removeDB("test_db", &error_message);
   EXPECT_NE(ret_rocksdb, nullptr);
@@ -63,6 +66,9 @@ TEST(ApplicationDBManagerTest, Basics) {
   ret = db_manager.addDB("test_db1", std::move(test_db1),
     replicator::DBRole::SLAVE, &error_message);
   ASSERT_TRUE(ret);
+
+  const char* test_db1_state = "ApplicationDBManager: \ntest_db1:\n __no_replicated_db__\n";
+  EXPECT_EQ(db_manager.Introspect(), std::string(test_db1_state));
 }
 
 int main(int argc, char** argv) {

--- a/rocksdb_admin/tests/application_db_manager_test.cpp
+++ b/rocksdb_admin/tests/application_db_manager_test.cpp
@@ -53,7 +53,14 @@ TEST(ApplicationDBManagerTest, Basics) {
     EXPECT_NE(ret_db, nullptr);
   }
 
-  const char * test_db_state =  "ApplicationDBManager: \ntest_db:\n ReplicatedDB: \n  name: test_db\n  DBRole: MASTER\n  upstream_addr: unknown_addr\n  cur_seq_no: 0\n\n";
+  const char* test_db_state = 
+"ApplicationDBManager:\n\
+test_db:\n\
+ ReplicatedDB:\n\
+  name: test_db\n\
+  DBRole: MASTER\n\
+  upstream_addr: unknown_addr\n\
+  cur_seq_no: 0\n\n";
   EXPECT_EQ(db_manager.Introspect(), std::string(test_db_state));
 
   auto ret_rocksdb = db_manager.removeDB("test_db", &error_message);
@@ -67,7 +74,10 @@ TEST(ApplicationDBManagerTest, Basics) {
     replicator::DBRole::SLAVE, &error_message);
   ASSERT_TRUE(ret);
 
-  const char* test_db1_state = "ApplicationDBManager: \ntest_db1:\n __no_replicated_db__\n";
+  const char* test_db1_state = 
+"ApplicationDBManager:\n\
+test_db1:\n\
+ __no_replicated_db__\n";
   EXPECT_EQ(db_manager.Introspect(), std::string(test_db1_state));
 }
 

--- a/rocksdb_admin/tests/application_db_manager_test.cpp
+++ b/rocksdb_admin/tests/application_db_manager_test.cpp
@@ -58,7 +58,7 @@ TEST(ApplicationDBManagerTest, Basics) {
 test_db:\n\
  ReplicatedDB:\n\
   name: test_db\n\
-  DBRole: MASTER\n\
+  DBRole: LEADER\n\
   upstream_addr: unknown_addr\n\
   cur_seq_no: 0\n\n";
   EXPECT_EQ(db_manager.Introspect(), std::string(test_db_state));

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -144,6 +144,19 @@ rocksdb::Status RocksDBReplicator::ReplicatedDB::Write(
   return status;
 }
 
+std::string RocksDBReplicator::ReplicatedDB::introspect() {
+  std::string role_string = "SLAVE";
+  if (role_ == DBRole::MASTER) {
+    role_string = "MASTER";
+  }
+  std::stringstream ss;
+  ss << " ReplicatedDB: " << std::endl;
+  ss << "   name: " << db_name_ << std::endl;
+  ss << "   DBRole: " << role_string << std::endl;
+  ss << "   upstream_addr_" << upstream_addr_.getAddressStr() << std::endl;
+  return ss.str();
+}
+
 
 RocksDBReplicator::ReplicatedDB::ReplicatedDB(
     const std::string& db_name,

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -149,9 +149,9 @@ std::string RocksDBReplicator::ReplicatedDB::Introspect() {
   // TODO(jz): extract a common function for DBRole -> string
   std::string role_string = "__unknown_role__";
   if (role_ == DBRole::MASTER) {
-    role_string = "MASTER";
+    role_string = "LEADER";
   } else if (role_ == DBRole::SLAVE) {
-    role_string = "SLAVE";
+    role_string = "FOLLOWER";
   }
   auto upstream_addr_str = common::getNetworkAddressStr(upstream_addr_);
   auto cur_seq_no = db_wrapper_->LatestSequenceNumber();

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -105,7 +105,6 @@ class RocksDBReplicator {
     // delegating to the internal rocksdb::DB object.
 
 
-
     // Introspect the internal replication state
     std::string Introspect();
 
@@ -147,7 +146,6 @@ class RocksDBReplicator {
                 uint64_t>> cached_iters_;
     std::mutex cached_iters_mutex_;
     detail::MaxNumberBox max_seq_no_acked_;
-    std::atomic<uint64_t> cur_seq_no_{0};
     std::shared_ptr<replicator::DbWrapper> db_wrapper_;
     std::string replicator_zk_cluster_;
     std::string replicator_helix_cluster_;
@@ -214,7 +212,6 @@ class RocksDBReplicator {
                    const rocksdb::WriteOptions& options,
                    rocksdb::WriteBatch* updates,
                    rocksdb::SequenceNumber* seq_no = nullptr);
-
 
   // no copy or move
   RocksDBReplicator(const RocksDBReplicator&) = delete;

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -104,6 +104,10 @@ class RocksDBReplicator {
     // read APIs may be added later on demand. They can be simply implmented by
     // delegating to the internal rocksdb::DB object.
 
+
+
+    std::string introspect();
+
    private:
     ReplicatedDB(const std::string& db_name,
                  std::shared_ptr<DbWrapper> db_wrapper,
@@ -208,6 +212,7 @@ class RocksDBReplicator {
                    const rocksdb::WriteOptions& options,
                    rocksdb::WriteBatch* updates,
                    rocksdb::SequenceNumber* seq_no = nullptr);
+
 
   // no copy or move
   RocksDBReplicator(const RocksDBReplicator&) = delete;

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -106,7 +106,8 @@ class RocksDBReplicator {
 
 
 
-    std::string introspect();
+    // Introspect the internal replication state
+    std::string Introspect();
 
    private:
     ReplicatedDB(const std::string& db_name,
@@ -146,6 +147,7 @@ class RocksDBReplicator {
                 uint64_t>> cached_iters_;
     std::mutex cached_iters_mutex_;
     detail::MaxNumberBox max_seq_no_acked_;
+    std::atomic<uint64_t> cur_seq_no_{0};
     std::shared_ptr<replicator::DbWrapper> db_wrapper_;
     std::string replicator_zk_cluster_;
     std::string replicator_helix_cluster_;

--- a/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
+++ b/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
@@ -99,8 +99,18 @@ TEST(RocksDBReplicatorTest, Basics) {
   EXPECT_EQ(replicator->write("master", options, &updates),
             ReturnCode::DB_NOT_FOUND);
 
-  const char *expected_master_state = "ReplicatedDB: \n  name: master\n  DBRole: MASTER\n  upstream_addr: unknown_addr\n  cur_seq_no: 2\n";
-  const char *expected_slave_state = "ReplicatedDB: \n  name: slave\n  DBRole: SLAVE\n  upstream_addr: 127.0.0.1\n  cur_seq_no: 0\n";
+  const char* expected_master_state =
+"ReplicatedDB:\n\
+  name: master\n\
+  DBRole: MASTER\n\
+  upstream_addr: unknown_addr\n\
+  cur_seq_no: 2\n";
+  const char* expected_slave_state =
+"ReplicatedDB:\n\
+  name: slave\n\
+  DBRole: SLAVE\n\
+  upstream_addr: 127.0.0.1\n\
+  cur_seq_no: 0\n";
   EXPECT_EQ(replicated_db_master->Introspect(), std::string(expected_master_state));
   EXPECT_EQ(replicated_db_slave->Introspect(), std::string(expected_slave_state));
 }

--- a/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
+++ b/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
@@ -102,13 +102,13 @@ TEST(RocksDBReplicatorTest, Basics) {
   const char* expected_master_state =
 "ReplicatedDB:\n\
   name: master\n\
-  DBRole: MASTER\n\
+  DBRole: LEADER\n\
   upstream_addr: unknown_addr\n\
   cur_seq_no: 2\n";
   const char* expected_slave_state =
 "ReplicatedDB:\n\
   name: slave\n\
-  DBRole: SLAVE\n\
+  DBRole: FOLLOWER\n\
   upstream_addr: 127.0.0.1\n\
   cur_seq_no: 0\n";
   EXPECT_EQ(replicated_db_master->Introspect(), std::string(expected_master_state));

--- a/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
+++ b/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
@@ -98,6 +98,11 @@ TEST(RocksDBReplicatorTest, Basics) {
             ReturnCode::DB_NOT_FOUND);
   EXPECT_EQ(replicator->write("master", options, &updates),
             ReturnCode::DB_NOT_FOUND);
+
+  const char *expected_master_state = "ReplicatedDB: \n  name: master\n  DBRole: MASTER\n  upstream_addr: unknown_addr\n  cur_seq_no: 2\n";
+  const char *expected_slave_state = "ReplicatedDB: \n  name: slave\n  DBRole: SLAVE\n  upstream_addr: 127.0.0.1\n  cur_seq_no: 0\n";
+  EXPECT_EQ(replicated_db_master->Introspect(), std::string(expected_master_state));
+  EXPECT_EQ(replicated_db_slave->Introspect(), std::string(expected_slave_state));
 }
 
 struct Host {


### PR DESCRIPTION
Initial PR to support introspection into RocksDB replication states (e.g. DBRole, upstream_address, sequence number, etc), and expose it all the way to `AdminHandler::IntrospectDB` so application can easily hook this up, and render an admin page that shows the replication state for all local shards.

E.g. tested via a private build, and see this:
```
ApplicationDBManager:
audience_targeting-_-visitor_v2_DEV00740:
 ReplicatedDB:
  name: audience_targeting-_-visitor_v2_DEV00740
  DBRole: MASTER
  upstream_addr: unknown_addr
  cur_seq_no: 21368

audience_targeting-_-visitor_v2_DEV00396:
 ReplicatedDB:
  name: audience_targeting-_-visitor_v2_DEV00396
  DBRole: MASTER
  upstream_addr: unknown_addr
  cur_seq_no: 21061

online_migration_e2e_test-_-f200067:
 ReplicatedDB:
  name: online_migration_e2e_test-_-f200067
  DBRole: MASTER
  upstream_addr: unknown_addr
  cur_seq_no: 0

audience_targeting-_-visitor_v2_DEV00076:
 ReplicatedDB:
  name: audience_targeting-_-visitor_v2_DEV00076
  DBRole: SLAVE
  upstream_addr: 10.3.42.199
  cur_seq_no: 20715
``` 

