### PR TITLE
rocksdb_replicator: fix a log on missing update

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -450,7 +450,7 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
             // emit a metrics on missing sequence number, possibly due to WAL deletion after TTL expires.
             // ref: https://github.com/facebook/rocksdb/blob/7ae4da924ad4df9ffc04ba4b3577d1aa7025f4aa/include/rocksdb/db.h#L1417
             // "If the sequence number is non existent, it returns an iterator at the first available seq_no after the requested seq_no"
-            if (i == 0 && result.sequence != expected_seq_no) {
+            if (i == 0 && result.sequence > expected_seq_no) {
               LOG(ERROR) << "Missing updates for " << db->db_name_ << ", expected sequence number: "
                          << expected_seq_no << ", got: " << result.sequence;
               incCounter(kReplicatorGetUpdatesMissingSequence, 1, db->db_name_);

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -452,7 +452,7 @@ void RocksDBReplicator::ReplicatedDB::handleReplicateRequest(
             // "If the sequence number is non existent, it returns an iterator at the first available seq_no after the requested seq_no"
             if (i == 0 && result.sequence != expected_seq_no) {
               LOG(ERROR) << "Missing updates for " << db->db_name_ << ", expected sequence number: "
-                         << expected_seq_no << ", got: " << response.updates[0].get_seq_no();
+                         << expected_seq_no << ", got: " << result.sequence;
               incCounter(kReplicatorGetUpdatesMissingSequence, 1, db->db_name_);
             }
 


### PR DESCRIPTION
A straightforward change: the log happens under if check `result.sequence != expected_seq_no`, so the log should just reflect that. The current approach will result in a segfault when it happens (because of accessing `response.updates` which is still empty)

Also only log&metrics when `result.sequence > expected_seq_no` since I've see in a private build that:
```
E0324 17:06:04.648486 17054 replicated_db.cpp:454] Missing updates for audience_targeting-_-engagement_v2_DEV00962, expected sequence number: 348938336, got: 348938335
E0324 17:06:04.675640 14628 replicated_db.cpp:454] Missing updates for audience_targeting-_-engagement_v2_DEV00221, expected sequence number: 337178972, got: 337178969
E0324 17:06:04.677206 14628 replicated_db.cpp:454] Missing updates for audience_targeting-_-engagement_v2_DEV00221, expected sequence number: 337178975, got: 337178972
E0324 17:06:04.722473 10124 replicated_db.cpp:454] Missing updates for audience_targeting-_-engagement_v2_DEV00962, expected sequence number: 348938342, got: 348938341
E0324 17:06:04.722491 10129 replicated_db.cpp:454] Missing updates for audience_targeting-_-engagement_v2_DEV00962, expected sequence number: 348938342, got: 348938341
E0324 17:06:04.735060 17058 replicated_db.cpp:454] Missing updates for audience_targeting-_-engagement_v2_DEV00221, expected sequence number: 337178980, got: 337178977
```

e.g.. the follower expect updated since sequence number `348938342`, but the leader is replying from an older update `348938341`. That's not missing an update. This only happened for a few instances, so I am checking why. But making the change here to avoid noise. 