### PR TITLE
cluster_management: add simple retry for helix external view

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
@@ -313,7 +313,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
 
         // Get the latest external view and state map
         LOG.error("[" + dbName + "] Getting external view");
-        view = admin.getResourceExternalView(cluster, resourceName);
+        view = Utils.getHelixExternalViewWithFixedRetry(admin, cluster, resourceName);
         LOG.error("[" + dbName + "] Got external view");
         stateMap = view.getStateMap(partitionName);
         // changeDBRoleAndUpStream(all_other_followers_or_offlines, "Follower", "my_ip_port")
@@ -387,7 +387,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
 
     public String getLeaderInstance(NotificationContext context) {
       HelixAdmin admin = context.getManager().getClusterManagmentTool();
-      ExternalView view = admin.getResourceExternalView(cluster, resourceName);
+      ExternalView view = Utils.getHelixExternalViewWithFixedRetry(admin, cluster, resourceName);
       Map<String, String> stateMap = view.getStateMap(partitionName);
       for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
         if (instanceNameAndRole.getValue().equalsIgnoreCase("LEADER")) {
@@ -399,7 +399,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
 
     public Map<String, String> getLiveHostAndRole(NotificationContext context, String dbName) {
       HelixAdmin admin = context.getManager().getClusterManagmentTool();
-      ExternalView view = admin.getResourceExternalView(cluster, resourceName);
+      ExternalView view = Utils.getHelixExternalViewWithFixedRetry(admin, cluster, resourceName);
       Map<String, String> stateMap = view.getStateMap(partitionName);
 
       // find live replicas
@@ -663,7 +663,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
         // changeDBRoleAndUpStream(all_other_followers_or_offlines, "Follower",
         // "live_leader_or_follower")
         HelixAdmin admin = context.getManager().getClusterManagmentTool();
-        ExternalView view = admin.getResourceExternalView(cluster, resourceName);
+        ExternalView view = Utils.getHelixExternalViewWithFixedRetry(admin, cluster, resourceName);
         Map<String, String> stateMap = view.getStateMap(partitionName);
 
         // find upstream which is not me, and prefer leader

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/MasterSlaveStateModelFactory.java
@@ -269,7 +269,7 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
 
         // Get the latest external view and state map
         LOG.error("[" + dbName + "] Getting external view");
-        view = admin.getResourceExternalView(cluster, resourceName);
+        view = Utils.getHelixExternalViewWithFixedRetry(admin, cluster, resourceName);
         LOG.error("[" + dbName + "] Got external view");
         stateMap = view.getStateMap(partitionName);
         // changeDBRoleAndUpStream(all_other_slaves_or_offlines, "Slave", "my_ip_port")
@@ -341,7 +341,7 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
 
     public Map<String, String> getLiveHostAndRole(NotificationContext context, String dbName) {
       HelixAdmin admin = context.getManager().getClusterManagmentTool();
-      ExternalView view = admin.getResourceExternalView(cluster, resourceName);
+      ExternalView view = Utils.getHelixExternalViewWithFixedRetry(admin, cluster, resourceName);
       Map<String, String> stateMap = view.getStateMap(partitionName);
 
       // find live replicas
@@ -560,7 +560,7 @@ public class MasterSlaveStateModelFactory extends StateModelFactory<StateModel> 
       try (Locker locker = new Locker(partitionMutex)) {
         // changeDBRoleAndUpStream(all_other_slaves_or_offlines, "Slave", "live_master_or_slave")
         HelixAdmin admin = context.getManager().getClusterManagmentTool();
-        ExternalView view = admin.getResourceExternalView(cluster, resourceName);
+        ExternalView view = Utils.getHelixExternalViewWithFixedRetry(admin, cluster, resourceName);
         Map<String, String> stateMap = view.getStateMap(partitionName);
 
         // find upstream which is not me, and prefer master

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -40,6 +40,8 @@ import com.pinterest.rocksdb_admin.thrift.SetDBOptionsRequest;
 import org.apache.curator.RetryLoop;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.helix.model.Message;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.ExternalView;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TSocket;
@@ -52,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.TimeUnit;
 
 public class Utils {
 
@@ -59,6 +62,40 @@ public class Utils {
   static final String LOCAL_HOST_IP = "127.0.0.1";
   private static final String RESOURCE_INFO_META_SUFFIX = "resource_meta";
   private static final String RESOURCE_INFO_CONFIGS_SUFFIX = "resource_configs";
+
+  /**
+   * Obtain the Helix External View of a resource in a cluster.
+   * It performs a fixed number of retries to mitigate potential transient failure.
+   * @param admin Helix Admin client
+   * @param clusterName
+   * @param resourceName
+   * @return ExternalView, which will be null if failed
+   */
+  public static ExternalView getHelixExternalViewWithFixedRetry(HelixAdmin admin, String clusterName, String resourceName) {
+    ExternalView view = admin.getResourceExternalView(clusterName, resourceName);
+    if (view != null) {
+      return view;
+    }
+
+    // retry for maxRetries times with sleep in between
+    final int maxRetries = 3;
+    final int retryWaitSec = 1;
+    try {
+      for (int retryCount = 1; retryCount <= maxRetries; retryCount++) {
+        TimeUnit.SECONDS.sleep(retryWaitSec * retryCount);
+        view = admin.getResourceExternalView(clusterName, resourceName);
+        if (view != null) {
+          return view;
+        }
+      }
+    } catch (InterruptedException e) {
+      LOG.error("Interrupted when getting external view for resource " + resourceName, e);
+      return null;
+    }
+
+    LOG.error("failed to obtain external view for resource {} in cluster {} after {} retries", resourceName, clusterName, maxRetries);
+    return null;
+  }
 
   /**
    * Build a thrift client to local adminPort

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -81,10 +81,10 @@ public class Utils {
 
     // retry for maxRetries times with sleep in between
     final int maxRetries = 3;
-    final int retryWaitSec = 1;
+    final int retryWaitBaseSec = 1;
     try {
-      for (int retryCount = 1; retryCount <= maxRetries; retryCount++) {
-        TimeUnit.SECONDS.sleep(retryWaitSec * retryCount);
+      for (int retryCount = 0; retryCount < maxRetries; retryCount++) {
+        TimeUnit.SECONDS.sleep(retryWaitBaseSec * (1 << retryCount));
         view = admin.getResourceExternalView(clusterName, resourceName);
         if (view != null) {
           return view;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -77,6 +77,8 @@ public class Utils {
       return view;
     }
 
+    LOG.error("Failed to get external view for " + resourceName + ", retry ...");
+
     // retry for maxRetries times with sleep in between
     final int maxRetries = 3;
     final int retryWaitSec = 1;
@@ -93,7 +95,7 @@ public class Utils {
       return null;
     }
 
-    LOG.error("failed to obtain external view for resource {} in cluster {} after {} retries", resourceName, clusterName, maxRetries);
+    LOG.error("Failed to obtain external view for resource {} in cluster {} after {} retries", resourceName, clusterName, maxRetries);
     return null;
   }
 


### PR DESCRIPTION
Noticed in prod where state transitions could fail (thus leading to ERROR shards) due to failure to obtain Helix external view, hence getting NPE when accessing the `null` view. 

It's not clear whether the failure was transient, but I think it's a good practice to add some retry when talking to external dependency. (currently configured to have 3 retries, with 1s, 2s, and 3s sleep in between). 

This change affects both `LeaderFollower` and `MasterSlave` state models

I plan to have a a follow-up change on dealing with the `null` view if retry still fails. 

ref: https://jira.pinadmin.com/browse/KV-5161