### PR TITLE
LeaderFollowerStateModelFactory: fix NPE when accessing stateMap

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
@@ -212,7 +212,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
         // sanity check no existing Leader for up to 59 seconds
         for (int i = 0; i < 60; ++i) {
           view = admin.getResourceExternalView(cluster, resourceName);
-          stateMap = view.getStateMap(partitionName);
+          stateMap = Utils.getStateMap(view, partitionName);
 
           if (!stateMap.containsValue("LEADER")) {
             break;
@@ -313,7 +313,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
         LOG.error("[" + dbName + "] Getting external view");
         view = Utils.getHelixExternalViewWithFixedRetry(admin, cluster, resourceName);
         LOG.error("[" + dbName + "] Got external view");
-        stateMap = view.getStateMap(partitionName);
+        stateMap = Utils.getStateMap(view, partitionName);
         // changeDBRoleAndUpStream(all_other_followers_or_offlines, "Follower", "my_ip_port")
         for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
           String[] hostPort = instanceNameAndRole.getKey().split("_");
@@ -386,7 +386,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
     public String getLeaderInstance(NotificationContext context) {
       HelixAdmin admin = context.getManager().getClusterManagmentTool();
       ExternalView view = Utils.getHelixExternalViewWithFixedRetry(admin, cluster, resourceName);
-      Map<String, String> stateMap = view.getStateMap(partitionName);
+      Map<String, String> stateMap = Utils.getStateMap(view, partitionName);
       for (Map.Entry<String, String> instanceNameAndRole : stateMap.entrySet()) {
         if (instanceNameAndRole.getValue().equalsIgnoreCase("LEADER")) {
           return instanceNameAndRole.getKey();
@@ -398,7 +398,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
     public Map<String, String> getLiveHostAndRole(NotificationContext context, String dbName) {
       HelixAdmin admin = context.getManager().getClusterManagmentTool();
       ExternalView view = Utils.getHelixExternalViewWithFixedRetry(admin, cluster, resourceName);
-      Map<String, String> stateMap = view.getStateMap(partitionName);
+      Map<String, String> stateMap = Utils.getStateMap(view, partitionName);
 
       // find live replicas
       Map<String, String> liveHostAndRole = new HashMap<>();
@@ -662,7 +662,7 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
         // "live_leader_or_follower")
         HelixAdmin admin = context.getManager().getClusterManagmentTool();
         ExternalView view = Utils.getHelixExternalViewWithFixedRetry(admin, cluster, resourceName);
-        Map<String, String> stateMap = view.getStateMap(partitionName);
+        Map<String, String> stateMap = Utils.getStateMap(view, partitionName);
 
         // find upstream which is not me, and prefer leader
         String upstream = null;

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -110,6 +110,10 @@ public class Utils {
     if (partitionName == null || partitionName.isEmpty()) {
       return Collections.emptyMap();
     }
+    
+    if (view == null) {
+      return Collections.emptyMap();
+    }
 
     Map<String, String> result = view.getStateMap(partitionName);
     if (result == null) {

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -50,6 +50,7 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -97,6 +98,25 @@ public class Utils {
 
     LOG.error("Failed to obtain external view for resource {} in cluster {} after {} retries", resourceName, clusterName, maxRetries);
     return null;
+  }
+
+   /**
+   * Obtain the state map of a partition in the external view
+   * @param view Helix external view for a resource
+   * @param partitionName partition name to look up
+   * @return StateMap, which will be empty if the partition is not found, or there is no instance in the partition
+   */
+  public static Map<String, String> getStateMap(ExternalView view, String partitionName) {
+    if (partitionName == null || partitionName.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, String> result = view.getStateMap(partitionName);
+    if (result == null) {
+      return Collections.emptyMap();
+    }
+
+    return result;
   }
 
   /**


### PR DESCRIPTION
During failure testing (when 3 nodes of a shard is down briefly), we saw error shards with NPE:
```
Caused by: java.lang.NullPointerException
--
at com.pinterest.rocksplicator.LeaderFollowerStateModelFactory$LeaderFollowerStateModel.getLiveHostAndRole(LeaderFollowerStateModelFactory.java:407)
at com.pinterest.rocksplicator.LeaderFollowerStateModelFactory$LeaderFollowerStateModel.onBecomeFollowerFromOffline(LeaderFollowerStateModelFactory.java:449)
```
This is due to state map being `null` in helix external view, and our state transition logic doesn't check for null. 
Fixing this by wrapping the helix `getStateMap` to return an empty map (instead of `null`) when the partition state is empty. 

Note that this also introduced some behavior changes in some cases, e.g. in FOLLOWER->LEADER transition, what previously caused ERROR shard due to NPE, will now let the transition go through for availability purposes. Some comments are added during the review process of the PR. 

ref: https://jira.pinadmin.com/browse/KV-5445

Test Plan:
unit tests still pass with `mvn test`

Deployed a private build and verified:
- cluster works fine from stats (SR, latency, etc)
- failure testing: restarting 3 hosts for a shard at the same time, which previously caused the NPE bug and ERROR shard, but no more issue with this fix

