### PR TITLE
Define ReplicaRole in thrift and replace DBRole

### DIFF
--- a/cdc_admin/cdc_admin_handler.cpp
+++ b/cdc_admin/cdc_admin_handler.cpp
@@ -20,6 +20,7 @@
 
 #include "rocksdb_replicator/test_db_proxy.h"
 #include "thrift/lib/cpp2/protocol/Serializer.h"
+#include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
 
 DEFINE_string(rocksdb_dir, "/tmp/", "The dir for local rocksdb instances");
 
@@ -115,7 +116,7 @@ void CDCAdminHandler::async_tm_addObserver(
 
   // add the db to db_manager
   std::string err_msg;
-  replicator::DBRole role = replicator::DBRole::SLAVE;
+  replicator::ReplicaRole role = replicator::ReplicaRole::FOLLOWER;
   const std::string replicator_zk_cluster =
       request->__isset.replicator_zk_cluster ? request->replicator_zk_cluster : std::string("");
   const std::string replicator_helix_cluster = request->__isset.replicator_helix_cluster

--- a/cdc_admin/cdc_application_db.cpp
+++ b/cdc_admin/cdc_application_db.cpp
@@ -18,7 +18,7 @@ namespace cdc_admin {
 
 CDCApplicationDB::CDCApplicationDB(const std::string& db_name,
                                    std::shared_ptr<replicator::DbWrapper> db_wrapper,
-                                   replicator::DBRole role,
+                                   replicator::ReplicaRole role,
                                    std::unique_ptr<folly::SocketAddress> upstream_addr,
                                    const std::string& replicator_zk_cluster,
                                    const std::string& replicator_helix_cluster)
@@ -26,7 +26,7 @@ CDCApplicationDB::CDCApplicationDB(const std::string& db_name,
       db_(std::move(db_wrapper)),
       upstream_addr_(std::move(upstream_addr)),
       replicated_db_(nullptr) {
-  if (role == replicator::DBRole::SLAVE) {
+  if (role == replicator::ReplicaRole::FOLLOWER) {
     CHECK(upstream_addr_);
     auto ret = replicator::RocksDBReplicator::instance()->addDB(
         db_name_,

--- a/cdc_admin/cdc_application_db.h
+++ b/cdc_admin/cdc_application_db.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "cdc_admin/cdc_application_db_manager.h"
+#include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
 
 namespace cdc_admin {
 
@@ -29,7 +30,7 @@ public:
   // with the API upstream_addr: (IN) upstream address if applicable
   CDCApplicationDB(const std::string& db_name,
                    std::shared_ptr<replicator::DbWrapper> db_wrapper,
-                   replicator::DBRole role,
+                   replicator::ReplicaRole role,
                    std::unique_ptr<folly::SocketAddress> upstream_addr,
                    const std::string& replicator_zk_cluster,
                    const std::string& replicator_helix_cluster);

--- a/cdc_admin/cdc_application_db_manager.h
+++ b/cdc_admin/cdc_application_db_manager.h
@@ -18,6 +18,7 @@
 
 #include "common/segment_utils.h"
 #include "rocksdb_admin/application_db.h"
+#include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
 
 namespace cdc_admin {
 
@@ -43,7 +44,7 @@ public:
   // Return true on success
   bool addDB(const std::string& db_name,
              std::unique_ptr<UnderlyingDBType> db,
-             replicator::DBRole role,
+             replicator::ReplicaRole role,
              std::unique_ptr<folly::SocketAddress> upstream_addr,
              const std::string& replicator_zk_cluster,
              const std::string& replicator_helix_cluster,

--- a/rocksdb_admin/application_db.cpp
+++ b/rocksdb_admin/application_db.cpp
@@ -52,7 +52,7 @@ const std::string ApplicationDB::Properties::kHighestEmptyLevel =
 ApplicationDB::ApplicationDB(
     const std::string& db_name,
     std::shared_ptr<rocksdb::DB> db,
-    replicator::DBRole role,
+    replicator::ReplicaRole role,
     std::unique_ptr<folly::SocketAddress> upstream_addr)
     : db_name_(db_name)
     , db_(std::move(db))
@@ -128,7 +128,7 @@ rocksdb::Status ApplicationDB::Write(const rocksdb::WriteOptions& options,
     return replicated_db_->Write(options, write_batch);
   } else {
     // ApplicationDBManager can be use to manage rocksdb instance lifecycle
-    // without replication. In this case, ApplicationDB has the replicator::DBRole
+    // without replication. In this case, ApplicationDB has the replicator::ReplicaRole
     // as SLAVE and no upstream_addr. Thus the replicated_db_ is nullptr, and
     // we'll write to the local db_
     return db_->Write(options, write_batch);

--- a/rocksdb_admin/application_db.h
+++ b/rocksdb_admin/application_db.h
@@ -21,6 +21,7 @@
 #include "rocksdb/options.h"
 #include "rocksdb/write_batch.h"
 #include "rocksdb_replicator/rocksdb_replicator.h"
+#include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
 
 namespace admin {
 
@@ -44,7 +45,7 @@ class ApplicationDB {
   // upstream_addr: (IN) upstream address if applicable
   ApplicationDB(const std::string& db_name,
                 std::shared_ptr<rocksdb::DB> db,
-                replicator::DBRole role,
+                replicator::ReplicaRole role,
                 std::unique_ptr<folly::SocketAddress> upstream_addr);
 
   // Create a rocksdb iterator based on the give options.
@@ -110,7 +111,7 @@ class ApplicationDB {
   bool DBLmaxEmpty();
 
   // Whether this db instance is slave
-  bool IsSlave() const { return role_ == replicator::DBRole::SLAVE; }
+  bool IsSlave() const { return role_ == replicator::ReplicaRole::FOLLOWER; }
 
   // Name of this db
   const std::string& db_name() const { return db_name_; }
@@ -137,7 +138,7 @@ class ApplicationDB {
   const std::string db_name_;
   std::shared_ptr<rocksdb::DB> db_;
 
-  const replicator::DBRole role_;
+  const replicator::ReplicaRole role_;
   std::unique_ptr<folly::SocketAddress> upstream_addr_;
   replicator::RocksDBReplicator::ReplicatedDB* replicated_db_;
 

--- a/rocksdb_admin/application_db_manager.cpp
+++ b/rocksdb_admin/application_db_manager.cpp
@@ -33,14 +33,14 @@ ApplicationDBManager::ApplicationDBManager()
 
 bool ApplicationDBManager::addDB(const std::string& db_name,
                                  std::unique_ptr<rocksdb::DB> db,
-                                 replicator::DBRole role,
+                                 replicator::ReplicaRole role,
                                  std::string* error_message) {
   return addDB(db_name, std::move(db), role, nullptr, error_message);
 }
 
 bool ApplicationDBManager::addDB(const std::string& db_name,
                                  std::unique_ptr<rocksdb::DB> db,
-                                 replicator::DBRole role,
+                                 replicator::ReplicaRole role,
                                  std::unique_ptr<folly::SocketAddress> up_addr,
                                  std::string* error_message) {
   std::unique_lock<std::shared_mutex> lock(dbs_lock_);

--- a/rocksdb_admin/application_db_manager.h
+++ b/rocksdb_admin/application_db_manager.h
@@ -21,6 +21,7 @@
 
 #include "rocksdb/db.h"
 #include "rocksdb_admin/application_db.h"
+#include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
 
 namespace admin {
 
@@ -40,7 +41,7 @@ class ApplicationDBManager {
   // Return true on success
   bool addDB(const std::string& db_name,
              std::unique_ptr<rocksdb::DB> db,
-             replicator::DBRole role,
+             replicator::ReplicaRole role,
              std::string* error_message);
 
   // Add a rocksdb instance into db manager.
@@ -53,7 +54,7 @@ class ApplicationDBManager {
   // Return true on success
   bool addDB(const std::string& db_name,
              std::unique_ptr<rocksdb::DB> db,
-             replicator::DBRole role,
+             replicator::ReplicaRole role,
              std::unique_ptr<folly::SocketAddress> upstream_addr,
              std::string* error_message);
 

--- a/rocksdb_admin/tests/application_db_manager_test.cpp
+++ b/rocksdb_admin/tests/application_db_manager_test.cpp
@@ -21,6 +21,7 @@
 #include "glog/logging.h"
 #include "gtest/gtest.h"
 #include "rocksdb/db.h"
+#include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
 
 std::unique_ptr<rocksdb::DB> GetTestDB(const std::string& dir) {
   EXPECT_EQ(std::system(("rm -rf " + dir).c_str()), 0);
@@ -41,11 +42,11 @@ TEST(ApplicationDBManagerTest, Basics) {
   admin::ApplicationDBManager db_manager;
   std::string error_message;
   auto ret = db_manager.addDB("test_db", std::move(test_db),
-    replicator::DBRole::MASTER, &error_message);
+    replicator::ReplicaRole::LEADER, &error_message);
   ASSERT_TRUE(ret);
 
   ret = db_manager.addDB("test_db", std::move(test_db),
-    replicator::DBRole::MASTER, &error_message);
+    replicator::ReplicaRole::LEADER, &error_message);
   ASSERT_FALSE(ret);
 
   {
@@ -58,7 +59,7 @@ TEST(ApplicationDBManagerTest, Basics) {
 test_db:\n\
  ReplicatedDB:\n\
   name: test_db\n\
-  DBRole: LEADER\n\
+  ReplicaRole: LEADER\n\
   upstream_addr: unknown_addr\n\
   cur_seq_no: 0\n\n";
   EXPECT_EQ(db_manager.Introspect(), std::string(test_db_state));
@@ -71,7 +72,7 @@ test_db:\n\
 
   auto test_db1 = GetTestDB("/tmp/application_db_manager_test_db1");
   ret = db_manager.addDB("test_db1", std::move(test_db1),
-    replicator::DBRole::SLAVE, &error_message);
+    replicator::ReplicaRole::FOLLOWER, &error_message);
   ASSERT_TRUE(ret);
 
   const char* test_db1_state = 

--- a/rocksdb_admin/tests/application_db_test.cpp
+++ b/rocksdb_admin/tests/application_db_test.cpp
@@ -34,6 +34,7 @@
 #undef private
 #include "rocksdb_admin/tests/test_util.h"
 #include "rocksdb_replicator/rocksdb_replicator.h"
+#include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
 
 DEFINE_bool(log_to_stdout, false,
             "Enable output some assisting logs to stdout");
@@ -105,7 +106,7 @@ class ApplicationDBTestBase : public testing::Test {
     ASSERT_TRUE(status.ok()) << status.ToString();
     ASSERT_TRUE(db != nullptr);
     db_ = make_unique<ApplicationDB>(db_name_, shared_ptr<DB>(db),
-                                     replicator::DBRole::SLAVE, nullptr);
+                                     replicator::ReplicaRole::FOLLOWER, nullptr);
   }
 
   void DestroyAndReopen(const Options& options) {

--- a/rocksdb_replicator/performance.cpp
+++ b/rocksdb_replicator/performance.cpp
@@ -32,11 +32,12 @@
 #include "rocksdb/filter_policy.h"
 #include "rocksdb/rate_limiter.h"
 #include "rocksdb/table.h"
+#include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
 
 
 using folly::SocketAddress;
 using common::Stats;
-using replicator::DBRole;
+using replicator::ReplicaRole;
 using replicator::ReturnCode;
 using replicator::RocksDBReplicator;
 using rocksdb::DB;
@@ -118,7 +119,7 @@ int main(int argc, char** argv) {
     auto db_name = "shard" + to_string(i);
     SocketAddress addr(FLAGS_upstream_ip, FLAGS_rocksdb_replicator_port);
     replicator->addDB(db_name, cleanAndOpenDB(FLAGS_db_path + db_name, options),
-                      FLAGS_is_master ? DBRole::MASTER : DBRole::SLAVE, addr,
+                      FLAGS_is_master ? ReplicaRole::LEADER : ReplicaRole::FOLLOWER, addr,
                       &db);
     dbs.push_back(db);
   }

--- a/rocksdb_replicator/rocksdb_replicator.cpp
+++ b/rocksdb_replicator/rocksdb_replicator.cpp
@@ -95,7 +95,7 @@ RocksDBReplicator::~RocksDBReplicator() {
 
 ReturnCode RocksDBReplicator::addDB(const std::string& db_name,
                                     std::shared_ptr<rocksdb::DB> db,
-                                    const DBRole role,
+                                    const ReplicaRole role,
                                     const folly::SocketAddress& upstream_addr,
                                     ReplicatedDB** replicated_db) {
   std::shared_ptr<DbWrapper> db_wrapper(
@@ -106,7 +106,7 @@ ReturnCode RocksDBReplicator::addDB(const std::string& db_name,
 
 ReturnCode RocksDBReplicator::addDB(const std::string& db_name,
                                     std::shared_ptr<DbWrapper> db_wrapper,
-                                    const DBRole role,
+                                    const ReplicaRole role,
                                     const folly::SocketAddress& upstream_addr,
                                     ReplicatedDB** replicated_db,
                                     const std::string& replicator_zk_cluster,
@@ -123,7 +123,7 @@ ReturnCode RocksDBReplicator::addDB(const std::string& db_name,
     *replicated_db = new_db.get();
   }
 
-  if (role == DBRole::SLAVE) {
+  if (role == ReplicaRole::FOLLOWER) {
     new_db->pullFromUpstream();
   }
 

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -66,12 +66,6 @@ struct LogExtractor : public rocksdb::WriteBatch::Handler {
   uint64_t ms;
 };
 
-enum class DBRole {
-  MASTER,
-  SLAVE,
-  NOOP, // Don't perform any replication with this DB
-};
-
 enum class ReturnCode {
   OK = 0,
   DB_NOT_FOUND = 1,
@@ -112,7 +106,7 @@ class RocksDBReplicator {
     ReplicatedDB(const std::string& db_name,
                  std::shared_ptr<DbWrapper> db_wrapper,
                  folly::Executor* executor,
-                 const DBRole role,
+                 const ReplicaRole role,
                  const folly::SocketAddress& upstream_addr
                  = folly::SocketAddress(),
                  common::ThriftClientPool<ReplicatorAsyncClient>* client_pool
@@ -135,7 +129,7 @@ class RocksDBReplicator {
     const std::string db_name_;
     std::shared_ptr<replicator::DbWrapper> db_wrapper_;
     folly::Executor* const executor_;
-    const DBRole role_;
+    const ReplicaRole role_;
     folly::SocketAddress upstream_addr_;
     common::ThriftClientPool<ReplicatorAsyncClient>* const client_pool_;
     std::shared_ptr<ReplicatorAsyncClient> client_;
@@ -172,7 +166,7 @@ class RocksDBReplicator {
    */
   ReturnCode addDB(const std::string& db_name,
                    std::shared_ptr<rocksdb::DB> db,
-                   const DBRole role,
+                   const ReplicaRole role,
                    const folly::SocketAddress& upstream_addr
                    = folly::SocketAddress(),
                    ReplicatedDB** replicated_db = nullptr);
@@ -182,7 +176,7 @@ class RocksDBReplicator {
    */
   ReturnCode addDB(const std::string& db_name,
                    std::shared_ptr<DbWrapper> db_wrapper,
-                   const DBRole role,
+                   const ReplicaRole role,
                    const folly::SocketAddress& upstream_addr
                    = folly::SocketAddress(),
                    ReplicatedDB** replicated_db = nullptr,

--- a/rocksdb_replicator/thrift/replicator.thrift
+++ b/rocksdb_replicator/thrift/replicator.thrift
@@ -53,6 +53,12 @@ struct Update {
   3: optional i64 seq_no,
 }
 
+enum ReplicaRole {
+  NOOP = 0, // no replication needed
+  FOLLOWER = 1,
+  LEADER = 2
+}
+
 struct ReplicateResponse {
   # updates is an ordered continuous range of updates starting from the seq_no
   # specified in ReplicateRequest.


### PR DESCRIPTION
We plan to include the replication role in the Replication RPC request/response for various purposes, therefore we define a new `ReplicaRole` thrift enum for these purposes. 

For consolidation purposes, we remove the existing `DBRole` cpp enum in `rocksdb_replicator.h`, and instead use the newly introduced `ReplicaRole` everywhere. 

No production logic change in this PR