### PR TITLE
LeaderFollowerStateModelFactory: set rebuild WAL lag upper bound

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/LeaderFollowerStateModelFactory.java
@@ -637,6 +637,9 @@ public class LeaderFollowerStateModelFactory extends StateModelFactory<StateMode
       // do not trigger rebuild if the latest db update is within min(wal_ttl_seconds, 1h).
       // the 1h upper bound is to ensure we are not too lagging behind when catching up from upstream via replication,
       // since wal_ttl_seconds can be large.
+      // TODO: we hard-code the 1h upper bound because we have been using the default wal_ttl_seconds as 1h
+      // for years in production without ever having to change it, but we should evaluate it in the future
+      // based on the restore speed, and how much lagging behind we can tolerate when a follower goes online.
       long maxLogCatchupTimeSec = Math.min(localStatus.wal_ttl_seconds, 60*60 /* 1h */);
       if (System.currentTimeMillis() <
           localStatus.last_update_timestamp_ms + maxLogCatchupTimeSec * 1000) {


### PR DESCRIPTION
During FOLLOWER->LEADER state transition, follower may decide not to "rebuild" (restore from upstream snapshot) local db if its latest local db update is within the WAL TTL (default to 1h), i.e. that means newer updates have not been expired/deleted in the upstream, so it's able to catch up from replication RPC. 

However, WAL TTL can be arbitrary set, while we default it to 1h, application may increase it to be longer (e.g. 4h, or even a day).  In that case, we should probably trigger a rebuild if the follower is too lagging behind, since log catchup takes time. 

This PR proposes a simple change: regardless of the WAL TTL, we'll trigger rebuild if the local WAL is stale for more than one hour. We chose 1h as a starting point, because that's what the default WAL TTL is (so no production behavior change to existing applications that use the default WAL TTL), we may tune it in the future (e.g. further shrink it if our backup&restore path becomes more reliable)


ref: https://jira.pinadmin.com/browse/KV-5337