### PR TITLE
rocksdb_replicator: reset upstream when fetching from a non-leader that has no updates

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -226,6 +226,7 @@ RocksDBReplicator::ReplicatedDB::ReplicatedDB(
  * Helper function to reset the upstream IP after querying for latest leader from helix.
  */
 void RocksDBReplicator::ReplicatedDB::resetUpstream() {
+  resetUpstreamAttempts_++;
   if (replicator_zk_cluster_.empty() || replicator_helix_cluster_.empty()) {
     LOG(ERROR) << "[resetUpstream] ZK cluster or helix cluster name not provided.";
     return;

--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -64,8 +64,10 @@ const std::string kReplicatorLeaderSequenceNumbersBehind = "replicator_leader_se
 const std::string kReplicatorPullRequests = "replicator_pull_requests";
 const std::string kReplicatorPullRequestsSuccess = "replicator_pull_requests_success";
 const std::string kReplicatorPullRequestsFailure = "replicator_pull_requests_failure";
+const std::string kReplicatorPullRequestsNoUpdates = "replicator_pull_requests_no_updates";
 const std::string kReplicatorPullLatency = "replicator_pull_latency";
 const std::string kReplicatorHandleResponseFailure = "replicator_handle_response_failure";
+const std::string kReplicatorResetUpstreamOnNoUpdates = "replicator_reset_upstream_on_no_updates";
 
 void logMetric(const std::string& metric_name, int64_t value,
                const std::string& db_name) {

--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -67,7 +67,7 @@ const std::string kReplicatorPullRequestsFailure = "replicator_pull_requests_fai
 const std::string kReplicatorPullRequestsNoUpdates = "replicator_pull_requests_no_updates";
 const std::string kReplicatorPullLatency = "replicator_pull_latency";
 const std::string kReplicatorHandleResponseFailure = "replicator_handle_response_failure";
-const std::string kReplicatorResetUpstreamOnNoUpdates = "replicator_reset_upstream_on_no_updates";
+const std::string kReplicatorResetUpstreamOnNoUpdates = "replicator_reset_upstream_on_no_updates_attempted";
 
 void logMetric(const std::string& metric_name, int64_t value,
                const std::string& db_name) {

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -50,8 +50,10 @@ extern const std::string kReplicatorWriteFailureResponseTime;
 extern const std::string kReplicatorPullRequests;
 extern const std::string kReplicatorPullRequestsSuccess;
 extern const std::string kReplicatorPullRequestsFailure;
+extern const std::string kReplicatorPullRequestsNoUpdates;
 extern const std::string kReplicatorPullLatency;
 extern const std::string kReplicatorHandleResponseFailure;
+extern const std::string kReplicatorResetUpstreamOnNoUpdates;
 
 // add value to metric_name. If db_name is not empty, add value to the per db
 // metric also

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -132,6 +132,7 @@ class RocksDBReplicator {
     const ReplicaRole role_;
     folly::SocketAddress upstream_addr_;
     uint32_t pullFromUpstreamNoUpdates_ {0};
+    uint32_t resetUpstreamAttempts_ {0}; // currently only used for unit tests
     common::ThriftClientPool<ReplicatorAsyncClient>* const client_pool_;
     std::shared_ptr<ReplicatorAsyncClient> client_;
     detail::NonBlockingConditionVariable cond_var_;

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -131,6 +131,7 @@ class RocksDBReplicator {
     folly::Executor* const executor_;
     const ReplicaRole role_;
     folly::SocketAddress upstream_addr_;
+    uint32_t pullFromUpstreamNoUpdates_ {0};
     common::ThriftClientPool<ReplicatorAsyncClient>* const client_pool_;
     std::shared_ptr<ReplicatorAsyncClient> client_;
     detail::NonBlockingConditionVariable cond_var_;

--- a/rocksdb_replicator/tests/CMakeLists.txt
+++ b/rocksdb_replicator/tests/CMakeLists.txt
@@ -20,3 +20,7 @@ add_executable(max_number_box_test max_number_box_test.cpp)
 target_link_libraries(max_number_box_test rocksdb_replicator gtest)
 add_test(NAME max_number_box_test COMMAND max_number_box_test)
 
+add_executable(replicator_utils_test utils_test.cpp)
+target_link_libraries(replicator_utils_test rocksdb_replicator gtest)
+add_test(NAME replicator_utils_test COMMAND replicator_utils_test)
+

--- a/rocksdb_replicator/tests/CMakeLists.txt
+++ b/rocksdb_replicator/tests/CMakeLists.txt
@@ -19,8 +19,3 @@ add_test(NAME rocksdb_assumption_test COMMAND rocksdb_assumption_test)
 add_executable(max_number_box_test max_number_box_test.cpp)
 target_link_libraries(max_number_box_test rocksdb_replicator gtest)
 add_test(NAME max_number_box_test COMMAND max_number_box_test)
-
-add_executable(replicator_utils_test utils_test.cpp)
-target_link_libraries(replicator_utils_test rocksdb_replicator gtest)
-add_test(NAME replicator_utils_test COMMAND replicator_utils_test)
-

--- a/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
+++ b/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
@@ -25,10 +25,12 @@
 // private
 #define private public
 #include "rocksdb_replicator/rocksdb_replicator.h"
+#include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
 
 using folly::SocketAddress;
 using replicator::ReplicaRole;
 using replicator::ReturnCode;
+using replicator::ReplicaRole;
 using replicator::RocksDBReplicator;
 using rocksdb::DB;
 using rocksdb::Options;
@@ -113,6 +115,12 @@ TEST(RocksDBReplicatorTest, Basics) {
   cur_seq_no: 0\n";
   EXPECT_EQ(replicated_db_master->Introspect(), std::string(expected_master_state));
   EXPECT_EQ(replicated_db_slave->Introspect(), std::string(expected_slave_state));
+
+  EXPECT_EQ(ReplicaRole::LEADER, replicated_db_master->role_thrift_);
+  EXPECT_EQ(ReplicaRole::FOLLOWER, replicated_db_slave->role_thrift_);
+
+  EXPECT_EQ(0, replicated_db_master->pullFromUpstreamNoUpdates_);
+  EXPECT_EQ(0, replicated_db_slave->pullFromUpstreamNoUpdates_);
 }
 
 struct Host {

--- a/rocksdb_replicator/thrift/replicator.thrift
+++ b/rocksdb_replicator/thrift/replicator.thrift
@@ -63,6 +63,8 @@ struct ReplicateResponse {
   # updates is an ordered continuous range of updates starting from the seq_no
   # specified in ReplicateRequest.
   1: required list<Update> updates,
+  // role is the replica role of the upstream that provides the updates.
+  2: optional ReplicaRole role;
 }
 
 enum ErrorCode {


### PR DESCRIPTION
We see in production where writes can timeout after 2-ack mode is enabled, which usually is caused by followers talking to the wrong upstream (typically a follower), hence never ACKing the write. See this internal [doc](https://docs.google.com/document/d/1xMX3Vkf3fne-usSowSaW9L2deKDDuMEGHLg1IXkxNTo/edit#heading=h.pik5pkd0ubqe) for detailed investigation and plans on fixing those issues. 

This PR serves as the initial step to mitigate the issue: trigger a upstream reset when both of the two conditions below are met:
- no updates from upstream, for a consecutive number of times (controlled by a GFLAG, in case it's transient)
- upstream informs the follower that the upstream is NOT a leader (avoids unnecessary reset when there is no traffic). We introduced the `ReplicaRole` in https://github.com/pinterest/rocksplicator/pull/592

This new behavior is disabled by default (via a GFLAG `reset_upstream_on_empty_updates_from_non_leader`) for a safe rollout, but can be reversed once this feature goes out well in production.

Added unit tests for the two edge cases we see in prod (followers setting each other as upstream; and follower setting itself as upstream).