### PR TITLE
[EASY] Fix use after free in parseConfig

### DIFF
--- a/common/tests/parse_config_test.cpp
+++ b/common/tests/parse_config_test.cpp
@@ -1,0 +1,45 @@
+#include <atomic>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "common/thrift_router.h"
+
+static const char* g_config_v1 =
+  "{"
+  "  \"a\": {"
+  "  \"num_leaf_segments\": 1,"
+  "  \"127.0.0.1:8090\": [\"00000\"]"
+  "   },"
+  "  \"b\": {"
+  "  \"num_leaf_segments\": 1,"
+  "  \"127.0.0.1:8090\": [\"00000\"]"
+  "   }"
+  "}";
+
+
+// This test requires ASAN enabled to function correctly
+TEST(ParseConfigTest, TestUseAfterFree) {
+    auto result = common::parseConfig(g_config_v1, "");
+    for(auto& segment: result->segments) {
+      for(auto& shard_hosts: segment.second.shard_to_hosts) {
+        for(auto& host: shard_hosts) {
+          auto* hostPtr = host.first;
+          EXPECT_EQ(hostPtr->addr.describe(), "127.0.0.1:8090");
+          EXPECT_EQ(hostPtr->groups_prefix_lengths.size(), 2);
+        }
+      }
+    }
+}
+
+int main(int argc, char** argv) {
+  FLAGS_always_prefer_local_host = false;
+  ::testing::InitGoogleTest(&argc, argv);
+  FLAGS_channel_cleanup_min_interval_seconds = -1;
+  return RUN_ALL_TESTS();
+}

--- a/common/tests/parse_config_test.cpp
+++ b/common/tests/parse_config_test.cpp
@@ -23,8 +23,16 @@ static const char* g_config_v1 =
   "}";
 
 
