### PR TITLE
cluster_management: log dbName upon get sequence number failure

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -258,7 +258,7 @@ public class Utils {
           "Seq number for " + dbName + " on " + host + ": " + String.valueOf(response.seq_num));
       return response.seq_num;
     } catch (TException e) {
-      LOG.error("Failed to get sequence number", e);
+      LOG.error("Failed to get sequence number for " + dbName, e);
       return -1;
     }
   }


### PR DESCRIPTION
The helps to narrow down which shard/db failed to obtain sequence number (from another replica/leader)