### PR TITLE
rocksdb_replicator: reject replicate request when not leader

### DIFF
--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -38,6 +38,8 @@ const std::string kReplicatorRemoteApplicationExceptions =
   "replicator_remote_app_exceptions";
 const std::string kReplicatorRemoteApplicationExceptionsNotFound =
   "replicator_remote_app_exceptions_source_not_found";
+const std::string kReplicatorRemoteApplicationExceptionsNotLeader=
+  "replicator_remote_app_exceptions_not_leader";
 const std::string kReplicatorLeaderReset =
   "replicator_remote_app_leader_reset";
 

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -31,6 +31,7 @@ extern const std::string kReplicatorWriteBytes;
 extern const std::string kReplicatorConnectionErrors;
 extern const std::string kReplicatorRemoteApplicationExceptions;
 extern const std::string kReplicatorRemoteApplicationExceptionsNotFound;
+extern const std::string kReplicatorRemoteApplicationExceptionsNotLeader;
 
 extern const std::string kReplicatorGetUpdatesSinceErrors;
 extern const std::string kReplicatorGetUpdatesSinceMs;

--- a/rocksdb_replicator/thrift/replicator.thrift
+++ b/rocksdb_replicator/thrift/replicator.thrift
@@ -67,6 +67,7 @@ enum ErrorCode {
   # helix, and there is no harm if the upstream fails to distinguish between
   # SOURCE_REMOVED and SOURCE_NOT_FOUND
   SOURCE_REMOVED = 3,
+  NOT_LEADER = 4 # A non-leader replica received the replicate request
 }
 
 exception ReplicateException {


### PR DESCRIPTION
Observed in production that we may have followers not receiving updates because it has the wrong leader/upstream address  set. See the following real production example (see https://jira.pinadmin.com/browse/KV-5289 for details):

We have 3 hosts for a shard: hostA, hostB, hostC. 

Helix view:
- hostA: leader
- hostB: follower
- hostC: follower

However, each individual replica thinks differently:
- hostA: leader is itself
- hostB: leader is hostC
- hostC: leader is hostB

As a result, updates are still sent to hostA correctly as the true leader. However, those updates are never replicated to hostB or hostC, because they treat each other as leader, and send replication requests to each other (no-op because they have the same replication sequence number). This is very bad as the followers gets stuck forever (causing inconsistency read, and write timeout when 2-ack mode is on)

A follower only `resetUpstream` when the replication request returns with certain exceptions. 

Therefore, this PR proposes a simple fix: return an exception `NOT_LEADER` for the replication request if the receiving replica is NOT leader. 

For safer rollout/rollback, add a GFLAG to control this behavior. 
Also adding metrics to catch this edge case when it happens. 

