### PR TITLE
[EASY] Rocksplicator archival notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rocksplicator
 
-> **Important**: Rocksplicator is an archived project that is no longer actively maintained or supported by Pinterest.
+> **Important**: Rocksplicator is an [archived](https://github.com/pinterest/rocksplicator/issues/636) project that is no longer actively maintained or supported by Pinterest.
 
 [![Build Status](https://travis-ci.org/pinterest/rocksplicator.svg)](https://travis-ci.org/pinterest/rocksplicator)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rocksplicator
 
+> **Important**: Rocksplicator is an archived project that is no longer actively maintained or supported by Pinterest.
+
 [![Build Status](https://travis-ci.org/pinterest/rocksplicator.svg)](https://travis-ci.org/pinterest/rocksplicator)
 
 Rocksplicator is a set of C++ libraries and tools for building large scale [RocksDB](http://rocksdb.org/) based stateful services. Its goal is to help application developers solve common difficulties of building large scale stateful services, such as data replication, request routing and cluster management. With Rocksplicator, application developers just need to focus on their application logics, and won't need to deal with data replication, request routing nor cluster management.


### PR DESCRIPTION
Update rocksplicator readme to highlight that open source project is no longer maintained or supported by pinterest.

Issue link: https://github.com/pinterest/rocksplicator/issues/636