-// This test requires ASAN enabled to function correctly
 TEST(ParseConfigTest, TestUseAfterFree) {
+    /*
+    This test was originally introduced to test for use after free in common::parseConfig
+    Since use after free produces undefined behavior, sometimes it may work sometimes it
+    doesn't for example: 
+    - In rocksplicator repo using cmake this test will succeed because newly allocated data will use same memory as freed data for set datastructure.
+    - In cosmos this test will fail
+
+    If you enable asan in cosmos this test will fail and show the use after free.
+    */
     auto result = common::parseConfig(g_config_v1, "");
     for(auto& segment: result->segments) {
       for(auto& shard_hosts: segment.second.shard_to_hosts) {

--- a/common/thrift_router.cpp
+++ b/common/thrift_router.cpp
@@ -134,8 +134,9 @@ std::unique_ptr<const detail::ClusterLayout> parseConfig(
         }
         auto host_iter = cl->all_hosts.find(host);
         if (host_iter != cl->all_hosts.end()) {
-          // const_cast: I promise not to touch the variables used for sorting..we should refactor all_hosts to be a map
-          // instead of a set for this purpose..since set will always return const ref
+          // const_cast was introduced here because std::set iterator will always return a const value in order to prevent
+          // the user from modifying the comparison variables which is avoided.
+          // TODO(meariby): clean this up and use std::map instead keyed on the host identifier.
           auto& mapRef = const_cast<std::unordered_map<std::string, uint16_t>&>((*host_iter).groups_prefix_lengths);
           mapRef.insert(host.groups_prefix_lengths.begin(), host.groups_prefix_lengths.end());
           pHost = &(*host_iter);

--- a/common/thrift_router.cpp
+++ b/common/thrift_router.cpp
@@ -125,21 +125,26 @@ std::unique_ptr<const detail::ClusterLayout> parseConfig(
           host_port_group == SHARD_NUM_STRs[1]) {
         continue;
       }
-
-      detail::Host host;
-      if (!parseHost(host_port_group, &host, segment, local_group)) {
-        LOG(ERROR) << "Invalid host port group " << host_port_group;
-        return nullptr;
+      const detail::Host* pHost = nullptr;
+      {
+        detail::Host host;
+        if (!parseHost(host_port_group, &host, segment, local_group)) {
+          LOG(ERROR) << "Invalid host port group " << host_port_group;
+          return nullptr;
+        }
+        auto host_iter = cl->all_hosts.find(host);
+        if (host_iter != cl->all_hosts.end()) {
+          // const_cast: I promise not to touch the variables used for sorting..we should refactor all_hosts to be a map
+          // instead of a set for this purpose..since set will always return const ref
+          auto& mapRef = const_cast<std::unordered_map<std::string, uint16_t>&>((*host_iter).groups_prefix_lengths);
+          mapRef.insert(host.groups_prefix_lengths.begin(), host.groups_prefix_lengths.end());
+          pHost = &(*host_iter);
+        } else {
+          auto insertRecord = cl->all_hosts.insert(std::move(host));
+          pHost = &(*insertRecord.first);
+        }
       }
-      auto host_iter = cl->all_hosts.find(host);
-      if (host_iter != cl->all_hosts.end()) {
-        host.groups_prefix_lengths.insert(
-                host_iter->groups_prefix_lengths.begin(),
-                host_iter->groups_prefix_lengths.end());
-        cl->all_hosts.erase(host_iter);
-      }
-      cl->all_hosts.insert(std::move(host));
-      const detail::Host* pHost = &*(cl->all_hosts.find(host));
+      CHECK(pHost != nullptr);
       const auto& shard_list = segment_value[host_port_group];
       // for each shard
       for (Json::ArrayIndex i = 0; i < shard_list.size(); ++i) {


### PR DESCRIPTION
This change fixes a problem in current code of parseConfig which might cause corruption in the shardmap, see comments starting with ERROR for explanation

```
std::unique_ptr<const detail::ClusterLayout> parseConfig(
    const std::string& content, const std::string& local_group) {
  auto cl = std::make_unique<detail::ClusterLayout>();
  ...
  for (const auto& segment : root.getMemberNames()) {
    // for each segment
    for (const auto& host_port_group : segment_value.getMemberNames()) {
      // for host
      detail::Host host; // Allocates a new host
      if (!parseHost(host_port_group, &host, segment, local_group)) {
        LOG(ERROR) << "Invalid host port group " << host_port_group;
        return nullptr;
      }
      auto host_iter = cl->all_hosts.find(host);
      if (host_iter != cl->all_hosts.end()) {
        host.groups_prefix_lengths.insert(
                host_iter->groups_prefix_lengths.begin(),
                host_iter->groups_prefix_lengths.end());
        cl->all_hosts.erase(host_iter);  // If similar host exists in map delete it
      }
      cl->all_hosts.insert(std::move(host)); // replace it by current host
      const detail::Host* pHost = &*(cl->all_hosts.find(host)); // ERROR: reuse same host object after move (undefined behavior)
      const auto& shard_list = segment_value[host_port_group];
      // for each shard
      for (Json::ArrayIndex i = 0; i < shard_list.size(); ++i) {
        const auto& shard = shard_list[i];
        ...
        std::pair<const detail::Host*, detail::Role> p;
        p.first = pHost; // ERROR: Uses the host pointer pointing to the object in the map which may be erased in later iteration (undefined behavior)
```

To verify this I have created a unit test and ran it with ASAN In cosmos and added loglines for explaining when an Host object is created/destroyed based on its memory address


Log output:
```
I0415 17:10:46.586014   468 thrift_router.cpp:163] Storing 106515189095456 to a : 0
I0415 17:10:46.586161   468 thrift_router.h:58] Destroying host at 106515189095456
I0415 17:10:46.586225   468 thrift_router.cpp:140] Deleting 106515189095456 (Destroying the object used by a)
I0415 17:10:46.586302   468 thrift_router.cpp:163] Storing 106515189095680 to b : 0
``` 
```
SUMMARY: AddressSanitizer: heap-use-after-free /usr/include/c++/8/bits/hashtable.h:523 in std::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, unsigned short>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, unsigned short> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::size() const
```

To reproduce test results do this

Add this to cosmos/thirdparty/rocksplicator/BUILD
```
simple_cc_test(
    name = "parse_config_test",
    srcs = [
        "rocksplicator/common/tests/parse_config_test.cpp",
    ],
    deps = [
        ":common",
        "//third_party:gtest_main",
        "//third_party:gmock",
        "//common:jsoncpp",
    ],
    linkopts = [
        "-lgflags",
    ],
)
```

Add this to cosmos .bazelrc
```
build:asan --strip=never
build:asan --copt -fsanitize=address
build:asan --copt -DADDRESS_SANITIZER
build:asan --copt -O1
build:asan --copt -g
build:asan --copt -fno-omit-frame-pointer
build:asan --linkopt -fsanitize=address
```

Run
```
./tools/bazel18.sh test //third_party/rocksplicator:thrift_router_test --config=asan --compilation_mode=dbg
```