### PR TITLE
replicated_db: add stats when pulling from non leader

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -330,6 +330,10 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
             }
           }
 
+          if (response.role != ReplicaRole::LEADER) {
+            incCounter(kReplicatorPullFromNonLeader, 1, db->db_name_);
+          }
+
           if (!response.updates.empty()) {
             db->pullFromUpstreamNoUpdates_ = 0;
             db->cond_var_.notifyAll();

--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -65,6 +65,7 @@ const std::string kReplicatorPullRequests = "replicator_pull_requests";
 const std::string kReplicatorPullRequestsSuccess = "replicator_pull_requests_success";
 const std::string kReplicatorPullRequestsFailure = "replicator_pull_requests_failure";
 const std::string kReplicatorPullRequestsNoUpdates = "replicator_pull_requests_no_updates";
+const std::string kReplicatorPullFromNonLeader = "replicator_pull_from_non_leader";
 const std::string kReplicatorPullLatency = "replicator_pull_latency";
 const std::string kReplicatorHandleResponseFailure = "replicator_handle_response_failure";
 const std::string kReplicatorResetUpstreamOnNoUpdates = "replicator_reset_upstream_on_no_updates_attempted";

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -51,6 +51,7 @@ extern const std::string kReplicatorPullRequests;
 extern const std::string kReplicatorPullRequestsSuccess;
 extern const std::string kReplicatorPullRequestsFailure;
 extern const std::string kReplicatorPullRequestsNoUpdates;
+extern const std::string kReplicatorPullFromNonLeader;
 extern const std::string kReplicatorPullLatency;
 extern const std::string kReplicatorHandleResponseFailure;
 extern const std::string kReplicatorResetUpstreamOnNoUpdates;

--- a/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
+++ b/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
@@ -361,7 +361,9 @@ TEST(RocksDBReplicatorTest, 1_master_2_slaves_chain) {
   EXPECT_EQ(db_slave_2->GetLatestSequenceNumber(), 2 * n_keys);
 }
 
-TEST(RocksDBReplicatorTest, 1_master_1_slave_upstream_itself) {
+// This tests the case when there is one leader and one follower for the shard,
+// and the follower sets itself as the upstream, which should trigger upstream reset.
+TEST(RocksDBReplicatorTest, 1_leader_1_follower_upstream_itself) {
   FLAGS_replicator_max_server_wait_time_ms = 100;
   FLAGS_replicator_client_server_timeout_difference_ms = 100;
   FLAGS_reset_upstream_on_empty_updates_from_non_leader = true;
@@ -417,7 +419,9 @@ TEST(RocksDBReplicatorTest, 1_master_1_slave_upstream_itself) {
   EXPECT_EQ(0, db_slave->GetLatestSequenceNumber());
 }
 
-TEST(RocksDBReplicatorTest, 1_master_2_slaves_stuck) {
+// This tests the case when there is one leader and two followers for the shard,
+// and the followers setting each other as the upstream, which should trigger upstream reset.
+TEST(RocksDBReplicatorTest, 1_leader_2_followers_deadlock) {
   int16_t master_port = 9097;
   int16_t slave_port_1 = 9098;
   int16_t slave_port_2 = 9099;


### PR DESCRIPTION
Forgot to push my local change to upstream for the most recent comments in https://github.com/pinterest/rocksplicator/pull/591. So creating a make-up PR for this. 

Notably adding a counter to track the pulling from non-leader case