### PR TITLE
[EASY] Fix bug introduced because folly::stringPrintf takes only char*

### DIFF
--- a/rocksdb_admin/admin_handler.cpp
+++ b/rocksdb_admin/admin_handler.cpp
@@ -981,7 +981,8 @@ void AdminHandler::async_tm_backupDBToS3(
   common::Timer timer(kS3BackupMs);
   LOG(INFO) << "S3 Backup " << request->db_name << " to " << request->s3_backup_dir;
   auto ts = common::timeutil::GetCurrentTimestamp();
-  auto local_path = folly::stringPrintf("%s%s%d/", getS3TmpPath(), request->db_name.c_str(), ts);
+  const std::string s3_tmp_path = getS3TmpPath();
+  auto local_path = folly::stringPrintf("%s%s%d/", s3_tmp_path.c_str(), request->db_name.c_str(), ts);
   boost::system::error_code remove_err;
   boost::system::error_code create_err;
   boost::filesystem::remove_all(local_path, remove_err);
@@ -1174,8 +1175,9 @@ void AdminHandler::async_tm_restoreDBFromS3(
   }
 
   auto ts = common::timeutil::GetCurrentTimestamp();
+  const std::string s3_tmp_path = getS3TmpPath();
   auto local_path = FLAGS_enable_checkpoint_backup ? FLAGS_rocksdb_dir + request->db_name :
-                    folly::stringPrintf("%s%s%d/", getS3TmpPath(), request->db_name.c_str(), ts);
+                    folly::stringPrintf("%s%s%d/", s3_tmp_path.c_str(), request->db_name.c_str(), ts);
   boost::system::error_code remove_err;
   boost::system::error_code create_err;
   boost::filesystem::remove_all(local_path, remove_err);


### PR DESCRIPTION
I introduced this bug by passing strings to folly::stringPrintf.
This diff fixes that problem, the bug haven't made it to production which is good.

Test plan:
To test this change I am testing backup/restore flows on dev cluster