### PR TITLE
rocksdb_replicator: detect WAL expiration in replication

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -454,8 +454,8 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
             // ref: https://github.com/facebook/rocksdb/blob/7ae4da924ad4df9ffc04ba4b3577d1aa7025f4aa/include/rocksdb/db.h#L1417
             // "If the sequence number is non existent, it returns an iterator at the first available seq_no after the requested seq_no"
             if (i == 0 && result.sequence != expected_seq_no) {
-              LOG(ERROR) << "Missing updates, expected sequence number: " << expected_seq_no
-                << ", got: " << response.updates[0].get_seq_no();
+              LOG(ERROR) << "Missing updates for " << db->db_name_ << ", expected sequence number: "
+                         << expected_seq_no << ", got: " << response.updates[0].get_seq_no();
               incCounter(kReplicatorGetUpdatesMissingSequence, 1, db->db_name_);
             }
 

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -449,6 +449,16 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
                i < (*request)->max_updates && iter && iter->Valid();
                ++i, iter->Next()) {
             auto result = iter->GetBatch();
+
+            // emit a metrics on missing sequence number, possibly due to WAL deletion after TTL expires.
+            // ref: https://github.com/facebook/rocksdb/blob/7ae4da924ad4df9ffc04ba4b3577d1aa7025f4aa/include/rocksdb/db.h#L1417
+            // "If the sequence number is non existent, it returns an iterator at the first available seq_no after the requested seq_no"
+            if (i == 0 && result.sequence != expected_seq_no) {
+              LOG(ERROR) << "Missing updates, expected sequence number: " << expected_seq_no
+                << ", got: " << response.updates[0].get_seq_no();
+              incCounter(kReplicatorGetUpdatesMissingSequence, 1, db->db_name_);
+            }
+
             Update update;
             update.set_seq_no(result.sequence);
             next_seq_no += result.writeBatchPtr->Count();

--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -43,6 +43,8 @@ const std::string kReplicatorLeaderReset =
 
 const std::string kReplicatorGetUpdatesSinceErrors =
   "replicator_get_update_since_errors";
+const std::string kReplicatorGetUpdatesMissingSequence =
+  "replicator_get_update_missing_sequence";
 const std::string kReplicatorGetUpdatesSinceMs =
   "replicator_get_update_since_ms";
 const std::string kReplicatorReplyUpdatesSuccessLatency =

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -33,6 +33,7 @@ extern const std::string kReplicatorRemoteApplicationExceptions;
 extern const std::string kReplicatorRemoteApplicationExceptionsNotFound;
 
 extern const std::string kReplicatorGetUpdatesSinceErrors;
+extern const std::string kReplicatorGetUpdatesMissingSequence;
 extern const std::string kReplicatorGetUpdatesSinceMs;
 extern const std::string kReplicatorReplyUpdatesSuccessLatency;
 extern const std::string kReplicatorReplyUpdatesFailureLatency;


### PR DESCRIPTION
We current set WAL TTL to be 1h which has a risk for data loss. On the leader side, 
if the requested sequence number do not exist (WAL deletion), it simply returns the 
WAL update with the earliest available sequence number. 

This PR adds a metrics & log when the above case happens.
Counter name: `replicator_get_update_missing_sequence`

Test plan: deployed a private build and don't see metrics emission to this yet, as expected.