### PR TITLE
Add new replicator role to distinguish follower vs. observer

### DIFF
--- a/cdc_admin/cdc_admin_handler.cpp
+++ b/cdc_admin/cdc_admin_handler.cpp
@@ -116,7 +116,7 @@ void CDCAdminHandler::async_tm_addObserver(
 
   // add the db to db_manager
   std::string err_msg;
-  replicator::ReplicaRole role = replicator::ReplicaRole::FOLLOWER;
+  replicator::ReplicaRole role = replicator::ReplicaRole::OBSERVER;
   const std::string replicator_zk_cluster =
       request->__isset.replicator_zk_cluster ? request->replicator_zk_cluster : std::string("");
   const std::string replicator_helix_cluster = request->__isset.replicator_helix_cluster

--- a/cdc_admin/cdc_application_db.cpp
+++ b/cdc_admin/cdc_application_db.cpp
@@ -26,7 +26,7 @@ CDCApplicationDB::CDCApplicationDB(const std::string& db_name,
       db_(std::move(db_wrapper)),
       upstream_addr_(std::move(upstream_addr)),
       replicated_db_(nullptr) {
-  if (role == replicator::ReplicaRole::FOLLOWER) {
+  if (role == replicator::ReplicaRole::OBSERVER) {
     CHECK(upstream_addr_);
     auto ret = replicator::RocksDBReplicator::instance()->addDB(
         db_name_,
@@ -40,7 +40,7 @@ CDCApplicationDB::CDCApplicationDB(const std::string& db_name,
       throw ret;
     }
   }
-  // SLAVE should be the only role we use for CDC
+  // OBSERVER should be the only role we use for CDC
 }
 
 CDCApplicationDB::~CDCApplicationDB() {

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -93,7 +93,7 @@ rocksdb::Status RocksDBReplicator::ReplicatedDB::Write(
     const rocksdb::WriteOptions& options,
     rocksdb::WriteBatch* updates,
     rocksdb::SequenceNumber* seq_no) {
-  if (role_ == ReplicaRole::FOLLOWER) {
+  if (role_ == ReplicaRole::FOLLOWER || role_ == ReplicaRole::OBSERVER) {
     throw ReturnCode::WRITE_TO_SLAVE;
   }
 
@@ -196,7 +196,7 @@ RocksDBReplicator::ReplicatedDB::ReplicatedDB(
     , write_options_()
     , cached_iters_()
     , cached_iters_mutex_() {
-  if (role == ReplicaRole::FOLLOWER) {
+  if (role == ReplicaRole::FOLLOWER || role == ReplicaRole::OBSERVER) {
     client_ = client_pool_->getClient(upstream_addr);
   }
 
@@ -254,7 +254,7 @@ void RocksDBReplicator::ReplicatedDB::resetUpstream() {
 }
 
 void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
-  CHECK(role_ == ReplicaRole::FOLLOWER);
+  CHECK(role_ == ReplicaRole::FOLLOWER || role_ == ReplicaRole::OBSERVER);
   ReplicateRequest req;
   req.seq_no = db_wrapper_->LatestSequenceNumber();
   req.db_name = db_name_;

--- a/rocksdb_replicator/rocksdb_replicator.cpp
+++ b/rocksdb_replicator/rocksdb_replicator.cpp
@@ -123,7 +123,7 @@ ReturnCode RocksDBReplicator::addDB(const std::string& db_name,
     *replicated_db = new_db.get();
   }
 
-  if (role == ReplicaRole::FOLLOWER) {
+  if (role == ReplicaRole::FOLLOWER || role == ReplicaRole::OBSERVER) {
     new_db->pullFromUpstream();
   }
 

--- a/rocksdb_replicator/tests/utils_test.cpp
+++ b/rocksdb_replicator/tests/utils_test.cpp
@@ -20,6 +20,7 @@ TEST(ReplicatorUtilsTest, ReplicaRoleString) {
   std::unordered_map<replicator::ReplicaRole, std::string> testscases = {
       {replicator::ReplicaRole::LEADER, "LEADER"},
       {replicator::ReplicaRole::FOLLOWER, "FOLLOWER"},
+      {replicator::ReplicaRole::OBSERVER, "OBSERVER"},
       {replicator::ReplicaRole::NOOP, "NOOP"},
   };
   for (auto p : testscases) {

--- a/rocksdb_replicator/thrift/replicator.thrift
+++ b/rocksdb_replicator/thrift/replicator.thrift
@@ -36,6 +36,9 @@ struct ReplicateRequest {
   # uppper limit set by client side.
   # A value of 0 means no limit
   4: required i32 max_updates,
+
+  # role is the replica role of the downstream host requesting the updates
+  5: optional ReplicaRole role;
 }
 
 typedef binary (cpp.type = "folly::IOBuf") IOBuf
@@ -56,7 +59,8 @@ struct Update {
 enum ReplicaRole {
   NOOP = 0, // no replication needed
   FOLLOWER = 1,
-  LEADER = 2
+  LEADER = 2,
+  OBSERVER = 3 // replicates but should not be counted as a follower ack
 }
 
 struct ReplicateResponse {

--- a/rocksdb_replicator/utils.h
+++ b/rocksdb_replicator/utils.h
@@ -24,6 +24,8 @@ const char* ReplicaRoleString(ReplicaRole role) {
         return "NOOP";
     case ReplicaRole::FOLLOWER:
         return "FOLLOWER";
+    case ReplicaRole::OBSERVER:
+        return "OBSERVER";
     case ReplicaRole::LEADER:
         return "LEADER" ;
 


### PR DESCRIPTION
For 2-ack mode, we need to differentiate between a follower and observer. Add a new replicator role for this. 