### PR TITLE
rocksdb_replicator: fixing a confusing exception message

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -277,8 +277,8 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
             t.exception().throwException();
 #endif
           } catch (const ReplicateException& ex) {
-            LOG(ERROR) << "ReplicateException: (upstream): " << db->upstream_addr_.getAddressStr() << " " << static_cast<int>(ex.code)
-                       << " " << ex.msg;
+            LOG(ERROR) << "ReplicateException: upstream = " << db->upstream_addr_.getAddressStr() << ", code = " << static_cast<int>(ex.code)
+                       << ", message = " << ex.msg;
             incCounter(kReplicatorRemoteApplicationExceptions, 1, db->db_name_);
             
             if (ex.code == ErrorCode::SOURCE_NOT_FOUND) {


### PR DESCRIPTION
Saw this in prod and I got confused:
```
replicated_db.cpp:280] ReplicateException: (upstream): 10.1.213.2 1 audience_targeting-_-engagement_v2_DEV00155 has been removed
```
With this change, it'll be
```
replicated_db.cpp:280] ReplicateException: upstream = 10.1.213.2, code = 1, message = audience_targeting-_-engagement_v2_DEV00155 has been removed
``` 