### PR TITLE
Enable IMDSv2 query for getAvailabilityZoneImpl

### DIFF
--- a/common/availability_zone.cpp
+++ b/common/availability_zone.cpp
@@ -42,8 +42,10 @@ bool isAllowedAz(const std::string& az) {
 
 std::string getAvailabilityZoneImpl() {
   static const std::string command =
-    "curl --silent --max-time 10 --connect-timeout 5 "
-    "http://169.254.169.254/latest/meta-data/placement/availability-zone";
+      "TOKEN=$(curl -X PUT -H \"X-aws-ec2-metadata-token-ttl-seconds: 300\" "
+      "http://169.254.169.254/latest/api/token 2> /dev/null) && curl -H "
+      "\"X-aws-ec2-metadata-token: $TOKEN\" "
+      "http://169.254.169.254/latest/meta-data/placement/availability-zone";
 
   auto f = popen(command.c_str(), "re");
   if (f == nullptr) {

--- a/common/availability_zone.cpp
+++ b/common/availability_zone.cpp
@@ -42,10 +42,10 @@ bool isAllowedAz(const std::string& az) {
 
 std::string getAvailabilityZoneImpl() {
   static const std::string command =
-      "TOKEN=$(curl -X PUT -H \"X-aws-ec2-metadata-token-ttl-seconds: 300\" "
-      "http://169.254.169.254/latest/api/token 2> /dev/null) && curl -H "
-      "\"X-aws-ec2-metadata-token: $TOKEN\" "
-      "http://169.254.169.254/latest/meta-data/placement/availability-zone";
+    "TOKEN=$(curl -X PUT -H \"X-aws-ec2-metadata-token-ttl-seconds: 300\" "
+    "http://169.254.169.254/latest/api/token 2> /dev/null) && "
+    "curl --silent --max-time 10 --connect-timeout 5 -H \"X-aws-ec2-metadata-token: $TOKEN\" "
+    "http://169.254.169.254/latest/meta-data/placement/availability-zone";
 
   auto f = popen(command.c_str(), "re");
   if (f == nullptr) {


### PR DESCRIPTION
IMDSv2 uses session-oriented requests to mitigate several types of vulnerabilities that could be used to attempt to access the IMDS, protecting against malicious activities such as SSRF attacks. The change does not impact existing usage of "getAvailabilityZoneImpl" call.

Before:
```
➜  ~ curl --silent --max-time 10 --connect-timeout 5 http://169.254.169.254/latest/meta-data/placement/availability-zone
us-east-1a%
```
After:
```
➜  ~ TOKEN=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 300" http://169.254.169.254/latest/api/token 2> /dev/null) && curl --silent --max-time 10 --connect-timeout 5 -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/availability-zone
us-east-1a%
```