### PR TITLE
rocksdb_replicator: adaptive replication timeout for 2-ACK mode

### DIFF
--- a/rocksdb_admin/tests/application_db_manager_test.cpp
+++ b/rocksdb_admin/tests/application_db_manager_test.cpp
@@ -61,7 +61,9 @@ test_db:\n\
   name: test_db\n\
   ReplicaRole: LEADER\n\
   upstream_addr: uninitialized_addr\n\
-  cur_seq_no: 0\n\n";
+  cur_seq_no: 0\n\
+  current_replicator_timeout_ms_: 2000\n\n";
+
   EXPECT_EQ(db_manager.Introspect(), std::string(test_db_state));
 
   auto ret_rocksdb = db_manager.removeDB("test_db", &error_message);

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -63,15 +63,19 @@ DEFINE_int32(replicator_replication_mode, 0,
              "stack for the connection to one of the Slave; "
              "2: ack client once committed to Master and one of the Slaves.");
 
-DEFINE_uint64(replicator_timeout_ms, 5 * 1000,
+DEFINE_uint64(replicator_timeout_ms, 2 * 1000,
               "How long to wait for Follower ACK before timeout a client write, 0 means"
               " waiting forever");
 
 DEFINE_uint64(replicator_timeout_degraded_ms, 10,
               "In Degradation mode, i.e. when the writes keep timing out waiting for follower ACK, "
               "we would use this timeout to fail fast. "
-              "0 means this mode is disabled. "
-              "This needs to be smaller than replicator_timeout_ms for the config to be valid and used.");
+              "Note that for this config to be valid and used, it needs to be "
+              "smaller than replicator_timeout_ms, but not smaller than 1 (set by kMinReplTimeoutMs)");
+
+DEFINE_uint64(replicator_consecutive_ack_timeout_before_degradation, 100,
+             "The max number of consecutive replication timeout, before a DB enters degradation mode "
+             "and use the above replicator_timeout_degraded_ms");
 
 DECLARE_int32(replicator_idle_iter_timeout_ms);
 DEFINE_string(replicator_zk_cluster, "", "Zookeeper cluster");
