### PR TITLE
cluster_management/LeaderFollower: fix compilation error

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
@@ -386,7 +386,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
     }
 
     public String getLeaderInstance(NotificationContext context) {
-      HelixAdmin admin = context.getManager().getClusterManagmentTool()
+      HelixAdmin admin = context.getManager().getClusterManagmentTool();
       ExternalView view = admin.getResourceExternalView(cluster, resourceName);
       Map<String, String> stateMap = view.getStateMap(partitionName);
       for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
@@ -491,7 +491,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
             if (leaderInstance != null && leaderInstance != upstream) {
               String[] leaderHostPort = leaderInstance.split("_");
               upstreamHost = leaderHostPort[0];
-              upstreamPort = leaderHostPort[1];
+              upstreamPort = Integer.parseInt(leaderHostPort[1]);
               LOG.error("Leader address differs from current upstream. Using leader " + upstreamHost + " as the upstream for " + dbName);
             }
 


### PR DESCRIPTION
This wasn't caught in https://github.com/pinterest/rocksplicator/pull/593 because:
1. Our CI build seems broken, no long triggered
2. I didn't do mvn test locally for each iteration of the PR (especially before landing)
3. I did build a private build and deployed, not issues. Could it be that the private build may not be building from the source in /cluster_management (perhaps it's downloading from artifactory?)

Will follow up with 1 & 3. But fixing the compilation error in this PR. 

Test plan: ran `mvn test` locally now passes