### PR TITLE
Add support for passing db name to rocksdb options generator

### DIFF
--- a/examples/counter_service/counter_handler.h
+++ b/examples/counter_service/counter_handler.h
@@ -33,7 +33,7 @@ class CounterHandler
  public:
   CounterHandler(
     std::unique_ptr<::admin::ApplicationDBManager> db_manager,
-    admin::RocksDBOptionsGeneratorType rocksdb_options,
+    admin::RocksDBOptionsGenerator rocksdb_options,
     std::unique_ptr<CounterRouter> router,
     rocksdb::WriteOptions write_options,
     rocksdb::ReadOptions read_options)

--- a/examples/counter_service/rocksdb_options.cpp
+++ b/examples/counter_service/rocksdb_options.cpp
@@ -106,7 +106,7 @@ rocksdb::Options __GetRocksdbOptions() {
 
 namespace counter {
 
-rocksdb::Options GetRocksdbOptions(const std::string& segment) {
+rocksdb::Options GetRocksdbOptions(const std::string& segment, const std::string& db) {
   static const rocksdb::Options options = __GetRocksdbOptions();
   return options;
 }

--- a/examples/counter_service/rocksdb_options.h
+++ b/examples/counter_service/rocksdb_options.h
@@ -27,6 +27,6 @@ namespace counter {
 /*
  * Get the rocksdb options used for segment name
  */
-rocksdb::Options GetRocksdbOptions(const std::string& segment);
+rocksdb::Options GetRocksdbOptions(const std::string& segment, const std::string& db);
 
 }  // namespace counter

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -45,11 +45,20 @@ namespace admin {
 using RocksDBOptionsGeneratorType =
   std::function<rocksdb::Options(const std::string&)>;
 
+using RocksDBOptionsGenerator = 
+  std::function<rocksdb::Options(const std::string&, const std::string&)>;
+
+
 class AdminHandler : virtual public AdminSvIf {
  public:
+  // TODO deprecate after getting rid of all callsites
   AdminHandler(
     std::unique_ptr<ApplicationDBManager> db_manager,
     RocksDBOptionsGeneratorType rocksdb_options);
+
+  AdminHandler(
+    std::unique_ptr<ApplicationDBManager> db_manager,
+    RocksDBOptionsGenerator rocksdb_options);
 
   virtual ~AdminHandler();
 
@@ -162,7 +171,7 @@ class AdminHandler : virtual public AdminSvIf {
                      const int64_t last_kafka_msg_timestamp_ms = -1);
 
   std::unique_ptr<ApplicationDBManager> db_manager_;
-  RocksDBOptionsGeneratorType rocksdb_options_;
+  RocksDBOptionsGenerator rocksdb_options_;
   // S3 util used for download
   std::shared_ptr<common::S3Util> s3_util_;
   // Lock for protecting the s3 util

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -808,7 +808,7 @@ TEST(AdminHandlerTest, MetaData) {
 
   auto db_manager = std::make_unique<admin::ApplicationDBManager>();
   admin::AdminHandler handler(std::move(db_manager),
-                              admin::RocksDBOptionsGeneratorType());
+                              admin::RocksDBOptionsGenerator());
 
   const std::string db_name = "test_db";
   const std::string s3_bucket = "test_bucket";


### PR DESCRIPTION
This diff adds support for passing db name to rocksdb options generator.
Since this change spans across multiple projects in cosmos I added a second constructor to make it less intrusive.
I can merge this change in cosmos and make another change to update everybody's rocksdb options to accept db name.
Reason db_name is useful is for logging shard specific stats in compaction filters for improved debugging experience.

For testing I ran

```
docker run -v /home/meariby/code/rocksplicator:/rocksplicator -v $HOME/docker-root:/root -ti gopalrajpurohit/rocksplicator-build:librdkafka_1_4_0 bash
cd /rocksplicator && mkdir -p build && cd build && cmake .. && make -j
cd /rocksplicator && mkdir -p build && cd build && cmake .. && make -j && make test
```

I will also make sure cosmos build with this change as-is as part of test plan.

Cosmos diff:
https://phabricator.pinadmin.com/D901271