### PR TITLE
rocksdb_replicator: emit a metrics on handling resplication response failure

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -310,6 +310,7 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
             auto byteRange = update.raw_data.coalesce();
             write_bytes += byteRange.size();
             if (!db->db_wrapper_->HandleReplicateResponse(&update)) {
+              incCounter(kReplicatorPullRequestsFailure, 1, db->db_name_);
               delay_next_pull = true;
               break;
             }

--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -61,6 +61,7 @@ const std::string kReplicatorPullRequests = "replicator_pull_requests";
 const std::string kReplicatorPullRequestsSuccess = "replicator_pull_requests_success";
 const std::string kReplicatorPullRequestsFailure = "replicator_pull_requests_failure";
 const std::string kReplicatorPullLatency = "replicator_pull_latency";
+const std::string kReplicatorHandleResponseFailure = "replicator_handle_response_failure";
 
 void logMetric(const std::string& metric_name, int64_t value,
                const std::string& db_name) {

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -49,6 +49,7 @@ extern const std::string kReplicatorPullRequests;
 extern const std::string kReplicatorPullRequestsSuccess;
 extern const std::string kReplicatorPullRequestsFailure;
 extern const std::string kReplicatorPullLatency;
+extern const std::string kReplicatorHandleResponseFailure;
 
 // add value to metric_name. If db_name is not empty, add value to the per db
 // metric also


### PR DESCRIPTION
This is so we have better visibility on replication response failures