### PR TITLE
rocksdb_replicator: do not count observer replication ACK

### DIFF
--- a/rocksdb_replicator/replicator_stats.cpp
+++ b/rocksdb_replicator/replicator_stats.cpp
@@ -76,6 +76,8 @@ const std::string kReplicatorPullFromNonLeader = "replicator_pull_from_non_leade
 const std::string kReplicatorPullLatency = "replicator_pull_latency";
 const std::string kReplicatorHandleResponseFailure = "replicator_handle_response_failure";
 const std::string kReplicatorResetUpstreamOnNoUpdates = "replicator_reset_upstream_on_no_updates_attempted";
+const std::string kReplicatorHandleObserverRequests = "replicator_handle_observer_requests";
+
 
 void logMetric(const std::string& metric_name, int64_t value,
                const std::string& db_name) {

--- a/rocksdb_replicator/replicator_stats.h
+++ b/rocksdb_replicator/replicator_stats.h
@@ -59,6 +59,7 @@ extern const std::string kReplicatorPullFromNonLeader;
 extern const std::string kReplicatorPullLatency;
 extern const std::string kReplicatorHandleResponseFailure;
 extern const std::string kReplicatorResetUpstreamOnNoUpdates;
+extern const std::string kReplicatorHandleObserverRequests;
 
 // add value to metric_name. If db_name is not empty, add value to the per db
 // metric also


### PR DESCRIPTION
On replication mode TWO (2-ack mode), upon writes, the leader will need to wait for at least 
one follower to receive the update, before returning successfully to to the client. Currently it does so by tracking the `max_seq_no_acked_` which is the maximum ACK-ed sequence number from **any** replication requests. That's problematic, because the replication requests could come from either `FOLLOWER` or `OBSERVER`.  See https://github.com/pinterest/rocksplicator/pull/601 where we introduced the `OBSERVER` role.

This PR corrects that behavior, specifically, on the FOLLOWER/OBSERVER side, set the `role` in each replication request, and on the leader side, do not count OBSERVER sequence number when updating `max_seq_no_acked_`. Log a counter for visibility in that case. 


-- test plan -- 
Added unit test to verify the behavior. Will also try to deploy a test build to confirm. 