### PR TITLE
cluster_management: support an option to close admin client connection

### DIFF
--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -135,6 +135,9 @@ public class Utils {
 
   /**
    * Build a thrift client to host:adminPort
+   * Note this opens a socket underneath and doesn't close it. This would become a problem if 
+   * many admin clients are created on demand, causing connection leaking. 
+   * To properly close the connection, use getAdminClientOnSocket instead. 
    * @param host
    * @param adminPort
    * @return a client object
@@ -142,6 +145,18 @@ public class Utils {
    */
   public static Admin.Client getAdminClient(String host, int adminPort) throws TTransportException {
     TSocket sock = new TSocket(host, adminPort);
+    sock.open();
+    return new Admin.Client(new TBinaryProtocol(sock));
+  }
+
+   /**
+   * Open the provided TSocket and build a Admin thrift client on top of it for application usage.
+   * It's caller's responsibility to close the socket after usage. 
+   * @param sock user constructed TSocket
+   * @return an Admin client object
+   * @throws TTransportException 
+   */
+  public static Admin.Client getAdminClientOnSocket(TSocket sock) throws TTransportException {
     sock.open();
     return new Admin.Client(new TBinaryProtocol(sock));
   }
@@ -313,12 +328,15 @@ public class Utils {
   public static long getLatestSequenceNumber(String dbName, String host, int adminPort) {
     LOG.error("Get seq number from " + host + " for " + dbName);
     try {
-      Admin.Client client = getAdminClient(host, adminPort);
+      TSocket sock = new TSocket(host, adminPort);
+      Admin.Client client = getAdminClientOnSocket(sock);
 
       GetSequenceNumberRequest request = new GetSequenceNumberRequest(dbName);
       GetSequenceNumberResponse response = client.getSequenceNumber(request);
       LOG.error(
           "Seq number for " + dbName + " on " + host + ": " + String.valueOf(response.seq_num));
+      
+      sock.close();
       return response.seq_num;
     } catch (TException e) {
       LOG.error("Failed to get sequence number for " + dbName, e);

--- a/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
+++ b/cluster_management/src/main/java/com/pinterest/rocksplicator/Utils.java
@@ -331,13 +331,16 @@ public class Utils {
       TSocket sock = new TSocket(host, adminPort);
       Admin.Client client = getAdminClientOnSocket(sock);
 
-      GetSequenceNumberRequest request = new GetSequenceNumberRequest(dbName);
-      GetSequenceNumberResponse response = client.getSequenceNumber(request);
-      LOG.error(
-          "Seq number for " + dbName + " on " + host + ": " + String.valueOf(response.seq_num));
-      
-      sock.close();
-      return response.seq_num;
+      try {
+        GetSequenceNumberRequest request = new GetSequenceNumberRequest(dbName);
+        GetSequenceNumberResponse response = client.getSequenceNumber(request);
+        LOG.error(
+            "Seq number for " + dbName + " on " + host + ": " + String.valueOf(response.seq_num));
+        return response.seq_num;
+      } finally {
+        // ensure the socket is closed when the request is completed (regardless of success or failure)
+        sock.close();
+      }
     } catch (TException e) {
       LOG.error("Failed to get sequence number for " + dbName, e);
       return -1;


### PR DESCRIPTION
The current `getAdminClient` creates a Admin thrift client for various usage during state transition or 
even during runtime (e.g. in `PartitionStateUpdater`). Under the hood it opens a TCP socket which the
thrift client uses to establish connections. 

The socket is not closed after usage, which could be problematic, if there are a large number of admin clients
used. This is the case for the usage in `PartitionStateUpdater`, which schedules all leader partitions in a process
to retrieve local db state (via admin client) every few minutes. Eventually, we see process crash or run into failing state where it exhausted the socket count. 

This PR proposes a simple fix: provide a new `getAdminClientOnSocket` to asks the caller to provide the socket
and hence let the caller know they should be responsible for closing the socket. 

Test plan:
mvn test still work
tested in a private build, among many other tests, please see an [internal doc](https://docs.google.com/document/d/11-ybbeTkZsbw3QH4RIfpH9seHcP5rkbWzbAaguGAy2o/edit#) for detailed investigation and validation. 