### PR TITLE
rocksdb_replicator: enable leader behind follower stats

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -68,9 +68,6 @@ DEFINE_uint64(replicator_timeout_ms, 5 * 1000,
               " waiting forever");
 
 DECLARE_int32(replicator_idle_iter_timeout_ms);
-DEFINE_bool(emit_stat_for_leader_behind,
-            false,
-            "Flag to control whether to emit a stat when the leader is behind the follower during a sync request.");
 DEFINE_string(replicator_zk_cluster, "", "Zookeeper cluster");
 DEFINE_string(replicator_helix_cluster, "", "Helix cluster");
 DEFINE_int32(replication_error_reset_upstream_percentage, 10,
@@ -386,7 +383,7 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
 
   // Inverse of predicate below: if requested sequence number is HIGHER than latest sequence number on leader, emit a stat)
   auto leaderSeqNum = db->db_wrapper_->LatestSequenceNumber();
-  if (FLAGS_emit_stat_for_leader_behind && leaderSeqNum < seq_no) {
+  if (leaderSeqNum < seq_no) {
     logMetric(kReplicatorLeaderSequenceNumbersBehind, seq_no - leaderSeqNum, db ->db_name_);
   }
 


### PR DESCRIPTION
Noticed in prod that we may see leader behind follower sequence, so I wonder if we have metrics for it. Turns out we do, but never enabled it. 

Removing the GFLAG since I don't think it's necessary, it's useful to always have this visibility to catch issues: an upstream/leader received a replication request, but turns out its own local sequence number is lower than requested. 

Test Plan: deployed a private build and don't see any such metrics emitted, as expected. I don't think this case is expected to happen in production, but if they do, it'll be a good chance to debug why