### PR TITLE
cluster_management: log dates in helix participant

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Participant.java
@@ -220,7 +220,7 @@ public class Participant {
   public static void main(String[] args) throws Exception {
     org.apache.log4j.Logger.getRootLogger().setLevel(Level.WARN);
     BasicConfigurator.configure(new ConsoleAppender(
-        new PatternLayout("%d{HH:mm:ss.SSS} [%t] %-5p %30.30c - %m%n")
+        new PatternLayout("%d{dd MMM yyyy HH:mm:ss.SSS} [%t] %-5p %30.30c - %m%n")
     ));
     CommandLine cmd = processCommandLineArgs(args);
     final String zkConnectString = cmd.getOptionValue(zkServer);


### PR DESCRIPTION
We are currently only logging the timestamp in hour:minute:second
```
23:09:29.824 [Thread-2] ERROR .pinterest.rocksplicator.Utils - Local seq number: 194251020
```
We need dates to tell when a log is generated. Making the change based on the docs here: https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html
> The date conversion specifier may be followed by a date format specifier enclosed between braces. For example, %d{HH:mm:ss,SSS} or %d{dd MMM yyyy HH:mm:ss,SSS}

Tested via a private build:
```
2022-03-04 01:30:01,448 [main] (Participant.java:289) ERROR Participant running
```

One this goes well, will do the same change for all other java components we have