@@ -146,32 +150,35 @@ rocksdb::Status RocksDBReplicator::ReplicatedDB::Write(
     // TODO(bol): This potentially could block all worker threads. We may
     // consider having a dedicated set of worker threads for admin requests,
     // and/or provide async write API when this turns out to be a problem.
-    if (!max_seq_no_acked_.wait(cur_seq_no, current_replicator_timeout_ms_)) {
+    if (!max_seq_no_acked_.wait(cur_seq_no, current_replicator_timeout_ms_.load())) {
       incCounter(kReplicatorWriteWaitTimedOut, 1, db_name_);
       LOG(ERROR) << "Failed to receive ack from follower, timing out for " << db_name_;
       numConsecutiveReplTimeout_ ++;
 
       // enter degradation mode if there has been consecutive timeouts waiting for the follower ACK.
       // This allows us to use a smaller wait timeout to fail fast, instead of blocking for long.
-      if (numConsecutiveReplTimeout_ == kNumReplTimeoutsBeforeDegradation
-          && current_replicator_timeout_ms_ == FLAGS_replicator_timeout_ms
+      if (numConsecutiveReplTimeout_.load() == FLAGS_replicator_consecutive_ack_timeout_before_degradation
+          && current_replicator_timeout_ms_.load() == FLAGS_replicator_timeout_ms
           && FLAGS_replicator_timeout_degraded_ms < FLAGS_replicator_timeout_ms
           && FLAGS_replicator_timeout_degraded_ms >= kMinReplTimeoutMs) {
-        current_replicator_timeout_ms_ = FLAGS_replicator_timeout_degraded_ms;
+        current_replicator_timeout_ms_.store(FLAGS_replicator_timeout_degraded_ms);
         LOG(ERROR) << "Enter degradation mode for db " << db_name_
-                   << " after " << numConsecutiveReplTimeout_ << " write timeouts,"
-                   << " use new timeout to fail fast: " << current_replicator_timeout_ms_ << "ms";
+                   << " after " << numConsecutiveReplTimeout_.load() << " write timeouts,"
+                   << " use new timeout to fail fast: " << current_replicator_timeout_ms_.load() << "ms";
         incCounter(kReplicatorWriteTwoAckDegraded, 1, db_name_);
       }
       return rocksdb::Status::TimedOut("Failed to receive ack from follower");
     }
-    numConsecutiveReplTimeout_ = 0;
-    if (current_replicator_timeout_ms_ != FLAGS_replicator_timeout_ms) {
-      current_replicator_timeout_ms_ = FLAGS_replicator_timeout_ms;
+
+    numConsecutiveReplTimeout_.store(0);
+    // TODO(jz): consider use CAS
+    if (current_replicator_timeout_ms_.load() != FLAGS_replicator_timeout_ms) {
+      current_replicator_timeout_ms_.store(FLAGS_replicator_timeout_ms);
       LOG(ERROR) << "2-ACK Write succeeded, exit degradation mode and switch to use normal replicator timeout: "
-                << current_replicator_timeout_ms_ << "ms";
+                << current_replicator_timeout_ms_.load() << "ms";
       incCounter(kReplicatorWriteTwoAckRecovered, 1, db_name_);
     }
+
     break;
   default:
     CHECK(replication_mode == 0)
@@ -195,6 +202,7 @@ std::string RocksDBReplicator::ReplicatedDB::Introspect() {
   ss << "  ReplicaRole: " << role_str_ << std::endl;
   ss << "  upstream_addr: " << upstream_addr_str << std::endl;
   ss << "  cur_seq_no: " << cur_seq_no << std::endl;
+  ss << "  current_replicator_timeout_ms_: " << current_replicator_timeout_ms_.load() << std::endl;
   // TODO(jz): add max_seq_no_acked_
   return ss.str();
 }
@@ -236,8 +244,9 @@ RocksDBReplicator::ReplicatedDB::ReplicatedDB(
     replicator_helix_cluster_ = FLAGS_replicator_helix_cluster;
   }
 
+  // ensure we don't use a timeout smaller than kMinReplTimeoutMs
   if (FLAGS_replicator_timeout_ms > kMinReplTimeoutMs) {
-    current_replicator_timeout_ms_ = FLAGS_replicator_timeout_ms;
+    current_replicator_timeout_ms_.store(FLAGS_replicator_timeout_ms);
   }
 
   rpc_options_.setTimeout(

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -87,7 +87,6 @@ DECLARE_int32(rocksdb_replicator_port);
 
 namespace {
 
-const uint32_t kNumReplTimeoutsBeforeDegradation = 100;
 
 uint64_t GetCurrentTimeMs() {
   return std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -61,6 +61,8 @@ const std::string kReplicatorWriteWaitTimedOut =
 const std::string kReplicatorWriteToLeaderMs = "replicator_write_to_leader_ms";
 const std::string kReplicatorWriteSuccessResponseTime = "replicator_write_success_response_time";
 const std::string kReplicatorWriteFailureResponseTime = "replicator_write_failure_response_time";
+const std::string kReplicatorWriteTwoAckDegraded = "replicator_write_two_ack_degraded";
+const std::string kReplicatorWriteTwoAckRecovered = "replicator_write_two_ack_recovered";
 
 const std::string kReplicatorLeaderSequenceNumbersBehind = "replicator_leader_sequence_numbers_behind";
 const std::string kReplicatorPullRequests = "replicator_pull_requests";

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -47,6 +47,9 @@ extern const std::string kReplicatorWriteWaitTimedOut;
 extern const std::string kReplicatorWriteToLeaderMs;
 extern const std::string kReplicatorWriteSuccessResponseTime;
 extern const std::string kReplicatorWriteFailureResponseTime;
+extern const std::string kReplicatorWriteTwoAckDegraded;
+extern const std::string kReplicatorWriteTwoAckRecovered;
+
 
 extern const std::string kReplicatorPullRequests;
 extern const std::string kReplicatorPullRequestsSuccess;

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -147,7 +147,7 @@ class RocksDBReplicator {
                 uint64_t>> cached_iters_;
     std::mutex cached_iters_mutex_;
     detail::MaxNumberBox max_seq_no_acked_;
-    uint32_t current_replication_timeout_ms_ {kMinReplTimeoutMs};
+    uint32_t current_replicator_timeout_ms_ {kMinReplTimeoutMs};
     uint32_t numConsecutiveReplTimeout_ {0};
     std::string replicator_zk_cluster_;
     std::string replicator_helix_cluster_;

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -52,6 +52,8 @@ namespace wangle {
 
 namespace replicator {
 
+const uint32_t kMinReplTimeoutMs = 1;
+
 /*
  * An extractor to extract update time from an update
  */
@@ -144,6 +146,8 @@ class RocksDBReplicator {
                 uint64_t>> cached_iters_;
     std::mutex cached_iters_mutex_;
     detail::MaxNumberBox max_seq_no_acked_;
+    uint32_t current_replication_timeout_ms_ {kMinReplTimeoutMs};
+    uint32_t numConsecutiveReplTimeout_ {0};
     std::string replicator_zk_cluster_;
     std::string replicator_helix_cluster_;
 

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -53,7 +53,6 @@ namespace wangle {
 namespace replicator {
 
 const uint32_t kMinReplTimeoutMs = 1;
-const uint32_t kNumReplTimeoutsBeforeDegradation = 100;
 
 /*
  * An extractor to extract update time from an update
@@ -147,8 +146,8 @@ class RocksDBReplicator {
                 uint64_t>> cached_iters_;
     std::mutex cached_iters_mutex_;
     detail::MaxNumberBox max_seq_no_acked_;
-    uint32_t current_replicator_timeout_ms_ {kMinReplTimeoutMs};
-    uint32_t numConsecutiveReplTimeout_ {0};
+    std::atomic<uint32_t> current_replicator_timeout_ms_ {kMinReplTimeoutMs};
+    std::atomic<uint32_t> numConsecutiveReplTimeout_ {0};
     std::string replicator_zk_cluster_;
     std::string replicator_helix_cluster_;
 

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -53,6 +53,7 @@ namespace wangle {
 namespace replicator {
 
 const uint32_t kMinReplTimeoutMs = 1;
+const uint32_t kNumReplTimeoutsBeforeDegradation = 100;
 
 /*
  * An extractor to extract update time from an update

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -118,6 +118,7 @@ class RocksDBReplicator {
 
     void pullFromUpstream();
     void resetUpstream();
+    rocksdb::Status writeWaitFollowerACK(uint64_t cur_seq_no);
     using CallbackType =
       apache::thrift::HandlerCallback<std::unique_ptr<ReplicateResponse>>;
     void handleReplicateRequest(std::unique_ptr<CallbackType> callback,

--- a/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
+++ b/rocksdb_replicator/tests/rocksdb_replicator_test.cpp
@@ -542,7 +542,7 @@ TEST(RocksDBReplicatorTest, 1_master_1_slave_replication_mode_2) {
   //
   // remove the slave db from the replication library.
   // write more keys to the master db and expect requests to fail
-  // (WRITE_ERROR) due to timeout waiting for slave db ACK.
+  // due to timeout waiting for slave db ACK.
   // The slave db will not have the new keys.
   EXPECT_EQ(slave.replicator_->removeDB("shard1"), ReturnCode::OK);
   for (uint32_t i = 0; i < n_keys; ++i) {
@@ -557,7 +557,7 @@ TEST(RocksDBReplicatorTest, 1_master_1_slave_replication_mode_2) {
     EXPECT_EQ(db_master->GetLatestSequenceNumber(), i + 1 + n_keys * 2);
   }
   EXPECT_EQ(db_slave->GetLatestSequenceNumber(), n_keys * 2);
-  EXPECT_EQ(100 /* FLAGS_replicator_timeout_ms */, replicated_db_master->current_replication_timeout_ms_);
+  EXPECT_EQ(100 /* FLAGS_replicator_timeout_ms */, replicated_db_master->current_replicator_timeout_ms_);
 
   // enter degradation mode after consecutive timeouts
   for (uint32_t i = 0; i < kNumReplTimeoutsBeforeDegradation; ++i) {
@@ -570,7 +570,7 @@ TEST(RocksDBReplicatorTest, 1_master_1_slave_replication_mode_2) {
     EXPECT_EQ(status, Status::TimedOut("Failed to receive ack from follower"));
   }
   EXPECT_EQ(db_slave->GetLatestSequenceNumber(), n_keys * 2);
-  EXPECT_EQ(5 /* FLAGS_replicator_timeout_degraded_ms */, replicated_db_master->current_replication_timeout_ms_);
+  EXPECT_EQ(5 /* FLAGS_replicator_timeout_degraded_ms */, replicated_db_master->current_replicator_timeout_ms_);
 
   // back to normal mode after adding the slave db back
   EXPECT_EQ(slave.replicator_->addDB("shard1", db_slave, ReplicaRole::FOLLOWER,
@@ -581,7 +581,7 @@ TEST(RocksDBReplicatorTest, 1_master_1_slave_replication_mode_2) {
   updates.Put("new_key", "new_value");
   EXPECT_NO_THROW(status = replicated_db_master->Write(options, &updates));
   EXPECT_TRUE(status.ok());
-  EXPECT_EQ(100 /* FLAGS_replicator_timeout_ms */, replicated_db_master->current_replication_timeout_ms_);
+  EXPECT_EQ(100 /* FLAGS_replicator_timeout_ms */, replicated_db_master->current_replicator_timeout_ms_);
 }
 
 TEST(RocksDBReplicatorTest, Stress) {


### PR DESCRIPTION
When 2-ACK Mode is enabled, writes to the leader will need to wait for at least one follower ACK, before returning to the client. The wait timeout is controlled by a GFLAG `replicator_timeout_ms`, which can be generous to accommodate for the p99/p999 network delay (e.g. we typically set it to be 1s in production). However, in the cases when there is replication issues for a db, the leader may not be receiving followers' ACK for a long time, and as a result, all writes to this db would be blocked for 1s, which may end up blocking all worker threads and impacting all other dbs in the process. In production, we see this happens quite often, which leads to load shedding errors in the thrift handler and other cascading failures (e.g. state transitions may fail due to this).

As a mitigation, we introduce adaptive replication timeout, i.e.:
-  We keep the current `GFLAG_replication_timeout_ms` as the normal timeout (e.g. 1s)
- We introduce a new  `GFLAG_replication_timeout_degraded_ms` which can be very small (e.g. 10ms), based on stats: https://statsboard.pinadmin.com/share/j7qev, p99 is usually around 1ms, so requests should typically still succeed in that case.
- For a DB, if we see N (e.g. N=100) **consecutive** timeouts, we know that it's likely there is replication issue and the leader cannot receive follower ACK, so we fall back to the degraded mode, and use `GFLAG_replication_timeout_degraded_ms` instead. The goal is to **fail-fast** so that we can yield resource for other DBs. 
- In degradation mode, as soon as there is **one** successful request (i.e. follower ACK returned with `GFLAG_replication_timeout_degraded_ms`), we immediately **recover** to normal mode with the regular `GFLAG_replication_timeout_ms`.

Also, while we are here, updating the default `replicator_timeout_ms` GFLAG to be 2s based on our production stats that should be sufficient for the worst-case. 

========= Testing Plan ============
Added new unit tests.

Also, a private build with this PR is deployed to a cluster.

[**Degradation**]
Stop 2 replicas for a DB, we see timeouts of requests (about 1s apart). Then the DB enters **degradation** mode:

```
$cat rockstorewidecolumn.log | grep 'use new timeout' -A5 -B5
E0412 04:14:30.128701  5267 replicated_db.cpp:152] Failed to receive ack from follower, timing out for jzhan_rw_test00050
E0412 04:14:31.133306  5267 replicated_db.cpp:152] Failed to receive ack from follower, timing out for jzhan_rw_test00050
E0412 04:14:32.137323  5267 replicated_db.cpp:152] Failed to receive ack from follower, timing out for jzhan_rw_test00050
E0412 04:14:33.141415  5267 replicated_db.cpp:152] Failed to receive ack from follower, timing out for jzhan_rw_test00050
E0412 04:14:34.145385  5267 replicated_db.cpp:152] Failed to receive ack from follower, timing out for jzhan_rw_test00050
E0412 04:14:34.145534  5267 replicated_db.cpp:162] Enter degradation mode for db jzhan_rw_test00050 after 100 write timeouts, use new timeout to fail fast: 10ms
E0412 04:14:34.160810  5267 replicated_db.cpp:152] Failed to receive ack from follower, timing out for jzhan_rw_test00050
E0412 04:14:34.174832  5267 replicated_db.cpp:152] Failed to receive ack from follower, timing out for jzhan_rw_test00050
E0412 04:14:34.188071  5267 replicated_db.cpp:152] Failed to receive ack from follower, timing out for jzhan_rw_test00050
E0412 04:14:34.201182  5267 replicated_db.cpp:152] Failed to receive ack from follower, timing out for jzhan_rw_test00050
E0412 04:14:34.214716  5267 replicated_db.cpp:152] Failed to receive ack from follower, timing out for jzhan_rw_test00050
```

it took 100 consecutive request timeouts to enter degradation mode
```
jzhan@infra-rockstorewidecolumndev-rw-wc-beta-test-dev-0a083df5:/data/xvdb/rockstorewidecolumn$ cat rockstorewidecolumn.log | grep 'use new timeout to fail fast: 10ms' -B 1000 | grep 'Failed to receive ack from follower' | wc -l
100
```

In degradation mode, timeout is 10ms, and we can see from below, average request latency is 13ms (the `adhoc.py` scripts simply issues 1000 requests in sequential)
```
root@dev-jzhan:/mnt/pinboard/tools/rocksplicator/scripts# python adhoc.py
KVStoreGetRowsResponse(rowResponses=[KVStoreGetSingleRowResponse(status=Status(statusCode=0, statusMsg=None), row=Row(key=b'1', items=[Item(column='col', data=None, timestamp=None, itemStatus=Status(statusCode=0, statusMsg=None), values=[CellValue(data=b'11', timestamp=1649737293925)])], columnContinuation=None)), KVStoreGetSingleRowResponse(status=Status(statusCode=0, statusMsg=None), row=Row(key=b'2', items=[Item(column='col', data=None, timestamp=None, itemStatus=Status(statusCode=0, statusMsg=None), values=[CellValue(data=b'2222', timestamp=1649737293926)])], columnContinuation=None))])
13288
```

[**Recovery**] Bring back one replica, and we can see the DB exits the degradation mode:
```
E0412 04:21:33.936885  5265 replicated_db.cpp:152] Failed to receive ack from follower, timing out for jzhan_rw_test00050
I0412 04:22:20.511140  5265 replicated_db.cpp:172] 2-ACK Write succeeded, exit degradation mode and switch to use normal replicator timeout: 1000ms
E0412 04:22:22.457592  5122 file_watcher.cpp:166] File removed or unmounted: /data/xvdb/rocksplicator/zkshardmap/rockstorewidecolumndev-rw-wc-beta-test
```

Now request all go through quickly (4ms on average)
```
root@dev-jzhan:/mnt/pinboard/tools/rocksplicator/scripts# python adhoc.py
KVStoreGetRowsResponse(rowResponses=[KVStoreGetSingleRowResponse(status=Status(statusCode=0, statusMsg=None), row=Row(key=b'1', items=[Item(column='col', data=None, timestamp=None, itemStatus=Status(statusCode=0, statusMsg=None), values=[CellValue(data=b'11', timestamp=1649737877360)])], columnContinuation=None)), KVStoreGetSingleRowResponse(status=Status(statusCode=0, statusMsg=None), row=Row(key=b'2', items=[Item(column='col', data=None, timestamp=None, itemStatus=Status(statusCode=0, statusMsg=None), values=[CellValue(data=b'2222', timestamp=1649737877361)])], columnContinuation=None))])
4539
```

Also see metrics that are added in this PR: https://statsboard.pinadmin.com/share/2sqdr

