### PR TITLE
Deprecates support for Ubuntu 14

### DIFF
--- a/common/aws_s3_rate_limiter.h
+++ b/common/aws_s3_rate_limiter.h
@@ -20,11 +20,7 @@
 
 #include "aws/core/utils/ratelimiter/RateLimiterInterface.h"
 
-#if __GNUC__ >= 8
 #include "folly/synchronization/AtomicStruct.h"
-#else
-#include "folly/AtomicStruct.h"
-#endif
 
 #include "glog/logging.h"
 

--- a/common/concurrent_rate_limiter.h
+++ b/common/concurrent_rate_limiter.h
@@ -18,12 +18,7 @@
 
 #pragma once
 
-#if __GNUC__ >= 8
 #include "folly/synchronization/AtomicStruct.h"
-#else
-#include "folly/AtomicStruct.h"
-#endif
-
 #include "glog/logging.h"
 
 namespace common {

--- a/common/file_watcher.cpp
+++ b/common/file_watcher.cpp
@@ -20,15 +20,8 @@
 #include "common/stats/stats.h"
 
 #include <folly/FileUtil.h>
-
-#if __GNUC__ >= 8
 #include <folly/hash/SpookyHashV2.h>
 #include <folly/system/ThreadName.h>
-#else
-#include <folly/SpookyHashV2.h>
-#include <folly/ThreadName.h>
-#endif
-
 #include <sys/inotify.h>
 
 #include <string>

--- a/common/file_watcher.h
+++ b/common/file_watcher.h
@@ -106,11 +106,7 @@ class FileWatcher {
 
   struct INotifyHandler : public folly::EventHandler {
     INotifyHandler(folly::EventBase* evb, int fd, FileWatcher* watcher)
-#if __GNUC__ >= 8
         : folly::EventHandler(evb, folly::NetworkSocket(fd))
-#else
-        : folly::EventHandler(evb, fd)
-#endif
         , watcher_(watcher) {
     }
 

--- a/common/future_util.cpp
+++ b/common/future_util.cpp
@@ -21,12 +21,7 @@
 #include <gflags/gflags.h>
 
 #include "common/global_cpu_executor.h"
-
-#if __GNUC__ >= 8
 #include "folly/executors/CPUThreadPoolExecutor.h"
-#else
-#include "wangle/concurrent/CPUThreadPoolExecutor.h"
-#endif
 
 
 DEFINE_bool(delayed_future_with_cpu_executor, false,
@@ -35,11 +30,7 @@ DEFINE_bool(delayed_future_with_cpu_executor, false,
 namespace common {
 
 folly::Future<folly::Unit> GenerateDelayedFuture(folly::Duration delay) {
-#if __GNUC__ >= 8
   auto future = folly::futures::sleepUnsafe(delay);
-#else
-  auto future = folly::futures::sleep(delay);
-#endif
 
   if (FLAGS_delayed_future_with_cpu_executor) {
     future = future.via(common::getGlobalCPUExecutor());

--- a/common/global_cpu_executor.cpp
+++ b/common/global_cpu_executor.cpp
@@ -20,13 +20,8 @@
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-
 #include "common/identical_name_thread_factory.h"
-#if __GNUC__ >= 8
 #include "folly/executors/CPUThreadPoolExecutor.h"
-#else
-#include "wangle/concurrent/CPUThreadPoolExecutor.h"
-#endif
 
 DEFINE_int32(global_worker_threads, sysconf(_SC_NPROCESSORS_ONLN),
              "The number of threads for global CPU executor.");
@@ -40,15 +35,9 @@ DEFINE_bool(block_on_global_cpu_pool_full, true,
 DEFINE_string(global_cpu_thread_pool_name, "g-cpu-pool",
               "The name for threads in the global cpu pool");
 
-#if __GNUC__ >= 8
 using folly::CPUThreadPoolExecutor;
 using folly::LifoSemMPMCQueue;
 using folly::QueueBehaviorIfFull;
-#else
-using wangle::CPUThreadPoolExecutor;
-using wangle::LifoSemMPMCQueue;
-using wangle::QueueBehaviorIfFull;
-#endif
 
 namespace {
 

--- a/common/global_cpu_executor.h
+++ b/common/global_cpu_executor.h
@@ -18,11 +18,7 @@
 
 #pragma once
 
-#if __GNUC__ >= 8
 namespace folly {
-#else
-namespace wangle {
-#endif
 
 class CPUThreadPoolExecutor;
 
@@ -37,10 +33,6 @@ namespace common {
  * GFlag of thread count. In case that happens, we will fallback to use the
  * number of cores as the thread pool size.
  */
-#if __GNUC__ >= 8
 folly::CPUThreadPoolExecutor* getGlobalCPUExecutor();
-#else
-wangle::CPUThreadPoolExecutor* getGlobalCPUExecutor();
-#endif
 
 }  // namespace common

--- a/common/identical_name_thread_factory.h
+++ b/common/identical_name_thread_factory.h
@@ -21,21 +21,12 @@
 #include <string>
 #include <thread>
 
-#if __GNUC__ >= 8
 #include "folly/executors/thread_factory/ThreadFactory.h"
 #include "folly/system/ThreadName.h"
-#else
-#include "folly/ThreadName.h"
-#include "wangle/concurrent/ThreadFactory.h"
-#endif
 
 namespace common {
 
-#if __GNUC__ >= 8
 class IdenticalNameThreadFactory : public folly::ThreadFactory {
-#else
-class IdenticalNameThreadFactory : public wangle::ThreadFactory {
-#endif
  public:
   explicit IdenticalNameThreadFactory(const std::string& name)
     : name_(name) {}

--- a/common/object_lock.h
+++ b/common/object_lock.h
@@ -19,11 +19,7 @@
 #pragma once
 
 #include <boost/intrusive/list.hpp>
-#if __GNUC__ >= 8
 #include <folly/concurrency/CacheLocality.h>
-#else
-#include <folly/detail/CacheLocality.h>
-#endif
 #include <folly/MPMCQueue.h>
 #include <cstddef>
 #include <functional>
@@ -50,13 +46,8 @@ class ObjectLock {
   };
 
   struct Bucket {
-#if __GNUC__ >= 8
     alignas(folly::hardware_destructive_interference_size) MutexType bucketMutex;
     alignas(folly::hardware_destructive_interference_size) boost::intrusive::list<Node> nodes;
-#else
-    MutexType bucketMutex FOLLY_ALIGN_TO_AVOID_FALSE_SHARING;
-    boost::intrusive::list<Node> nodes FOLLY_ALIGN_TO_AVOID_FALSE_SHARING;
-#endif
 
     template <typename ALLOC>
     void Lock(const ObjectType& object, ALLOC&& alloc) {

--- a/common/safe_future_client.h
+++ b/common/safe_future_client.h
@@ -28,12 +28,8 @@
 #include "folly/futures/Future.h"
 #include "folly/futures/Promise.h"
 #include "folly/io/async/EventBase.h"
-#if __GNUC__ >= 8
 #include "folly/executors/task_queue/BlockingQueue.h"
 #include "folly/executors/CPUThreadPoolExecutor.h"
-#else
-#include "wangle/concurrent/CPUThreadPoolExecutor.h"
-#endif
 
 namespace common {
 
@@ -117,11 +113,7 @@ class SafeFutureClient {
 
           try {
             common::getGlobalCPUExecutor()->add(std::move(process_response_op));
-#if __GNUC__ >= 8
           } catch (const folly::QueueFullException& e) {
-#else
-          } catch (const wangle::QueueFullException& e) {
-#endif
             // If add() throws, process_response_op is ok to use here.
             // Remember that std::move() is just a typecast that doesn't
             // actually move anything. And Executor won't consume it if add()
@@ -176,11 +168,7 @@ class SafeFutureClient {
     common::Timer timer(RequestTraits<T>::response_processing_metric_name);
 
     if (recvState->isException()) {
-#if __GNUC__ >= 8
       p->setException(recvState->exception());
-#else
-      p->setException(recvState->exceptionWrapper());
-#endif
       return;
     }
 

--- a/common/ssl_context_manager.cpp
+++ b/common/ssl_context_manager.cpp
@@ -58,11 +58,7 @@ std::shared_ptr<folly::SSLContext> loadSSLContext() {
 void scheduleRefresh(std::shared_ptr<folly::SSLContext>* cur_ctx) {
   auto delayed_future =
     common::GenerateDelayedFuture(std::chrono::seconds(60 * 60));
-#if __GNUC__ >= 8
   std::move(delayed_future).then([cur_ctx] (auto&&) {
-#else
-  delayed_future.then([cur_ctx] () {
-#endif
       auto new_ctx = loadSSLContext();
       if (new_ctx) {
         LOG(INFO) << "Got a new SSLContext, swapping";

--- a/common/stats/stats.h
+++ b/common/stats/stats.h
@@ -64,12 +64,7 @@
 
 #pragma once
 
-#if __GNUC__ >= 8
 #include <folly/concurrency/CacheLocality.h>
-#else
-#include <folly/detail/CacheLocality.h>
-#endif
-
 #include <folly/ThreadLocal.h>
 #include <folly/stats/Histogram.h>
 #include <folly/stats/MultiLevelTimeSeries.h>

--- a/common/stats/status_server.cpp
+++ b/common/stats/status_server.cpp
@@ -181,22 +181,14 @@ std::string StatusServer::GetPageContent(const std::string& end_point, Arguments
   // Note: folly:Uri is not thread-safe!
   folly::Uri u("http://blah.blah" + end_point);
 
-#if __GNUC__ >= 8
   auto iter = op_map_.find(u.path());
-#else
-  auto iter = op_map_.find(u.path().toStdString());
-#endif
   if (iter == op_map_.end()) {
     return "Unsupported http path: " + end_point + "!\n";
   }
 
   auto params = u.getQueryParams();
   for (const auto& p : params) {
-#if __GNUC__ >= 8
     args->emplace_back(p.first, p.second);
-#else
-    args->emplace_back(p.first.toStdString(), p.second.toStdString());
-#endif
   }
 
   return iter->second(args);

--- a/common/thrift_client_pool.h
+++ b/common/thrift_client_pool.h
@@ -27,9 +27,7 @@
 #include <vector>
 
 #include "folly/futures/Promise.h"
-#if __GNUC__ >= 8
 #include "folly/system/ThreadName.h"
-#endif
 #include "folly/io/async/EventBase.h"
 #include "folly/io/async/SSLContext.h"
 #include "folly/Demangle.h"
@@ -277,11 +275,9 @@ class ThriftClientPool {
         if (FLAGS_channel_enable_snappy) {
           channel->setTransform(apache::thrift::transport::THeader::SNAPPY_TRANSFORM);
         }
-#if __GNUC__ >= 8
         if (FLAGS_channel_enable_zstd) {
           channel->setTransform(apache::thrift::transport::THeader::ZSTD_TRANSFORM);
         }
-#endif
         if (USE_BINARY_PROTOCOL) {
           channel->setProtocolId(apache::thrift::protocol::T_BINARY_PROTOCOL);
           if (FLAGS_use_framed_transport_for_binary_protocol) {

--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -57,12 +57,8 @@
 #include "rocksdb_replicator/rocksdb_replicator.h"
 #include "rocksdb_replicator/thrift/gen-cpp2/Replicator.h"
 #include "thrift/lib/cpp2/protocol/Serializer.h"
-#if __GNUC__ >= 8
 #include "folly/executors/CPUThreadPoolExecutor.h"
 #include "folly/system/ThreadName.h"
-#else
-#include "wangle/concurrent/CPUThreadPoolExecutor.h"
-#endif
 
 DEFINE_string(hdfs_name_node, "hdfs://hbasebak-infra-namenode-prod1c01-001:8020",
               "The hdfs name node used for backup");
@@ -134,15 +130,9 @@ DEFINE_int32(async_delete_dbs_wait_sec,
              60,
              "How long in sec to wait between the dbs deletion");
 
-#if __GNUC__ >= 8
 using folly::CPUThreadPoolExecutor;
 using folly::LifoSemMPMCQueue;
 using folly::QueueBehaviorIfFull;
-#else
-using wangle::CPUThreadPoolExecutor;
-using wangle::LifoSemMPMCQueue;
-using wangle::QueueBehaviorIfFull;
-#endif
 
 namespace {
 

--- a/rocksdb_replicator/cached_iter_cleaner.cpp
+++ b/rocksdb_replicator/cached_iter_cleaner.cpp
@@ -17,11 +17,7 @@
 //
 
 #include <folly/io/async/EventBase.h>
-#if __GNUC__ >= 8
 #include "folly/system/ThreadName.h"
-#else
-#include <folly/ThreadName.h>
-#endif
 #include <gflags/gflags.h>
 
 #include "rocksdb_replicator/rocksdb_replicator.h"

--- a/rocksdb_replicator/non_blocking_condition_variable.h
+++ b/rocksdb_replicator/non_blocking_condition_variable.h
@@ -110,11 +110,7 @@ class NonBlockingConditionVariable {
       // we may accumulate some unnecessary tasks if they have run before the
       // timeout.
       std::weak_ptr<Task> weak_task(task);
-#if __GNUC__ >= 8
       auto future = folly::futures::sleepUnsafe(std::chrono::milliseconds(timeout_ms));
-#else
-      auto future = folly::futures::sleep(std::chrono::milliseconds(timeout_ms));
-#endif
       std::move(future).then([weak_task = std::move(weak_task), executor = executor_] (folly::Try<folly::Unit>&& t) {
           auto task = weak_task.lock();
           if (task && task->should_i_run()) {

--- a/rocksdb_replicator/replicated_db.cpp
+++ b/rocksdb_replicator/replicated_db.cpp
@@ -335,11 +335,7 @@ void RocksDBReplicator::ReplicatedDB::pullFromUpstream() {
           incCounter(kReplicatorPullRequestsFailure, 1, db->db_name_);
           delay_next_pull = true;
           try {
-#if __GNUC__ >= 8
             t.exception().throw_exception();
-#else
-            t.exception().throwException();
-#endif
           } catch (const ReplicateException& ex) {
             LOG(ERROR) << "ReplicateException: upstream = " << common::getNetworkAddressStr(db->upstream_addr_) << ", code = " << static_cast<int>(ex.code)
                        << ", message = " << ex.msg;

--- a/rocksdb_replicator/replicator_handler.cpp
+++ b/rocksdb_replicator/replicator_handler.cpp
@@ -20,11 +20,7 @@
 
 namespace replicator {
 
-#if __GNUC__ >= 8
 void ReplicatorHandler::async_tm_replicate(
-#else
-void ReplicatorHandler::async_eb_replicate(
-#endif
     std::unique_ptr<apache::thrift::HandlerCallback<
       std::unique_ptr<ReplicateResponse>>> callback,
     std::unique_ptr<ReplicateRequest> request) {

--- a/rocksdb_replicator/replicator_handler.h
+++ b/rocksdb_replicator/replicator_handler.h
@@ -33,11 +33,7 @@ class ReplicatorHandler : public ReplicatorSvIf {
 
   explicit ReplicatorHandler(DBMapType* db_map) : db_map_(db_map) {}
 
-#if __GNUC__ >= 8
   void async_tm_replicate(
-#else
-  void async_eb_replicate(
-#endif
       std::unique_ptr<apache::thrift::HandlerCallback<
         std::unique_ptr<ReplicateResponse>>> callback,
       std::unique_ptr<ReplicateRequest> request) override;

--- a/rocksdb_replicator/rocksdb_replicator.h
+++ b/rocksdb_replicator/rocksdb_replicator.h
@@ -42,11 +42,7 @@ namespace folly {
   class Executor;
 }
 
-#if __GNUC__ >= 8
 namespace folly {
-#else
-namespace wangle {
-#endif
   class CPUThreadPoolExecutor;
 }
 
@@ -237,11 +233,7 @@ class RocksDBReplicator {
   RocksDBReplicator();
   ~RocksDBReplicator();
 
-#if __GNUC__ >= 8
   std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
-#else
-  std::unique_ptr<wangle::CPUThreadPoolExecutor> executor_;
-#endif
 
   common::ThriftClientPool<ReplicatorAsyncClient> client_pool_;
 


### PR DESCRIPTION
[rocksplicator](https://github.com/pinterest/rocksplicator) has conditional code that depends on `__GNUC__`, the major version of GCC used for compiling the code.  This was introduced for the Ubuntu 14 => Ubuntu 18 migration, as 14 and 18 use different GCC versions.

Per discussion with Bo Liu, the U14 code path is no longer used and can be cleaned up.

Why now: Pinterest is evaluating Clang as an alternative compiler.  The latest Clang (v14) defines `__GNUC__` as 4, since it's compatible with GCC 4.  Therefore, when rocksplicator is compiled with Clang, the U14 code path is incorrectly picked, which doesn't compile in the U18 environment.  I discussed this with Bo Liu and we decided that it's time to remove the U14 code path.