### PR TITLE
rocksdb_replicator: add a util function ReturnCodeString

### DIFF
--- a/rocksdb_replicator/tests/utils_test.cpp
+++ b/rocksdb_replicator/tests/utils_test.cpp
@@ -27,6 +27,20 @@ TEST(ReplicatorUtilsTest, ReplicaRoleString) {
   }
 }
 
+TEST(ReplicatorUtilsTest, ReturnCodeString) {
+  std::unordered_map<replicator::ReturnCode, std::string> testscases = {
+      {replicator::ReturnCode::OK, "OK"},
+      {replicator::ReturnCode::DB_NOT_FOUND, "DB_NOT_FOUND"},
+      {replicator::ReturnCode::DB_PRE_EXIST, "DB_PRE_EXIST"},
+      {replicator::ReturnCode::WRITE_TO_SLAVE, "WRITE_TO_SLAVE"},
+      {replicator::ReturnCode::WRITE_ERROR, "WRITE_ERROR"},
+      {replicator::ReturnCode::WAIT_SLAVE_TIMEOUT, "WAIT_SLAVE_TIMEOUT"},
+  };
+  for (auto p : testscases) {
+      EXPECT_EQ(p.second, replicator::ReturnCodeString(p.first));
+  }
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/rocksdb_replicator/utils.h
+++ b/rocksdb_replicator/utils.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
+#include "rocksdb_replicator/rocksdb_replicator.h"
 
 namespace replicator {  // namespace replicator
 
@@ -29,6 +30,26 @@ const char* ReplicaRoleString(ReplicaRole role) {
 
     default:
         return "__unknown_role__";
+  }
+}
+
+const char* ReturnCodeString(ReturnCode code) {
+  switch(code) {
+    case ReturnCode::OK:
+        return "OK";
+    case ReturnCode::DB_NOT_FOUND:
+        return "DB_NOT_FOUND";
+    case ReturnCode::DB_PRE_EXIST:
+        return "DB_PRE_EXIST" ;
+    case ReturnCode::WRITE_TO_SLAVE:
+        return "WRITE_TO_SLAVE" ;
+    case ReturnCode::WRITE_ERROR:
+        return "WRITE_ERROR" ;
+    case ReturnCode::WAIT_SLAVE_TIMEOUT:
+        return "WAIT_SLAVE_TIMEOUT" ;
+
+    default:
+        return "__unknown_code__";
   }
 }
 


### PR DESCRIPTION
This will be used on the caller side to log/print the return code as string