### PR TITLE
rocksdb_replicator: fix counter name kReplicatorHandleResponseFailure

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -310,7 +310,7 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
             auto byteRange = update.raw_data.coalesce();
             write_bytes += byteRange.size();
             if (!db->db_wrapper_->HandleReplicateResponse(&update)) {
-              incCounter(kReplicatorPullRequestsFailure, 1, db->db_name_);
+              incCounter(kReplicatorHandleResponseFailure, 1, db->db_name_);
               delay_next_pull = true;
               break;
             }


### PR DESCRIPTION
https://github.com/pinterest/rocksplicator/pull/583 has a copy-pasta typo, fixing it to use the correct counter