### PR TITLE
rocksdb_replicator: emit metrics on reply updates latency

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -386,6 +386,8 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
           return;
         }
 
+        auto start_ts = GetCurrentTimeMs();
+
         const auto expected_seq_no = (*request)->seq_no + 1;
         rocksdb::SequenceNumber next_seq_no = expected_seq_no;
         auto iter = db->getCachedIter(expected_seq_no);
@@ -440,6 +442,9 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
           }
           logMetric(kReplicatorOutNumUpdates, response.updates.size(), db->db_name_);
           incCounter(kReplicatorOutBytes, read_bytes, db->db_name_);
+
+          auto end_success_ts = GetCurrentTimeMs();
+          logMetric(kReplicatorReplyUpdatesSuccessLatency, start_ts < end_success_ts ? end_success_ts - start_ts : 0, db->db_name_);
         } else {
           LOG(ERROR) << "Failed to pull updates from " << db->db_name_
                      << " with error: " << status.ToString();
@@ -448,6 +453,9 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
           e.msg = status.ToString();
           e.code = ErrorCode::SOURCE_READ_ERROR;
           (*callback).release()->exceptionInThread(std::move(e));
+
+          auto end_failure_ts = GetCurrentTimeMs();
+          logMetric(kReplicatorReplyUpdatesFailureLatency, start_ts < end_failure_ts ? end_failure_ts - start_ts : 0, db->db_name_);
         }
 
         if (iter) {

--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -45,6 +45,10 @@ const std::string kReplicatorGetUpdatesSinceErrors =
   "replicator_get_update_since_errors";
 const std::string kReplicatorGetUpdatesSinceMs =
   "replicator_get_update_since_ms";
+const std::string kReplicatorReplyUpdatesSuccessLatency =
+  "replicator_reply_updates_success_latency";
+const std::string kReplicatorReplyUpdatesFailureLatency =
+  "replicator_reply_updates_failure_latency";
 
 const std::string kReplicatorWriteSuccess =
   "replicator_write_success";

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -34,6 +34,8 @@ extern const std::string kReplicatorRemoteApplicationExceptionsNotFound;
 
 extern const std::string kReplicatorGetUpdatesSinceErrors;
 extern const std::string kReplicatorGetUpdatesSinceMs;
+extern const std::string kReplicatorReplyUpdatesSuccessLatency;
+extern const std::string kReplicatorReplyUpdatesFailureLatency;
 
 extern const std::string kReplicatorLeaderSequenceNumbersBehind;
 extern const std::string kReplicatorLeaderReset;


### PR DESCRIPTION
this is so we have visibility on how long the leader takes to process the replication request, once it has new updates available  for follower. 