### PR TITLE
rocksdb_replicator: log db & upstream address upon replication exception

### DIFF
--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -283,7 +283,7 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
             t.exception().throwException();
 #endif
           } catch (const ReplicateException& ex) {
-            LOG(ERROR) << "ReplicateException: upstream = " << db->upstream_addr_.getAddressStr() << ", code = " << static_cast<int>(ex.code)
+            LOG(ERROR) << "ReplicateException: upstream = " << common::getNetworkAddressStr(db->upstream_addr_) << ", code = " << static_cast<int>(ex.code)
                        << ", message = " << ex.msg;
             incCounter(kReplicatorRemoteApplicationExceptions, 1, db->db_name_);
             
@@ -294,7 +294,7 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
               db->resetUpstream();
             }
           } catch (const std::exception& ex) {
-            LOG(ERROR) << "std::exception when replicating from upstream " << db->upstream_addr_.getAddressStr()
+            LOG(ERROR) << "std::exception when replicating from upstream " << common::getNetworkAddressStr(db->upstream_addr_)
                        << " for db " << db->db_name_ << ": " << ex.what();
             incCounter(kReplicatorConnectionErrors, 1, db->db_name_);
             if (FLAGS_reset_upstream_on_std_exception) {

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -294,7 +294,8 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
               db->resetUpstream();
             }
           } catch (const std::exception& ex) {
-            LOG(ERROR) << "std::exception: " << ex.what();
+            LOG(ERROR) << "std::exception when replicating from upstream " << db->upstream_addr_.getAddressStr()
+                       << " for db " << db->db_name_ << ": " << ex.what();
             incCounter(kReplicatorConnectionErrors, 1, db->db_name_);
             if (FLAGS_reset_upstream_on_std_exception) {
               db->resetUpstream();


### PR DESCRIPTION
When replication happen due to network errors happen (e.g. upstream is down), we get logs like:
```
E0328 07:18:51.642714 14803 replicated_db.cpp:297] std::exception: Channel is !good()
```
Adding db name and upstream address would help us pinpoint where it failed