### PR TITLE
common/network_utils: return uninitialized_addr on empty address

### DIFF
--- a/common/network_util.cpp
+++ b/common/network_util.cpp
@@ -52,6 +52,10 @@ const std::string& getLocalIPAddress() {
 }
 
 std::string getNetworkAddressStr(const folly::SocketAddress& addr) noexcept {
+  if (!addr.isInitialized()) {
+    return "uninitialized_addr";
+  }
+  
   std::string add_str = "unknown_addr";
   try {
     add_str = addr.getAddressStr();

--- a/common/network_util.h
+++ b/common/network_util.h
@@ -28,7 +28,8 @@ const std::string& getLocalIPAddress();
 
 /**
  * Get a string representation of the provide socket address if it is IPv4 or IPv6,
- * otherwise "unknown_addr" is returned.
+ * return "uninitialized_addr" if an empty address is provided;
+ * return "unknown_addr" if an error is encountered parsing the address.
  */
 std::string getNetworkAddressStr(const folly::SocketAddress&) noexcept;
 

--- a/common/tests/network_util_test.cpp
+++ b/common/tests/network_util_test.cpp
@@ -11,6 +11,9 @@ TEST(NetworkUtilTest, GetNetworkAddressStr) {
   EXPECT_EQ(common::getNetworkAddressStr(addr), "uninitialized_addr");
 
   EXPECT_THROW(addr.setFromIpPort("bad-ip", 1234), std::runtime_error);
+  EXPECT_EQ(common::getNetworkAddressStr(addr), "uninitialized_addr");
+
+  addr.setFromPath("foo");
   EXPECT_EQ(common::getNetworkAddressStr(addr), "unknown_addr");
 
   addr.setFromIpPort("255.254.253.252", 8888);

--- a/common/tests/network_util_test.cpp
+++ b/common/tests/network_util_test.cpp
@@ -8,7 +8,7 @@ namespace common {
 
 TEST(NetworkUtilTest, GetNetworkAddressStr) {
   folly::SocketAddress addr;
-  EXPECT_EQ(common::getNetworkAddressStr(addr), "unknown_addr");
+  EXPECT_EQ(common::getNetworkAddressStr(addr), "uninitialized_addr");
 
   EXPECT_THROW(addr.setFromIpPort("bad-ip", 1234), std::runtime_error);
   EXPECT_EQ(common::getNetworkAddressStr(addr), "unknown_addr");

--- a/rocksdb_admin/tests/application_db_manager_test.cpp
+++ b/rocksdb_admin/tests/application_db_manager_test.cpp
@@ -60,7 +60,7 @@ test_db:\n\
  ReplicatedDB:\n\
   name: test_db\n\
   ReplicaRole: LEADER\n\
-  upstream_addr: unknown_addr\n\
+  upstream_addr: uninitialized_addr\n\
   cur_seq_no: 0\n\n";
   EXPECT_EQ(db_manager.Introspect(), std::string(test_db_state));
 

--- a/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
+++ b/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
@@ -110,7 +110,7 @@ TEST(RocksDBReplicatorTest, Basics) {
 "ReplicatedDB:\n\
   name: master\n\
   ReplicaRole: LEADER\n\
-  upstream_addr: unknown_addr\n\
+  upstream_addr: uninitialized_addr\n\
   cur_seq_no: 2\n";
   const char* expected_slave_state =
 "ReplicatedDB:\n\


### PR DESCRIPTION
If an empty folly:SocketAddress is provided, return the string representation as `uninitialized_addr` instead of `unknown_addr`, and don't log an error as that can be expected: in fact this happens today for any leader replica which 
doesn't have an upstream -- as a result, we may see noisy log when introspecting the leader states