### PR TITLE
Replicator: add ReplicaRoleString utils

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -337,7 +337,7 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
             // no updates consecutively, and the upstream says it's NOT a leader.
             // Therefore we reset upstream.
             db->pullFromUpstreamNoUpdates_++;
-            if (response.role != ReplicaRole::LEADER
+            if (response.__isset.role && response.role != ReplicaRole::LEADER
                 && FLAGS_reset_upstream_on_empty_updates_from_non_leader
                 && db->pullFromUpstreamNoUpdates_ >= FLAGS_replicator_max_consecutive_no_updates_before_upstream_reset) {
               LOG(ERROR) << "No updates when fetching from a non-leader (" + std::string(ReplicaRoleString(response.role))
@@ -443,7 +443,7 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
         }
         if (use_cached_iter || status.ok() || status.IsNotFound()) {
           ReplicateResponse response;
-          response.role = db->role_;
+          response.set_role(db->role_);
           uint64_t read_bytes = 0;
           for (int32_t i = 0;
                i < (*request)->max_updates && iter && iter->Valid();

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -325,7 +325,7 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
             }
           }
 
-          if (response.role != ReplicaRole::LEADER) {
+          if (response.__isset.role && response.role != ReplicaRole::LEADER) {
             incCounter(kReplicatorPullFromNonLeader, 1, db->db_name_);
           }
 

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -130,6 +130,7 @@ class RocksDBReplicator {
     std::shared_ptr<replicator::DbWrapper> db_wrapper_;
     folly::Executor* const executor_;
     const ReplicaRole role_;
+    const char* role_str_;
     folly::SocketAddress upstream_addr_;
     uint32_t pullFromUpstreamNoUpdates_ {0};
     uint32_t resetUpstreamAttempts_ {0}; // currently only used for unit tests

--- a/rocksdb_replicator/tests/CMakeLists.txt
+++ b/rocksdb_replicator/tests/CMakeLists.txt
@@ -19,3 +19,7 @@ add_test(NAME rocksdb_assumption_test COMMAND rocksdb_assumption_test)
 add_executable(max_number_box_test max_number_box_test.cpp)
 target_link_libraries(max_number_box_test rocksdb_replicator gtest)
 add_test(NAME max_number_box_test COMMAND max_number_box_test)
+
+add_executable(replicator_utils_test utils_test.cpp)
+target_link_libraries(replicator_utils_test rocksdb_replicator gtest)
+add_test(NAME replicator_utils_test COMMAND replicator_utils_test)

--- a/rocksdb_replicator/tests/utils_test.cpp
+++ b/rocksdb_replicator/tests/utils_test.cpp
@@ -1,0 +1,33 @@
+/// Copyright 2016 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+//
+
+#include "gtest/gtest.h"
+#include "rocksdb_replicator/utils.h"
+
+TEST(ReplicatorUtilsTest, ReplicaRoleString) {
+  std::unordered_map<replicator::ReplicaRole, std::string> testscases = {
+      {replicator::ReplicaRole::LEADER, "LEADER"},
+      {replicator::ReplicaRole::FOLLOWER, "FOLLOWER"},
+      {replicator::ReplicaRole::NOOP, "NOOP"},
+  };
+  for (auto p : testscases) {
+      EXPECT_EQ(p.second, replicator::ReplicaRoleString(p.first));
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rocksdb_replicator/utils.h
+++ b/rocksdb_replicator/utils.h
@@ -1,0 +1,35 @@
+/// Copyright 2016 Pinterest Inc.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+#pragma once
+
+#include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
+
+namespace replicator {  // namespace replicator
+
+const char* ReplicaRoleString(ReplicaRole role) {
+  switch(role) {
+    case ReplicaRole::NOOP:
+        return "NOOP";
+    case ReplicaRole::FOLLOWER:
+        return "FOLLOWER";
+    case ReplicaRole::LEADER:
+        return "LEADER" ;
+
+    default:
+        return "__unknown_role__";
+  }
+}
+
+}  // namespace replicator


### PR DESCRIPTION
Address a TODO to convert ReplicaRole enum to string. Use it in introspection & logging.