### PR TITLE
cluster_management: include dates in logs for other components

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/ClientShardMapAgent.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/ClientShardMapAgent.java
@@ -136,7 +136,7 @@ public class ClientShardMapAgent {
   public static void main(String[] args) throws Exception {
     org.apache.log4j.Logger.getRootLogger().setLevel(Level.INFO);
     BasicConfigurator.configure(new ConsoleAppender(
-        new PatternLayout("%d{HH:mm:ss.SSS} [%t] %-5p %30.30c - %m%n")
+        new PatternLayout("%d{dd MMM yyyy HH:mm:ss.SSS} [%t] %-5p %30.30c - %m%n")
     ));
     CommandLine cmd = processCommandLineArgs(args);
 

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/DistributedSpectatorMain.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/DistributedSpectatorMain.java
@@ -206,7 +206,7 @@ public class DistributedSpectatorMain {
   public static void main(String[] args) throws Exception {
     org.apache.log4j.Logger.getRootLogger().setLevel(Level.INFO);
     BasicConfigurator.configure(new ConsoleAppender(
-        new PatternLayout("%d{HH:mm:ss.SSS} [%t] %-5p %30.30c - %m%n")
+        new PatternLayout("%d{dd MMM yyyy HH:mm:ss.SSS} [%t] %-5p %30.30c - %m%n")
     ));
 
     CommandLine cmd = processCommandLineArgs(args);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Spectator.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Spectator.java
@@ -210,7 +210,7 @@ public class Spectator {
   public static void main(String[] args) throws Exception {
     org.apache.log4j.Logger.getRootLogger().setLevel(Level.WARN);
     BasicConfigurator.configure(new ConsoleAppender(
-        new PatternLayout("%d{HH:mm:ss.SSS} [%t] %-5p %30.30c - %m%n")
+        new PatternLayout("%d{dd MMM yyyy HH:mm:ss.SSS} [%t] %-5p %30.30c - %m%n")
     ));
     CommandLine cmd = processCommandLineArgs(args);
     final String zkConnectString = cmd.getOptionValue(zkServer);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/helix_client/HelixClient.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/helix_client/HelixClient.java
@@ -152,7 +152,7 @@ public class HelixClient {
   public static void main(String[] args) throws Exception {
     org.apache.log4j.Logger.getRootLogger().setLevel(Level.WARN);
     BasicConfigurator.configure(new ConsoleAppender(
-        new PatternLayout("%d{HH:mm:ss.SSS} [%t] %-5p %30.30c - %m%n")
+        new PatternLayout("%d{dd MMM yyyy HH:mm:ss.SSS} [%t] %-5p %30.30c - %m%n")
     ));
     CommandLine cmd = processCommandLineArgs(args);
     final String zkConnectString = cmd.getOptionValue(zkServer);


### PR DESCRIPTION
Similar to https://github.com/pinterest/rocksplicator/pull/589, let's add date in logs for other helix/java components

tested on a private build, e.g. for shardmap-agent:
```
06 Apr 2022 07:56:55.943 [main] ERROR ksplicator.ClientShardMapAgent - ShardMapAgent running
```