### PR TITLE
rocksdb_replicator: emit a metrics on number of updates in replication response

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -438,6 +438,7 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
             // post the largest sequence number we have written to the Slave.
             db->max_seq_no_acked_.post(next_seq_no - 1);
           }
+          logMetric(kReplicatorOutNumUpdates, response.updates.size(), db->db_name_);
           incCounter(kReplicatorOutBytes, read_bytes, db->db_name_);
         } else {
           LOG(ERROR) << "Failed to pull updates from " << db->db_name_

--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -29,6 +29,7 @@ namespace replicator {
 
 const std::string kReplicatorLatency = "replicator_latency_ms";
 const std::string kReplicatorOutBytes = "replicator_out_bytes";
+const std::string kReplicatorOutNumUpdates = "replicator_out_num_updates";
 const std::string kReplicatorInBytes = "replicator_in_bytes";
 const std::string kReplicatorWriteBytes = "replicator_write_bytes";
 

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -24,6 +24,7 @@ namespace replicator {
 
 extern const std::string kReplicatorLatency;
 extern const std::string kReplicatorOutBytes;
+extern const std::string kReplicatorOutNumUpdates;
 extern const std::string kReplicatorInBytes;
 extern const std::string kReplicatorWriteBytes;
 


### PR DESCRIPTION
This gives us some visibility on how many updates are returned in the replication response (from leader to follower).

Tested via a private build