### PR TITLE
rocksplicator EASY clean up s3 tmp upon startup

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -435,6 +435,10 @@ void deleteTmpDBs() {
   }
 }
 
+inline std::string getS3TmpPath() {
+  return FLAGS_rocksdb_dir + "s3_tmp/"; 
+}
+
 }  // anonymous namespace
 
 namespace admin {
@@ -503,6 +507,14 @@ AdminHandler::AdminHandler(
   // Initialize the atomic int variables
   num_current_s3_sst_downloadings_.store(0);
   num_current_s3_sst_uploadings_.store(0);
+  // All interactions with admin handler that involve s3_tmp folder will
+  // be called on the admin handler instance, these are
+  // 1) backupDbToS3
+  // 2) addS3SstFilesToDB
+  // 3) restoreDbFromS3
+  // thus no way they can be called before the handler instance 
+  // finishes construction.
+  initS3Tmp();
 }
 
 AdminHandler::~AdminHandler() {
@@ -969,7 +981,7 @@ void AdminHandler::async_tm_backupDBToS3(
   common::Timer timer(kS3BackupMs);
   LOG(INFO) << "S3 Backup " << request->db_name << " to " << request->s3_backup_dir;
   auto ts = common::timeutil::GetCurrentTimestamp();
-  auto local_path = folly::stringPrintf("%ss3_tmp/%s%d/", FLAGS_rocksdb_dir.c_str(), request->db_name.c_str(), ts);
+  auto local_path = folly::stringPrintf("%s%s%d/", getS3TmpPath(), request->db_name.c_str(), ts);
   boost::system::error_code remove_err;
   boost::system::error_code create_err;
   boost::filesystem::remove_all(local_path, remove_err);
@@ -1163,7 +1175,7 @@ void AdminHandler::async_tm_restoreDBFromS3(
 
   auto ts = common::timeutil::GetCurrentTimestamp();
   auto local_path = FLAGS_enable_checkpoint_backup ? FLAGS_rocksdb_dir + request->db_name :
-                    folly::stringPrintf("%ss3_tmp/%s%d/", FLAGS_rocksdb_dir.c_str(), request->db_name.c_str(), ts);
+                    folly::stringPrintf("%s%s%d/", getS3TmpPath(), request->db_name.c_str(), ts);
   boost::system::error_code remove_err;
   boost::system::error_code create_err;
   boost::filesystem::remove_all(local_path, remove_err);
@@ -1692,7 +1704,7 @@ void AdminHandler::async_tm_addS3SstFilesToDB(
     return;
   }
 
-  auto local_path = FLAGS_rocksdb_dir + "s3_tmp/" + request->db_name + "/";
+  auto local_path = getS3TmpPath() + request->db_name + "/";
   boost::system::error_code remove_err;
   boost::system::error_code create_err;
   boost::filesystem::remove_all(local_path, remove_err);
@@ -2180,6 +2192,14 @@ std::string AdminHandler::DumpDBStatsAsText() const {
 
 std::vector<std::string> AdminHandler::getAllDBNames() {
     return db_manager_->getAllDBNames();
+}
+
+void AdminHandler::initS3Tmp() {
+  auto s3_path = getS3TmpPath();
+  std::string error_message;
+  if(!ClearAndCreateDir(s3_path, &error_message)){
+    LOG(ERROR) << "Failed to clean and create directory: " << s3_path << ": " << error_message; 
+  }
 }
 
 }  // namespace admin

--- a/rocksdb_admin/admin_handler.h
+++ b/rocksdb_admin/admin_handler.h
@@ -210,6 +210,9 @@ class AdminHandler : virtual public AdminSvIf {
   std::shared_ptr<common::S3Util> createLocalS3Util(const uint32_t read_ratelimit_mb = 50,
                                                     const std::string& bucket = "");
 
+
+  void initS3Tmp();
+
   std::unique_ptr<std::thread> db_deletion_thread_;
   std::atomic<bool> stop_db_deletion_thread_;
 };

--- a/rocksdb_admin/tests/admin_handler_test.cpp
+++ b/rocksdb_admin/tests/admin_handler_test.cpp
@@ -92,14 +92,6 @@ DECLARE_string(rocksdb_dir);
 DECLARE_bool(enable_checkpoint_backup);
 DECLARE_bool(rocksdb_allow_overlapping_keys);
 
-void clearAndCreateDir(string dir_path) {
-  boost::system::error_code create_err;
-  boost::system::error_code remove_err;
-  fs::remove_all(dir_path, remove_err);
-  fs::create_directories(dir_path, create_err);
-  EXPECT_FALSE(remove_err || create_err);
-}
-
 string generateRandIntAsStr() {
   static thread_local unsigned int seed = time(nullptr);
   return to_string(rand_r(&seed));
@@ -147,8 +139,9 @@ class AdminHandlerTestBase : public testing::Test {
     FLAGS_s3_backup_prefix =
         FLAGS_s3_backup_prefix + testSessionIdAsStr() + "/";
 
-    LOG(INFO) << "Test start, clearAndCreateDir " << testDir();
-    clearAndCreateDir(testDir());
+    LOG(INFO) << "Test start, ClearAndCreateDir " << testDir();
+    std::string err;
+    EXPECT_TRUE(admin::ClearAndCreateDir(testDir(), &err));
 
     tie(handler_, server_, thread_, db_manager_) = makeServer(8090);
     sleep_for(seconds(1));
@@ -804,7 +797,8 @@ TEST_F(AdminHandlerTestBase, CheckDB) {
 
 TEST(AdminHandlerTest, MetaData) {
   FLAGS_rocksdb_dir = "/tmp/admin_handler_test/";
-  clearAndCreateDir(FLAGS_rocksdb_dir);
+  std::string err;
+  EXPECT_TRUE(admin::ClearAndCreateDir(FLAGS_rocksdb_dir, &err));
 
   auto db_manager = std::make_unique<admin::ApplicationDBManager>();
   admin::AdminHandler handler(std::move(db_manager),
@@ -880,6 +874,24 @@ TEST(AdminHandlerTest, MetaData) {
   meta.set_db_name(db_name);
   EXPECT_FALSE(DecodeThriftStruct(meta_from_backup, &meta));
   EXPECT_EQ(meta.db_name, db_name);
+}
+
+
+TEST(AdminHandlerTest, InitS3Tmp) {
+  gflags::FlagSaver saver;
+  FLAGS_rocksdb_dir = "/tmp/admin_handler_test/";
+  auto s3_path = FLAGS_rocksdb_dir + "s3_tmp/"; 
+  auto test_directory = s3_path + "test_directory";
+  std::string err;
+  EXPECT_TRUE(admin::ClearAndCreateDir(FLAGS_rocksdb_dir, &err));
+  EXPECT_TRUE(admin::ClearAndCreateDir(s3_path, &err));
+  EXPECT_TRUE(admin::ClearAndCreateDir(s3_path + "test_directory", &err));
+  EXPECT_TRUE(fs::exists(test_directory));
+
+  auto db_manager = std::make_unique<admin::ApplicationDBManager>();
+  admin::AdminHandler handler(std::move(db_manager),
+                              admin::RocksDBOptionsGenerator());
+  EXPECT_FALSE(fs::exists(test_directory));
 }
 
 }  // namespace admin

--- a/rocksdb_admin/utils.cpp
+++ b/rocksdb_admin/utils.cpp
@@ -1,0 +1,25 @@
+#include "rocksdb_admin/utils.h"
+#include "boost/filesystem.hpp"
+
+
+namespace admin {
+
+// Will remove and create a directory
+// returns false if any of these operations failed.
+bool ClearAndCreateDir(std::string dir_path, std::string* err) {
+  boost::system::error_code create_err;
+  boost::system::error_code remove_err;
+  boost::filesystem::remove_all(dir_path, remove_err);
+  if (remove_err) {
+    *err = remove_err.message();
+    return false;
+  }
+  boost::filesystem::create_directories(dir_path, create_err);
+  if(create_err) {
+      *err = create_err.message();
+      return false;
+  }
+  return true;
+}
+
+}

--- a/rocksdb_admin/utils.h
+++ b/rocksdb_admin/utils.h
@@ -41,4 +41,9 @@ bool EncodeThriftStruct(const T& obj, std::string* data) {
   return !ex;
 }
 
+// Will remove and create a directory
+// returns true if any of these operations failed.
+bool ClearAndCreateDir(std::string dir_path, std::string* err);
+
+
 }  // namespace admin


### PR DESCRIPTION
Right now we s3_tmp to store data downloaded from s3, data being uploaded to s3 and data being added to RO clusters.

This change will clean up s3_tmp upon startup

This way any obsolete backup/failures are deleted since they are not going to be used anymore.

I debated whether we shall do this in separate thread or not but deleting data usually takes less than few seconds and it's speed is proportional to amount of data we have so in 99.9% of cases it should be blazing fast.

Note: this doesn't affect path of FLAGS_enable_checkpoint_backup enabled here is the breakdown of code behavior

```
backup: (copy from master/rocksdb snap)
  auto local_path = folly::stringPrintf("%ss3_tmp/%s%d/", FLAGS_rocksdb_dir.c_str(), request->db_name.c_str(), ts);
restore: (recover from s3)
    if FLAGS_enable_checkpoint_backup:
        FLAGS_rocksdb_dir + request->db_name
    else
        folly::stringPrintf("%ss3_tmp/%s%d/", FLAGS_rocksdb_dir.c_str(), request->db_name.c_str(), ts)
add db: (Uploads)
  auto local_path = FLAGS_rocksdb_dir + "s3_tmp/" + request->db_name + "/";
```

Test plan:
Deployed to dev cluster
Verified that s3_tmp is cleaned up after deploy
NOTE: THIS WILL ONLY CLEAN UP if user is prod otherwise it will cause an error.