### PR TITLE
Adds more info to S3Util::listObjectsHelper error message

### DIFF
--- a/common/s3util.cpp
+++ b/common/s3util.cpp
@@ -32,6 +32,8 @@
 #include <aws/s3/model/Object.h>
 #include <aws/s3/model/PutObjectRequest.h>
 
+#include <folly/Format.h>
+
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
@@ -252,7 +254,11 @@ void S3Util::listObjectsHelper(const string& prefix, const string& delimiter,
     }
   } else {
     if (error_message != nullptr) {
-      *error_message = listObjectResult.GetError().GetMessage();
+      *error_message = folly::sformat("ListObjectsRequest failed with ResponseCode: {}, ExceptionName: {}, ErrorMessage: {}, ShouldRetry: {}.", 
+        static_cast<int32_t>(listObjectResult.GetError().GetResponseCode()),
+        listObjectResult.GetError().GetExceptionName(), 
+        listObjectResult.GetError().GetMessage(),
+        listObjectResult.GetError().ShouldRetry());
     }
   }
 }


### PR DESCRIPTION
This adds more information to listObjectsHelper while I believe the original task asked for more data (like request id) it is not supported in the current version of AWS API we are using so I tried to extract most information from what we have as exception name and whether it is a retryable error or not.

I tested this by making sure the code path is called and supplying a wrong bucket name to aws to trigger an error.

The error is logged inside admin_handler.cpp: restoreDbFromS3
```
# E0323 17:52:11.712312 21926 admin_handler.cpp:1146] Error happened when fetching files in checkpoint from S3: ListObjectRequest failed with exception_name: NoSuchBucket, error_message: The specified bucket does not exist, should_retry: false under path: meariby_test/rockstor..._data_dummy/1/
```